### PR TITLE
ADC bug fix

### DIFF
--- a/lib/bt_handling.dart
+++ b/lib/bt_handling.dart
@@ -57,7 +57,6 @@ class BluetoothHandling {
     UniversalBle.onValueChange = null;
 
     _btStateListeners.remove(listener);
-    dataHub._prevSampleCount = -1;
   }
 
   Future<void> _updateBluetoothState() async {
@@ -125,12 +124,14 @@ class BluetoothHandling {
   void toggleSession() {
     assert(_selectedDeviceId.isNotEmpty);
     _sessionInProgress = !_sessionInProgress;
+    dataHub._prevSampleCount = -1;
     _notifyStateChanged();
   }
 
   void stopSession() {
     if (_sessionInProgress) {
       _sessionInProgress = false;
+      dataHub._prevSampleCount = -1;
       _notifyStateChanged();
     }
   }
@@ -291,10 +292,10 @@ class DataHub extends Listenable {
       return false;
     }
 
-    final int count = data[0] << 8 + data[1];
+    final int count = data[0] + (data[1] << 8);
     if (_prevSampleCount != -1) {
       final int diff = (count - _prevSampleCount) & 0xFFFF;
-      if (diff > 0) {
+      if (diff != 0) {
         debugPrint('# lost $diff samples');
         // _lostPackets += diff;
         // TODO: signal lost packets


### PR DESCRIPTION
The "Buf fix" commit (84ac2aa) modifies lib/bt_handling.dart with 4 changes:

Removes dataHub._prevSampleCount = -1; from the removeListener method
Adds dataHub._prevSampleCount = -1; to toggleSession()
Adds dataHub._prevSampleCount = -1; to stopSession()
Fixes the byte-order in count parsing: data[0] << 8 + data[1] → data[0] + (data[1] << 8) and changes diff > 0 to diff != 0