### PR TITLE
Upgrade Android build dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,15 +8,15 @@ plugins {
 android {
     namespace = "com.example.dynamite_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "27.0.12077973" // flutter.ndkVersion TODO: is hardcoding right here?
+    ndkVersion = "27.3.13750724" // flutter.ndkVersion TODO: is hardcoding right here?
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Apr 09 18:31:33 EDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.9.1' apply false
-    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "com.android.application" version '8.11.1' apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary
- Kotlin: 1.9.10 -> 2.2.20
- Android Gradle Plugin (AGP): 8.9.1 -> 8.11.1
- Gradle: 8.11.1 -> 8.14
- NDK: 27.0.12077973 -> 27.3.13750724
- Java/JVM target: 1.8 -> 17

## Motivation
Flutter warned that Kotlin 1.9.10 support is being dropped (minimum 2.1.0).
Took the opportunity to bring all Android build tooling up to match the
current Flutter 3.41.6 template defaults.

## Changes
- `android/settings.gradle` — bumped AGP and Kotlin plugin versions
- `android/app/build.gradle` — updated Java compatibility and JVM target to 17, pinned NDK to latest stable
- `android/gradle/wrapper/gradle-wrapper.properties` — bumped Gradle distribution

No functional/code changes — build config only