### PR TITLE
Refactor graph rendering

### DIFF
--- a/lib/models/bucket_series.dart
+++ b/lib/models/bucket_series.dart
@@ -1,0 +1,327 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'gap_list.dart';
+
+// ---------------------------------------------------------------------------
+// Bucket aggregates
+//
+// The single home of the per-bucket min/max/sum machinery shared by the live
+// ingest (DataHub), session loading (SessionData), and the graph renderers'
+// bucket-accelerated block reductions (reduceBlockBuckets / foldBucketRange).
+// ---------------------------------------------------------------------------
+
+/// Min/max/sum aggregates over fixed [bucketSize]-sample windows of some
+/// integer series (raw values or first differences). Addressed by absolute
+/// bucket index `b = sampleIndex ~/ bucketSize`, stored at `b % mins.length`;
+/// [samples] is the total number of samples ingested, so slots are only
+/// trustworthy for the most recent `mins.length` bucket indices (older ones
+/// have been overwritten by the ring wrap -- see [reduceBlockBuckets]).
+/// Gap samples hold the previous real value (diff 0), so buckets are always
+/// fully populated and carry no missing-data state.
+typedef BucketSeries = ({
+  int bucketSize,
+  Int32List mins,
+  Int32List maxs,
+  Int32List sums,
+  int samples,
+});
+
+/// Mutable accumulator behind a [BucketSeries]: owns the ring of bucket
+/// aggregates and the reset-or-fold ingest step. The single implementation
+/// used by both the live hub and session loading, so the two can never
+/// bucket differently.
+class BucketAccumulator {
+  BucketAccumulator({required this.bucketSize, required int numBuckets})
+    : mins = Int32List(numBuckets),
+      maxs = Int32List(numBuckets),
+      sums = Int32List(numBuckets);
+
+  final int bucketSize;
+  final Int32List mins;
+  final Int32List maxs;
+  final Int32List sums;
+
+  int _samples = 0;
+
+  /// Ingest [value] as sample [sampleIndex]. Samples must arrive
+  /// sequentially from [sampleIndex] 0 (or the last [reset]).
+  void add(int sampleIndex, int value) {
+    assert(sampleIndex == _samples, 'samples must be ingested sequentially');
+    final int slot = (sampleIndex ~/ bucketSize) % mins.length;
+    if (sampleIndex % bucketSize == 0) {
+      mins[slot] = value;
+      maxs[slot] = value;
+      sums[slot] = value;
+    } else {
+      if (value < mins[slot]) mins[slot] = value;
+      if (value > maxs[slot]) maxs[slot] = value;
+      sums[slot] += value;
+    }
+    _samples = sampleIndex + 1;
+  }
+
+  /// Restart ingest from sample 0 (the aggregates themselves are
+  /// overwritten lazily by subsequent [add]s).
+  void reset() => _samples = 0;
+
+  /// Immutable-shaped view for the renderers (the arrays are shared, not
+  /// copied; [BucketSeries.samples] is a snapshot).
+  BucketSeries get series => (
+    bucketSize: bucketSize,
+    mins: mins,
+    maxs: maxs,
+    sums: sums,
+    samples: _samples,
+  );
+}
+
+/// The first-difference value to ingest for [sampleIndex]: 0 for the very
+/// first sample, inside gaps (held - held = 0 naturally), and for the first
+/// real sample after a gap -- that jump happened over the gap's whole
+/// duration, so recording it as a one-sample diff would fabricate a spike.
+/// The derivative graph's exact path suppresses the same samples with NaN
+/// (see DerivativeGraphPainter.sampleAt); this is the single home of the
+/// ingest-side rule, shared by DataHub and SessionData.
+///
+/// [prevValue] is ignored (may be any value) when the result is 0 by rule.
+int ingestDiff({
+  required int sampleIndex,
+  required int value,
+  required int prevValue,
+  required GapList gaps,
+}) {
+  if (sampleIndex == 0 || gaps.contains(sampleIndex - 1)) return 0;
+  return value - prevValue;
+}
+
+// ---------------------------------------------------------------------------
+// Envelope series (per-channel rendering recipe)
+// ---------------------------------------------------------------------------
+
+/// Everything needed to reduce one channel's series into min/avg/max blocks:
+/// the exact per-sample evaluator plus, optionally, the bucket aggregates
+/// that accelerate zoomed-out reductions.
+///
+/// [EnvelopeSeries.bucketed] is the only way to attach buckets, so a series
+/// can never carry buckets without the matching raw->display conversion.
+class EnvelopeSeries {
+  /// Value at an absolute sample index, in display units. NaN marks a
+  /// missing (gap) sample and breaks the polyline.
+  final double Function(int sampleIndex) sampleAt;
+
+  /// Bucket aggregates of the same series, in raw integer space; null for
+  /// series that render exclusively on the exact path.
+  final BucketSeries? buckets;
+
+  /// Raw-space -> display-units map matching [sampleAt]; non-null iff
+  /// [buckets] is.
+  final double Function(double raw)? rawToDisplay;
+
+  /// A series rendered exclusively on the exact per-sample path.
+  EnvelopeSeries.exact(this.sampleAt) : buckets = null, rawToDisplay = null;
+
+  /// A series with bucket-accelerated reduction (see [reduceBlockBuckets]
+  /// for the accuracy tradeoff).
+  ///
+  /// INVARIANTS (unenforceable here, checked by tests):
+  ///  * [buckets] must aggregate the SAME series [sampleAt] evaluates (raw
+  ///    values for the force graph, first differences for the derivative --
+  ///    diff extremes cannot be reconstructed from raw-value buckets, hence
+  ///    the dedicated ingest-time diff buckets).
+  ///  * [rawToDisplay] MUST be affine (e.g. tare offset + unit scale) so the
+  ///    average survives the mapping, and must agree with [sampleAt]
+  ///    (`sampleAt(j) == rawToDisplay(raw sample j)` outside gaps) so both
+  ///    paths plot the same series.
+  EnvelopeSeries.bucketed({
+    required this.sampleAt,
+    required BucketSeries this.buckets,
+    required double Function(double raw) this.rawToDisplay,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Block reductions
+// ---------------------------------------------------------------------------
+
+/// One block's reduction: extremes and sum over the [count] valid samples,
+/// in display units. `count == 0` means the whole block was missing data.
+typedef BlockReduction = ({double min, double max, double sum, int count});
+
+const BlockReduction _emptyReduction = (
+  min: double.infinity,
+  max: double.negativeInfinity,
+  sum: 0,
+  count: 0,
+);
+
+/// Exact per-sample reduction of `[from, to)`: every sample is evaluated
+/// through [sampleAt]; NaN (gap) samples are excluded.
+BlockReduction reduceBlockExact(
+  double Function(int sampleIndex) sampleAt,
+  int from,
+  int to,
+) {
+  double min = double.infinity;
+  double max = double.negativeInfinity;
+  double sum = 0;
+  int count = 0;
+  for (int j = from; j < to; j++) {
+    final v = sampleAt(j);
+    if (v.isNaN) continue;
+    sum += v;
+    if (v < min) min = v;
+    if (v > max) max = v;
+    count++;
+  }
+  return (min: min, max: max, sum: sum, count: count);
+}
+
+/// Bucket-accelerated reduction of `[from, to)` for a bucketed
+/// [EnvelopeSeries]; the counterpart of [reduceBlockExact] used when a block
+/// spans many samples.
+///
+/// ## ACCURACY TRADEOFF (partial block/bucket boundaries)
+///
+/// The result is approximate in two ways, both confined to buckets that
+/// straddle a block edge (at most one bucket per edge):
+///
+///  1. min/max: a boundary bucket contributes its FULL bucket min/max even
+///     when the block covers only part of it, so the envelope can be up to
+///     one bucket too wide at block edges -- conservative (an extreme is
+///     never dropped, only shown one block early/late).
+///  2. sum: a partially covered bucket contributes `bucketMean * covered`,
+///     i.e. its mean is assumed uniform across the bucket. (For the newest,
+///     partially FILLED bucket the mean is taken over the samples actually
+///     written, so a block covering the whole written portion is exact.)
+///
+/// Gap samples: the buckets contain held values (diff 0), so blocks
+/// overlapping a gap edge are biased toward the pre-gap value, whereas
+/// [reduceBlockExact] excludes gap samples via NaN. Renderers clip all data
+/// ink out of gap x-ranges, so the difference is confined to the clipped-in
+/// area around gap edges.
+///
+/// ## Ring-wrap safety
+///
+/// Bucket slots are only trustworthy for the most recent `numBuckets` bucket
+/// indices; the slot of the single bucket straddling the oldest retained
+/// sample is overwritten by the live edge once the ring wraps. That head
+/// portion is detected via [BucketSeries.samples] and reduced exactly
+/// through [EnvelopeSeries.sampleAt] instead, so stale aggregates are never
+/// read and no sample is silently dropped.
+BlockReduction reduceBlockBuckets(EnvelopeSeries series, int from, int to) {
+  final buckets = series.buckets!;
+  final rawToDisplay = series.rawToDisplay!;
+  final int bs = buckets.bucketSize;
+  final int numBuckets = buckets.mins.length;
+  final int samples = buckets.samples;
+
+  double min = double.infinity;
+  double max = double.negativeInfinity;
+  double sum = 0;
+  int count = 0;
+
+  void merge(BlockReduction r) {
+    if (r.count == 0) return;
+    if (r.min < min) min = r.min;
+    if (r.max > max) max = r.max;
+    sum += r.sum;
+    count += r.count;
+  }
+
+  // Exact-path fallback for the aliased head (see "Ring-wrap safety").
+  final int bNow = (samples - 1) ~/ bs;
+  final int firstValidBucket = math.max(0, bNow - numBuckets + 1);
+  if (from < firstValidBucket * bs) {
+    final int headEnd = math.min(to, firstValidBucket * bs);
+    merge(reduceBlockExact(series.sampleAt, from, headEnd));
+    from = headEnd;
+    if (from >= to) return (min: min, max: max, sum: sum, count: count);
+  }
+
+  double rawMin = double.infinity;
+  double rawMax = double.negativeInfinity;
+  double rawSum = 0;
+  int rawCount = 0;
+
+  final int bFirst = from ~/ bs;
+  final int bLast = (to - 1) ~/ bs;
+  for (int b = bFirst; b <= bLast; b++) {
+    final int li = b % numBuckets;
+
+    // Only the count is portion-aware; min/max/mean come from the whole
+    // bucket -- this is the boundary approximation.
+    int c = bs;
+    if (b == bFirst) c -= from - b * bs;
+    if (b == bLast) c -= (b + 1) * bs - to;
+    if (c <= 0) continue;
+
+    final int bMin = buckets.mins[li];
+    final int bMax = buckets.maxs[li];
+    if (bMin < rawMin) rawMin = bMin.toDouble();
+    if (bMax > rawMax) rawMax = bMax.toDouble();
+
+    // Samples actually written into this bucket (< bs only for the newest,
+    // still-filling bucket); its mean is sum/written, not sum/bs.
+    final int written = math.min(bs, samples - b * bs);
+    if (c > written) c = written; // defensive; to <= samples in practice
+    rawSum += buckets.sums[li] * c / written;
+    rawCount += c;
+  }
+
+  if (rawCount > 0) {
+    double mn = rawToDisplay(rawMin);
+    double mx = rawToDisplay(rawMax);
+    if (mn > mx) {
+      // A negative display multiplier flipped the ordering.
+      final t = mn;
+      mn = mx;
+      mx = t;
+    }
+    merge((
+      min: mn,
+      max: mx,
+      // Affine rawToDisplay: sum(f(x_i)) == n * f(sum(x_i) / n).
+      sum: rawCount * rawToDisplay(rawSum / rawCount),
+      count: rawCount,
+    ));
+  }
+
+  if (count == 0) return _emptyReduction;
+  return (min: min, max: max, sum: sum, count: count);
+}
+
+/// Fold the EXACT min/max of a bucket series over the sample window
+/// `[start, end)`: buckets fully inside the window are folded from the
+/// precomputed aggregates via [foldBucket]; the partial head/tail portions
+/// are handed to [scanExact], so the cost is O(window / bucketSize +
+/// bucketSize). Windows spanning fewer than two buckets fall back to a
+/// single [scanExact] (aggregates would not help).
+///
+/// Unlike [reduceBlockBuckets] this is exact, and it cannot read an aliased
+/// slot: a bucket fully inside `[start, end)` -- with the window clamped to
+/// the retained sample range, as renderers always do -- is always among the
+/// most recent `numBuckets` bucket indices.
+void foldBucketRange(
+  BucketSeries buckets,
+  int start,
+  int end, {
+  required void Function(int bucketMin, int bucketMax) foldBucket,
+  required void Function(int from, int to) scanExact,
+}) {
+  final int bs = buckets.bucketSize;
+  if (end - start < 2 * bs) {
+    scanExact(start, end);
+    return;
+  }
+  // First/last bucket indices fully inside the window.
+  final int bFirst = (start + bs - 1) ~/ bs;
+  final int bLastEx = end ~/ bs;
+  final int numBuckets = buckets.mins.length;
+  for (int b = bFirst; b < bLastEx; b++) {
+    final int li = b % numBuckets;
+    foldBucket(buckets.mins[li], buckets.maxs[li]);
+  }
+  scanExact(start, bFirst * bs);
+  scanExact(bLastEx * bs, end);
+}

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/app_settings.dart';
+import '../models/bucket_series.dart';
 import '../models/force_unit.dart';
 import '../models/gap_list.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -64,21 +65,12 @@ class _LiveDataSource extends ChangeNotifier implements GraphDataSource {
         min: _hub.rawMin[channelIndex].toDouble(),
         max: _hub.rawMax[channelIndex].toDouble(),
         tare: _hub.tare[channelIndex],
-        buckets: (
-          bucketSize: DataHub.bucketSize,
-          mins: _hub.bucketMins[channelIndex],
-          maxs: _hub.bucketMaxs[channelIndex],
-          sums: _hub.bucketSums[channelIndex],
-        ),
+        buckets: _hub.valueBuckets[channelIndex].series,
       );
 
   @override
-  BucketSeries? diffBuckets(int channelIndex) => (
-        bucketSize: DataHub.bucketSize,
-        mins: _hub.diffBucketMins[channelIndex],
-        maxs: _hub.diffBucketMaxs[channelIndex],
-        sums: _hub.diffBucketSums[channelIndex],
-      );
+  BucketSeries? diffBuckets(int channelIndex) =>
+      _hub.diffBuckets[channelIndex].series;
 
   @override
   GapList get gaps => _hub.gaps;

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -64,10 +64,20 @@ class _LiveDataSource extends ChangeNotifier implements GraphDataSource {
         min: _hub.rawMin[channelIndex].toDouble(),
         max: _hub.rawMax[channelIndex].toDouble(),
         tare: _hub.tare[channelIndex],
+        buckets: (
+          bucketSize: DataHub.bucketSize,
+          mins: _hub.bucketMins[channelIndex],
+          maxs: _hub.bucketMaxs[channelIndex],
+          sums: _hub.bucketSums[channelIndex],
+        ),
+      );
+
+  @override
+  BucketSeries? diffBuckets(int channelIndex) => (
         bucketSize: DataHub.bucketSize,
-        bucketMins: _hub.bucketMins[channelIndex],
-        bucketMaxs: _hub.bucketMaxs[channelIndex],
-        bucketSums: _hub.bucketSums[channelIndex],
+        mins: _hub.diffBucketMins[channelIndex],
+        maxs: _hub.diffBucketMaxs[channelIndex],
+        sums: _hub.diffBucketSums[channelIndex],
       );
 
   @override

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -52,10 +52,20 @@ class _SessionDataSource implements GraphDataSource {
     min: _data.mins[channelIndex],
     max: _data.maxs[channelIndex],
     tare: _data.tares[channelIndex],
+    buckets: (
+      bucketSize: _data.bucketSize,
+      mins: _data.bucketMins[channelIndex],
+      maxs: _data.bucketMaxs[channelIndex],
+      sums: _data.bucketSums[channelIndex],
+    ),
+  );
+
+  @override
+  BucketSeries? diffBuckets(int channelIndex) => (
     bucketSize: _data.bucketSize,
-    bucketMins: _data.bucketMins[channelIndex],
-    bucketMaxs: _data.bucketMaxs[channelIndex],
-    bucketSums: _data.bucketSums[channelIndex],
+    mins: _data.diffBucketMins[channelIndex],
+    maxs: _data.diffBucketMaxs[channelIndex],
+    sums: _data.diffBucketSums[channelIndex],
   );
 
   @override

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:file_selector/file_selector.dart';
 
 import '../models/app_settings.dart';
+import '../models/bucket_series.dart';
 import '../models/gap_list.dart';
 import '../services/database.dart';
 import '../services/session_storage.dart';
@@ -52,21 +53,12 @@ class _SessionDataSource implements GraphDataSource {
     min: _data.mins[channelIndex],
     max: _data.maxs[channelIndex],
     tare: _data.tares[channelIndex],
-    buckets: (
-      bucketSize: _data.bucketSize,
-      mins: _data.bucketMins[channelIndex],
-      maxs: _data.bucketMaxs[channelIndex],
-      sums: _data.bucketSums[channelIndex],
-    ),
+    buckets: _data.valueBuckets[channelIndex].series,
   );
 
   @override
-  BucketSeries? diffBuckets(int channelIndex) => (
-    bucketSize: _data.bucketSize,
-    mins: _data.diffBucketMins[channelIndex],
-    maxs: _data.diffBucketMaxs[channelIndex],
-    sums: _data.diffBucketSums[channelIndex],
-  );
+  BucketSeries? diffBuckets(int channelIndex) =>
+      _data.diffBuckets[channelIndex].series;
 
   @override
   GapList get gaps => _data.gaps;

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -63,6 +63,29 @@ class DataHub extends ChangeNotifier {
     (_) => Int32List(numBuckets),
     growable: false,
   );
+
+  /// Per-channel, per-bucket aggregates of the first-difference series
+  /// (`diff[j] = raw[j] - raw[j-1]`), same bucket grid as [bucketMins]. Used
+  /// by the derivative graph's bucket fast path. The diff is recorded as 0
+  /// for the very first sample, inside gaps (held - held), and for the first
+  /// real sample after a gap (see [_addData]).
+  final List<Int32List> diffBucketMins = List.generate(
+    DataHub.numAdcChannels,
+    (_) => Int32List(numBuckets),
+    growable: false,
+  );
+
+  final List<Int32List> diffBucketMaxs = List.generate(
+    DataHub.numAdcChannels,
+    (_) => Int32List(numBuckets),
+    growable: false,
+  );
+
+  final List<Int32List> diffBucketSums = List.generate(
+    DataHub.numAdcChannels,
+    (_) => Int32List(numBuckets),
+    growable: false,
+  );
   int _tareCount = 0;
   int totalSamples = 0;
   DeviceCalibration deviceCalibration = DeviceCalibration();
@@ -251,6 +274,17 @@ class DataHub extends ChangeNotifier {
   }
 
   void _addData(int val, int idx) {
+    // First difference vs the previous sample, ingested alongside the value.
+    // Recorded as 0 for the very first sample, inside gaps (held - held = 0),
+    // and for the first real sample after a gap: that jump happened over the
+    // gap's whole duration, so plotting it as a one-sample diff would
+    // fabricate a spike -- the derivative graph's exact path suppresses it
+    // the same way (see DerivativeGraphPainter.sampleAt).
+    int diff = 0;
+    if (totalSamples > 0 && !gaps.contains(totalSamples - 1)) {
+      diff = val - rawData[idx][(totalSamples - 1) % maxDataSz];
+    }
+
     rawData[idx][totalSamples % maxDataSz] = val;
     if (val > rawMax[idx]) {
       rawMax[idx] = val;
@@ -265,10 +299,16 @@ class DataHub extends ChangeNotifier {
       bucketMins[idx][bIdx] = val;
       bucketMaxs[idx][bIdx] = val;
       bucketSums[idx][bIdx] = val;
+      diffBucketMins[idx][bIdx] = diff;
+      diffBucketMaxs[idx][bIdx] = diff;
+      diffBucketSums[idx][bIdx] = diff;
     } else {
       if (val < bucketMins[idx][bIdx]) bucketMins[idx][bIdx] = val;
       if (val > bucketMaxs[idx][bIdx]) bucketMaxs[idx][bIdx] = val;
       bucketSums[idx][bIdx] += val;
+      if (diff < diffBucketMins[idx][bIdx]) diffBucketMins[idx][bIdx] = diff;
+      if (diff > diffBucketMaxs[idx][bIdx]) diffBucketMaxs[idx][bIdx] = diff;
+      diffBucketSums[idx][bIdx] += diff;
     }
   }
 }

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -43,7 +43,9 @@ class DataHub extends ChangeNotifier {
   );
 
   /// Per-channel, per-bucket aggregates over [bucketSize]-sample windows.
-  /// Used by the minimap to render a downsampled overview cheaply.
+  /// Used by the graph envelope renderers to downsample cheaply. Gap samples
+  /// hold the previous real value, so buckets are always fully populated and
+  /// need no missing-data handling.
   final List<Int32List> bucketMins = List.generate(
     DataHub.numAdcChannels,
     (_) => Int32List(numBuckets),

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 
 import 'adc_protocol.dart';
+import '../models/bucket_series.dart';
 import '../models/force_unit.dart';
 import '../models/gap_list.dart';
 
@@ -42,48 +43,23 @@ class DataHub extends ChangeNotifier {
     growable: false,
   );
 
-  /// Per-channel, per-bucket aggregates over [bucketSize]-sample windows.
-  /// Used by the graph envelope renderers to downsample cheaply. Gap samples
-  /// hold the previous real value, so buckets are always fully populated and
-  /// need no missing-data handling.
-  final List<Int32List> bucketMins = List.generate(
+  /// Per-channel bucket aggregates over [bucketSize]-sample windows of the
+  /// raw values. Used by the graph envelope renderers to downsample cheaply.
+  /// Gap samples hold the previous real value, so buckets are always fully
+  /// populated and need no missing-data handling.
+  final List<BucketAccumulator> valueBuckets = List.generate(
     DataHub.numAdcChannels,
-    (_) => Int32List(numBuckets),
+    (_) => BucketAccumulator(bucketSize: bucketSize, numBuckets: numBuckets),
     growable: false,
   );
 
-  final List<Int32List> bucketMaxs = List.generate(
+  /// Per-channel bucket aggregates of the first-difference series
+  /// (`diff[j] = raw[j] - raw[j-1]`), same bucket grid as [valueBuckets].
+  /// Used by the derivative graph's bucket fast path; the gap/first-sample
+  /// diff rule lives in [ingestDiff].
+  final List<BucketAccumulator> diffBuckets = List.generate(
     DataHub.numAdcChannels,
-    (_) => Int32List(numBuckets),
-    growable: false,
-  );
-
-  final List<Int32List> bucketSums = List.generate(
-    DataHub.numAdcChannels,
-    (_) => Int32List(numBuckets),
-    growable: false,
-  );
-
-  /// Per-channel, per-bucket aggregates of the first-difference series
-  /// (`diff[j] = raw[j] - raw[j-1]`), same bucket grid as [bucketMins]. Used
-  /// by the derivative graph's bucket fast path. The diff is recorded as 0
-  /// for the very first sample, inside gaps (held - held), and for the first
-  /// real sample after a gap (see [_addData]).
-  final List<Int32List> diffBucketMins = List.generate(
-    DataHub.numAdcChannels,
-    (_) => Int32List(numBuckets),
-    growable: false,
-  );
-
-  final List<Int32List> diffBucketMaxs = List.generate(
-    DataHub.numAdcChannels,
-    (_) => Int32List(numBuckets),
-    growable: false,
-  );
-
-  final List<Int32List> diffBucketSums = List.generate(
-    DataHub.numAdcChannels,
-    (_) => Int32List(numBuckets),
+    (_) => BucketAccumulator(bucketSize: bucketSize, numBuckets: numBuckets),
     growable: false,
   );
   int _tareCount = 0;
@@ -110,6 +86,8 @@ class DataHub extends ChangeNotifier {
       tare[i] = 0;
       _runningTotal[i] = 0;
       _currentRaw[i] = 0;
+      valueBuckets[i].reset();
+      diffBuckets[i].reset();
     }
   }
 
@@ -274,16 +252,16 @@ class DataHub extends ChangeNotifier {
   }
 
   void _addData(int val, int idx) {
-    // First difference vs the previous sample, ingested alongside the value.
-    // Recorded as 0 for the very first sample, inside gaps (held - held = 0),
-    // and for the first real sample after a gap: that jump happened over the
-    // gap's whole duration, so plotting it as a one-sample diff would
-    // fabricate a spike -- the derivative graph's exact path suppresses it
-    // the same way (see DerivativeGraphPainter.sampleAt).
-    int diff = 0;
-    if (totalSamples > 0 && !gaps.contains(totalSamples - 1)) {
-      diff = val - rawData[idx][(totalSamples - 1) % maxDataSz];
-    }
+    // First difference vs the previous sample, ingested alongside the value;
+    // the 0-for-first-sample/gap/gap-exit rule lives in [ingestDiff]. The
+    // ring read is safe for totalSamples == 0 (Dart % is non-negative) and
+    // ignored by rule there.
+    final int diff = ingestDiff(
+      sampleIndex: totalSamples,
+      value: val,
+      prevValue: rawData[idx][(totalSamples - 1) % maxDataSz],
+      gaps: gaps,
+    );
 
     rawData[idx][totalSamples % maxDataSz] = val;
     if (val > rawMax[idx]) {
@@ -293,23 +271,8 @@ class DataHub extends ChangeNotifier {
       rawMin[idx] = val;
     }
 
-    final int bIdx = (totalSamples % maxDataSz) ~/ bucketSize;
-    final int sIdx = (totalSamples % maxDataSz) % bucketSize;
-    if (sIdx == 0) {
-      bucketMins[idx][bIdx] = val;
-      bucketMaxs[idx][bIdx] = val;
-      bucketSums[idx][bIdx] = val;
-      diffBucketMins[idx][bIdx] = diff;
-      diffBucketMaxs[idx][bIdx] = diff;
-      diffBucketSums[idx][bIdx] = diff;
-    } else {
-      if (val < bucketMins[idx][bIdx]) bucketMins[idx][bIdx] = val;
-      if (val > bucketMaxs[idx][bIdx]) bucketMaxs[idx][bIdx] = val;
-      bucketSums[idx][bIdx] += val;
-      if (diff < diffBucketMins[idx][bIdx]) diffBucketMins[idx][bIdx] = diff;
-      if (diff > diffBucketMaxs[idx][bIdx]) diffBucketMaxs[idx][bIdx] = diff;
-      diffBucketSums[idx][bIdx] += diff;
-    }
+    valueBuckets[idx].add(totalSamples, val);
+    diffBuckets[idx].add(totalSamples, diff);
   }
 }
 

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -210,7 +210,9 @@ class SessionData {
   final List<double> maxs;
 
   /// Per-channel, per-bucket aggregates over [bucketSize]-sample windows.
-  /// Mirrors DataHub's live buckets so the minimap can downsample cheaply.
+  /// Mirrors DataHub's live buckets so the graphs can downsample cheaply.
+  /// Gap samples hold the previous real value, so buckets are always fully
+  /// populated and need no missing-data handling.
   final int bucketSize = 100;
   late final List<Int32List> bucketMins;
   late final List<Int32List> bucketMaxs;

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 
 import 'database.dart';
 import 'data_hub.dart';
+import '../models/bucket_series.dart';
 import '../models/gap_list.dart';
 
 /// Chunk format: packed int32 LE values, interleaved
@@ -209,23 +210,19 @@ class SessionData {
   final List<double> mins;
   final List<double> maxs;
 
-  /// Per-channel, per-bucket aggregates over [bucketSize]-sample windows.
-  /// Mirrors DataHub's live buckets so the graphs can downsample cheaply.
-  /// Gap samples hold the previous real value, so buckets are always fully
-  /// populated and need no missing-data handling.
+  /// Per-channel bucket aggregates over [bucketSize]-sample windows of the
+  /// raw values. Mirrors DataHub's live buckets (same [BucketAccumulator])
+  /// so the graphs can downsample cheaply. Gap samples hold the previous
+  /// real value, so buckets are always fully populated and need no
+  /// missing-data handling.
   final int bucketSize = 100;
-  late final List<Int32List> bucketMins;
-  late final List<Int32List> bucketMaxs;
-  late final List<Int32List> bucketSums;
+  late final List<BucketAccumulator> valueBuckets;
 
-  /// Per-channel, per-bucket aggregates of the first-difference series
+  /// Per-channel bucket aggregates of the first-difference series
   /// (`diff[i] = raw[i] - raw[i-1]`), same bucket grid. Used by the
-  /// derivative graph's bucket fast path. The diff is 0 for the first
-  /// sample, inside gaps, and for the first sample after a gap (mirroring
-  /// DataHub's live ingest).
-  late final List<Int32List> diffBucketMins;
-  late final List<Int32List> diffBucketMaxs;
-  late final List<Int32List> diffBucketSums;
+  /// derivative graph's bucket fast path; the gap/first-sample diff rule
+  /// lives in [ingestDiff], mirroring DataHub's live ingest.
+  late final List<BucketAccumulator> diffBuckets;
 
   SessionData({
     required this.channels,
@@ -241,20 +238,13 @@ class SessionData {
     final int numBuckets = (sampleCount == 0)
         ? 0
         : ((sampleCount - 1) ~/ bucketSize) + 1;
-    bucketMins = List.generate(channels.length, (_) => Int32List(numBuckets));
-    bucketMaxs = List.generate(channels.length, (_) => Int32List(numBuckets));
-    bucketSums = List.generate(channels.length, (_) => Int32List(numBuckets));
-    diffBucketMins = List.generate(
+    valueBuckets = List.generate(
       channels.length,
-      (_) => Int32List(numBuckets),
+      (_) => BucketAccumulator(bucketSize: bucketSize, numBuckets: numBuckets),
     );
-    diffBucketMaxs = List.generate(
+    diffBuckets = List.generate(
       channels.length,
-      (_) => Int32List(numBuckets),
-    );
-    diffBucketSums = List.generate(
-      channels.length,
-      (_) => Int32List(numBuckets),
+      (_) => BucketAccumulator(bucketSize: bucketSize, numBuckets: numBuckets),
     );
 
     for (int ch = 0; ch < channels.length; ch++) {
@@ -267,30 +257,15 @@ class SessionData {
         if (v < mn) mn = v.toDouble();
         if (v > mx) mx = v.toDouble();
 
-        // 0 for the first sample, inside gaps, and at the gap-exit sample
-        // (the jump there spans the gap's duration; a one-sample diff would
-        // fabricate a spike).
-        final int diff = (i > 0 && !this.gaps.contains(i - 1))
-            ? v - channels[ch][i - 1]
-            : 0;
+        final int diff = ingestDiff(
+          sampleIndex: i,
+          value: v,
+          prevValue: i > 0 ? channels[ch][i - 1] : 0,
+          gaps: this.gaps,
+        );
 
-        final int bIdx = i ~/ bucketSize;
-        final int sIdx = i % bucketSize;
-        if (sIdx == 0) {
-          bucketMins[ch][bIdx] = v;
-          bucketMaxs[ch][bIdx] = v;
-          bucketSums[ch][bIdx] = v;
-          diffBucketMins[ch][bIdx] = diff;
-          diffBucketMaxs[ch][bIdx] = diff;
-          diffBucketSums[ch][bIdx] = diff;
-        } else {
-          if (v < bucketMins[ch][bIdx]) bucketMins[ch][bIdx] = v;
-          if (v > bucketMaxs[ch][bIdx]) bucketMaxs[ch][bIdx] = v;
-          bucketSums[ch][bIdx] += v;
-          if (diff < diffBucketMins[ch][bIdx]) diffBucketMins[ch][bIdx] = diff;
-          if (diff > diffBucketMaxs[ch][bIdx]) diffBucketMaxs[ch][bIdx] = diff;
-          diffBucketSums[ch][bIdx] += diff;
-        }
+        valueBuckets[ch].add(i, v);
+        diffBuckets[ch].add(i, diff);
       }
       mins[ch] = mn;
       maxs[ch] = mx;

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -218,6 +218,15 @@ class SessionData {
   late final List<Int32List> bucketMaxs;
   late final List<Int32List> bucketSums;
 
+  /// Per-channel, per-bucket aggregates of the first-difference series
+  /// (`diff[i] = raw[i] - raw[i-1]`), same bucket grid. Used by the
+  /// derivative graph's bucket fast path. The diff is 0 for the first
+  /// sample, inside gaps, and for the first sample after a gap (mirroring
+  /// DataHub's live ingest).
+  late final List<Int32List> diffBucketMins;
+  late final List<Int32List> diffBucketMaxs;
+  late final List<Int32List> diffBucketSums;
+
   SessionData({
     required this.channels,
     required this.sampleRate,
@@ -235,6 +244,18 @@ class SessionData {
     bucketMins = List.generate(channels.length, (_) => Int32List(numBuckets));
     bucketMaxs = List.generate(channels.length, (_) => Int32List(numBuckets));
     bucketSums = List.generate(channels.length, (_) => Int32List(numBuckets));
+    diffBucketMins = List.generate(
+      channels.length,
+      (_) => Int32List(numBuckets),
+    );
+    diffBucketMaxs = List.generate(
+      channels.length,
+      (_) => Int32List(numBuckets),
+    );
+    diffBucketSums = List.generate(
+      channels.length,
+      (_) => Int32List(numBuckets),
+    );
 
     for (int ch = 0; ch < channels.length; ch++) {
       if (sampleCount == 0) continue;
@@ -246,16 +267,29 @@ class SessionData {
         if (v < mn) mn = v.toDouble();
         if (v > mx) mx = v.toDouble();
 
+        // 0 for the first sample, inside gaps, and at the gap-exit sample
+        // (the jump there spans the gap's duration; a one-sample diff would
+        // fabricate a spike).
+        final int diff = (i > 0 && !this.gaps.contains(i - 1))
+            ? v - channels[ch][i - 1]
+            : 0;
+
         final int bIdx = i ~/ bucketSize;
         final int sIdx = i % bucketSize;
         if (sIdx == 0) {
           bucketMins[ch][bIdx] = v;
           bucketMaxs[ch][bIdx] = v;
           bucketSums[ch][bIdx] = v;
+          diffBucketMins[ch][bIdx] = diff;
+          diffBucketMaxs[ch][bIdx] = diff;
+          diffBucketSums[ch][bIdx] = diff;
         } else {
           if (v < bucketMins[ch][bIdx]) bucketMins[ch][bIdx] = v;
           if (v > bucketMaxs[ch][bIdx]) bucketMaxs[ch][bIdx] = v;
           bucketSums[ch][bIdx] += v;
+          if (diff < diffBucketMins[ch][bIdx]) diffBucketMins[ch][bIdx] = diff;
+          if (diff > diffBucketMaxs[ch][bIdx]) diffBucketMaxs[ch][bIdx] = diff;
+          diffBucketSums[ch][bIdx] += diff;
         }
       }
       mins[ch] = mn;

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -543,23 +543,28 @@ int blockSizeFor(int viewSamples, double graphW) {
   return math.max(1, (viewSamples / graphW).floor());
 }
 
-/// A single channel's raw circular-buffer data plus its precomputed extremes
-/// and tare offset. Returned by [GraphDataSource.channel].
-///
-/// The bucket arrays hold min/max/sum aggregates over fixed [bucketSize]-
-/// sample windows (absolute bucket index `b = sampleIndex ~/ bucketSize`,
-/// stored at `b % bucketMins.length`). Gap samples hold the previous real
-/// value, so buckets are always fully populated and carry no missing-data
-/// state -- see the accuracy tradeoff documented on [drawChannelEnvelope].
+/// Min/max/sum aggregates over fixed [bucketSize]-sample windows of some
+/// integer series (raw values or first differences). Addressed by absolute
+/// bucket index `b = sampleIndex ~/ bucketSize`, stored at `b % mins.length`.
+/// Gap samples hold the previous real value (diff 0), so buckets are always
+/// fully populated and carry no missing-data state -- see the accuracy
+/// tradeoff documented on [drawChannelEnvelope].
+typedef BucketSeries = ({
+  int bucketSize,
+  Int32List mins,
+  Int32List maxs,
+  Int32List sums,
+});
+
+/// A single channel's raw circular-buffer data plus its precomputed extremes,
+/// tare offset, and raw-value [BucketSeries]. Returned by
+/// [GraphDataSource.channel].
 typedef ChannelSeries = ({
   List<int> data,
   double min,
   double max,
   double tare,
-  int bucketSize,
-  Int32List bucketMins,
-  Int32List bucketMaxs,
-  Int32List bucketSums,
+  BucketSeries buckets,
 });
 
 /// Data interface required by the shared graph components (main graph, minimap, etc).
@@ -588,8 +593,14 @@ abstract interface class GraphDataSource {
   /// Notifies listeners when the underlying data changes.
   Listenable get repaint;
 
-  /// Returns the series (data + extremes + tare) for a given channel index.
+  /// Returns the series (data + extremes + tare + buckets) for a given
+  /// channel index.
   ChannelSeries channel(int channelIndex);
+
+  /// Bucket aggregates of the first-difference series for a channel,
+  /// enabling the derivative graph's bucket fast path; null when the source
+  /// does not track them (the derivative then renders on the exact path).
+  BucketSeries? diffBuckets(int channelIndex);
 
   /// Sample ranges where data was lost (dropped packets). The buffer holds
   /// held values there; renderers break the polyline and hatch these ranges.
@@ -1119,7 +1130,7 @@ class _MinimapPainter extends CustomPainter {
       yMax: yMax,
       firstUsableSample: oldestSample,
       sampleAtFor: (ch) => taredDisplaySampleAt(_data, ch, unit),
-      bucketSeriesFor: _data.channel,
+      bucketSeriesFor: (ch) => _data.channel(ch).buckets,
       rawToDisplayFor: (ch) => taredDisplayFromRaw(_data, ch, unit),
       avgStrokeWidth: 1.0,
       avgAlpha: 180,
@@ -1866,9 +1877,11 @@ class VertexBatcher {
 /// their real samples only, while the buckets contain held values, biasing
 /// the fast path's boundary blocks toward the pre-gap value.
 ///
-/// The exact per-sample path has none of these differences; the derivative
-/// graph always uses it (first differences cannot be reconstructed from
-/// raw-value buckets).
+/// The exact per-sample path has none of these differences. The buckets must
+/// aggregate the SAME series that [sampleAt] evaluates (raw values for the
+/// force graph, first differences for the derivative graph -- diff extremes
+/// cannot be reconstructed from raw-value buckets, hence the dedicated
+/// ingest-time diff buckets).
 ///
 /// Reduction on the bucket path happens in raw counts and is converted with
 /// [rawToDisplay], which MUST be affine (e.g. tare offset + unit scale) so
@@ -1892,7 +1905,7 @@ void drawChannelEnvelope(
   double avgStrokeWidth = 1.5,
   int avgAlpha = 255,
   int envAlpha = 60,
-  ChannelSeries? bucketSeries,
+  BucketSeries? bucketSeries,
   double Function(double raw)? rawToDisplay,
 }) {
   final (avg: avg, env: env) = _envelopeBatchers(
@@ -1942,9 +1955,9 @@ void drawChannelEnvelope(
       // Bucket-accelerated reduction; approximate at the boundary buckets
       // (see ACCURACY TRADEOFF in the doc comment).
       final int bs = bucketSeries.bucketSize;
-      final bucketMins = bucketSeries.bucketMins;
-      final bucketMaxs = bucketSeries.bucketMaxs;
-      final bucketSums = bucketSeries.bucketSums;
+      final bucketMins = bucketSeries.mins;
+      final bucketMaxs = bucketSeries.maxs;
+      final bucketSums = bucketSeries.sums;
       final int numBuckets = bucketMins.length;
 
       double totalRaw = 0;
@@ -2092,7 +2105,7 @@ bool paintEnvelopeDataLayer(
   required double yMax,
   required int firstUsableSample,
   required double Function(int j) Function(int channel) sampleAtFor,
-  ChannelSeries? Function(int channel)? bucketSeriesFor,
+  BucketSeries? Function(int channel)? bucketSeriesFor,
   double Function(double raw)? Function(int channel)? rawToDisplayFor,
   double avgStrokeWidth = 1.5,
   int avgAlpha = 255,
@@ -2317,7 +2330,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
   /// Bucket aggregates enabling the fast block reduction for [channel], or
   /// null to force the exact per-sample path (see [drawChannelEnvelope]).
   /// Must be paired with [rawToDisplay].
-  ChannelSeries? bucketSeries(int channel) => null;
+  BucketSeries? bucketSeries(int channel) => null;
 
   /// Affine raw-counts -> display-units map matching [sampleAt]; required by
   /// the bucket fast path.
@@ -2477,7 +2490,7 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
       taredDisplaySampleAt(_data, channel, _settings.displayUnit);
 
   @override
-  ChannelSeries? bucketSeries(int channel) => _data.channel(channel);
+  BucketSeries? bucketSeries(int channel) => _data.channel(channel).buckets;
 
   @override
   double Function(double raw)? rawToDisplay(int channel) =>
@@ -2520,16 +2533,16 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
         }
       }
 
-      final int bs = s.bucketSize;
+      final int bs = s.buckets.bucketSize;
       if (sScanEnd - sScanStart >= 2 * bs) {
         // First/last bucket indices fully inside the scan range.
         final int bFirst = (sScanStart + bs - 1) ~/ bs;
         final int bLastEx = sScanEnd ~/ bs;
-        final int numBuckets = s.bucketMins.length;
+        final int numBuckets = s.buckets.mins.length;
         for (int b = bFirst; b < bLastEx; b++) {
           final int li = b % numBuckets;
-          fold((s.bucketMins[li] - tare).toDouble());
-          fold((s.bucketMaxs[li] - tare).toDouble());
+          fold((s.buckets.mins[li] - tare).toDouble());
+          fold((s.buckets.maxs[li] - tare).toDouble());
         }
         scanRaw(sScanStart, bFirst * bs);
         scanRaw(bLastEx * bs, sScanEnd);
@@ -2595,27 +2608,67 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
   }
 
   @override
+  BucketSeries? bucketSeries(int channel) => _data.diffBuckets(channel);
+
+  @override
+  double Function(double raw)? rawToDisplay(int channel) {
+    final scale =
+        _settings.displayUnit.multiplierFromRaw(_data.calibrationSlope) *
+        _data.sampleRate;
+    return (raw) => raw * scale;
+  }
+
+  @override
   YAxisRange computeYRange(int viewStart, int viewEnd) {
-    // Compute derivative min/max (in display units) across the visible window.
+    // Derivative min/max (display units) across the visible window. Full
+    // buckets are folded from the precomputed diff aggregates (exact for
+    // min/max); only the partial head/tail buckets are scanned per sample,
+    // so the cost is O(window / bucketSize).
     double dMin = 0;
     double dMax = 0;
     bool first = true;
     final startI = math.max(viewStart, _data.oldestSample + 1);
     final endI = math.min(viewEnd, _data.totalSamples);
+    final scale =
+        _settings.displayUnit.multiplierFromRaw(_data.calibrationSlope) *
+        _data.sampleRate;
+
+    void fold(double d) {
+      if (first || d < dMin) dMin = d;
+      if (first || d > dMax) dMax = d;
+      first = false;
+    }
+
     for (final ch in _settings.activeChannelIndices) {
       if (_data.channel(ch).data.isEmpty) continue;
+      if (startI >= endI) continue;
       final valueAt = sampleAt(ch);
-      for (int i = startI; i < endI; i++) {
-        final d = valueAt(i);
-        if (d.isNaN) continue;
-        if (first) {
-          dMin = d;
-          dMax = d;
-          first = false;
-        } else {
-          if (d < dMin) dMin = d;
-          if (d > dMax) dMax = d;
+
+      void scanExact(int from, int to) {
+        for (int i = from; i < to; i++) {
+          final d = valueAt(i);
+          if (d.isNaN) continue;
+          fold(d);
         }
+      }
+
+      final buckets = _data.diffBuckets(ch);
+      if (buckets != null && endI - startI >= 2 * buckets.bucketSize) {
+        final int bs = buckets.bucketSize;
+        // First/last bucket indices fully inside the scan range. Folding
+        // both scaled bounds keeps this correct under a negative scale.
+        final int bFirst = (startI + bs - 1) ~/ bs;
+        final int bLastEx = endI ~/ bs;
+        final int numBuckets = buckets.mins.length;
+        for (int b = bFirst; b < bLastEx; b++) {
+          final int li = b % numBuckets;
+          fold(buckets.mins[li] * scale);
+          fold(buckets.maxs[li] * scale);
+        }
+        scanExact(startI, bFirst * bs);
+        scanExact(bLastEx * bs, endI);
+      } else {
+        scanExact(startI, endI);
       }
     }
     return _computeYRange(dMin, dMax);

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -1859,10 +1859,12 @@ class VertexBatcher {
 ///  2. avg: a partially covered bucket contributes `bucketMean * covered`,
 ///     i.e. its mean is assumed uniform across the bucket.
 ///
-/// Gap handling also differs between the paths: [sampleAt] returns NaN
-/// inside gaps, so the exact path breaks the polyline there, while the
-/// buckets contain the held values and the fast path draws them (the
-/// hatching marks the range as missing either way).
+/// Gap handling: [paintEnvelopeDataLayer] clips all data ink out of the gap
+/// x-ranges, so neither path draws inside a gap. Within the remaining
+/// (clipped-in) area the paths still differ slightly at gap edges: [sampleAt]
+/// returns NaN inside gaps, so the exact path reduces boundary blocks from
+/// their real samples only, while the buckets contain held values, biasing
+/// the fast path's boundary blocks toward the pre-gap value.
 ///
 /// The exact per-sample path has none of these differences; the derivative
 /// graph always uses it (first differences cannot be reconstructed from
@@ -2129,6 +2131,18 @@ bool paintEnvelopeDataLayer(
       // segment; the envelope fill is clipped at the seam so the alpha
       // fills of adjacent segments never double-blend.
       final int limit = math.min(end + blockSize, totalSamples);
+
+      // No data ink inside gaps: clip out their x-ranges so neither the
+      // exact path's boundary blocks nor the bucket path's held-value line
+      // can draw where no data exists (the hatching, drawn by the graph
+      // chrome outside this layer, is the only marker there). Safe to apply
+      // at bake time: gaps are append-only at the live edge, so the gap set
+      // inside an already-baked segment can never change.
+      final clip = _gapClipPath(data.gaps, start, limit, gw / viewSpan);
+      if (clip != null) {
+        cCanvas.save();
+        cCanvas.clipPath(clip);
+      }
       for (final ch in activeChannels) {
         if (data.channel(ch).data.isEmpty) continue;
 
@@ -2150,10 +2164,36 @@ bool paintEnvelopeDataLayer(
           rawToDisplay: rawToDisplayFor?.call(ch),
         );
       }
+      if (clip != null) cCanvas.restore();
       // drawChannelEnvelope maps sample s to (s - start) * gw / viewSpan.
       return (end - start) * gw / viewSpan;
     },
   );
+}
+
+/// Everything-except-gaps clip for the sample window [start, end) under the
+/// mapping `x = (s - start) * pxPerSample`, or null when no gap overlaps the
+/// window (the common case; callers skip save/clip/restore entirely). Built
+/// as one huge rect with even-odd gap holes; gap ranges are disjoint, so
+/// even-odd punches each exactly once.
+Path? _gapClipPath(GapList gaps, int start, int end, double pxPerSample) {
+  if (gaps.isEmpty) return null;
+  const double big = 1e9; // covers any pad/overdraw around the plot area
+  Path? path;
+  for (final (gs, ge) in gaps.rangesIn(start, end)) {
+    path ??= Path()
+      ..fillType = PathFillType.evenOdd
+      ..addRect(const Rect.fromLTRB(-big, -big, big, big));
+    path.addRect(
+      Rect.fromLTRB(
+        (gs - start) * pxPerSample,
+        -big,
+        (ge - start) * pxPerSample,
+        big,
+      ),
+    );
+  }
+  return path;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../models/app_settings.dart';
+import '../models/force_unit.dart';
 import '../models/gap_list.dart';
 
 // ---------------------------------------------------------------------------
@@ -544,6 +545,12 @@ int blockSizeFor(int viewSamples, double graphW) {
 
 /// A single channel's raw circular-buffer data plus its precomputed extremes
 /// and tare offset. Returned by [GraphDataSource.channel].
+///
+/// The bucket arrays hold min/max/sum aggregates over fixed [bucketSize]-
+/// sample windows (absolute bucket index `b = sampleIndex ~/ bucketSize`,
+/// stored at `b % bucketMins.length`). Gap samples hold the previous real
+/// value, so buckets are always fully populated and carry no missing-data
+/// state -- see the accuracy tradeoff documented on [drawChannelEnvelope].
 typedef ChannelSeries = ({
   List<int> data,
   double min,
@@ -893,13 +900,13 @@ void _handleGraphPointerScroll(
 
 class Minimap extends StatefulWidget {
   final GraphDataSource dataSource;
-  final List<int> activeChannels;
+  final AppSettings settings;
   final GraphController graphCtrl;
 
   const Minimap({
     super.key,
     required this.dataSource,
-    required this.activeChannels,
+    required this.settings,
     required this.graphCtrl,
   });
 
@@ -992,7 +999,7 @@ class _MinimapState extends State<Minimap> {
               child: CustomPaint(
                 foregroundPainter: _MinimapPainter(
                   widget.dataSource,
-                  widget.activeChannels,
+                  widget.settings,
                   widget.graphCtrl,
                   colorScheme,
                   dpr,
@@ -1012,7 +1019,7 @@ class _MinimapState extends State<Minimap> {
 
 class _MinimapPainter extends CustomPainter {
   final GraphDataSource _data;
-  final List<int> _activeIndices;
+  final AppSettings _settings;
   final GraphController _ctrl;
   final ColorScheme _colorScheme;
   final double _dpr;
@@ -1025,7 +1032,7 @@ class _MinimapPainter extends CustomPainter {
 
   _MinimapPainter(
     this._data,
-    this._activeIndices,
+    this._settings,
     this._ctrl,
     this._colorScheme,
     this._dpr,
@@ -1055,52 +1062,67 @@ class _MinimapPainter extends CustomPainter {
     final mapSpan = math.max(totalSamples - oldestSample, _ctrl.minLiveSpan);
     final mapStart = totalSamples - mapSpan;
 
-    // Compute global min/max (raw, tare-subtracted) for full data. The
-    // +/-10000 floor keeps the range non-degenerate on flat data.
+    final activeIndices = _settings.activeChannelIndices;
+    final unit = _settings.displayUnit;
+
+    // Y-range from the precomputed per-channel extremes (O(channels); the
+    // minimap always spans the whole history, so the extremes ARE the window
+    // min/max). Computed raw and tare-subtracted with a +/-10000-count floor
+    // to keep the range non-degenerate on flat data, then converted to
+    // display units to match the shared series evaluators.
     double rawMax = 10000;
     double rawMin = -10000;
-    for (final ch in _activeIndices) {
+    for (final ch in activeIndices) {
       final s = _data.channel(ch);
       final mx = s.max - s.tare;
       final mn = s.min - s.tare;
       if (mx > rawMax) rawMax = mx;
       if (mn < rawMin) rawMin = mn;
     }
+    double yMin = unit.fromRaw(rawMin, _data.calibrationSlope);
+    double yMax = unit.fromRaw(rawMax, _data.calibrationSlope);
+    if (yMin > yMax) {
+      // A negative display multiplier flipped the ordering.
+      final t = yMin;
+      yMin = yMax;
+      yMax = t;
+    }
 
-    final tares = [for (final ch in _activeIndices) _data.channel(ch).tare];
-
-    // Blit the cached segment textures under the current mapping, spend at
-    // most one bake, and vector-draw the live-edge sliver. Gaps wider than
-    // ~2 target widths (bootstrap / data jump) stay blank while the rolling
-    // bakes fill the strip in.
-    final workRemains = _cache.paint(
+    // Missing-data hatching, behind the data lines (same layering as the
+    // main graphs).
+    drawMissingDataHatching(
       canvas,
-      configKey: [..._activeIndices, ...tares],
+      Size(gw, gh),
+      viewStart: mapStart,
+      viewEnd: mapStart + mapSpan,
+      data: _data,
+      color: _colorScheme.error,
+    );
+
+    final tares = [for (final ch in activeIndices) _data.channel(ch).tare];
+
+    // Segment-cached envelope data layer, shared with the main graphs. The
+    // bucket-accelerated reduction keeps both segment bakes and direct gap
+    // draws cheap even though every block spans many samples here.
+    final workRemains = paintEnvelopeDataLayer(
+      canvas,
+      cache: _cache,
+      data: _data,
+      activeChannels: activeIndices,
+      keyExtras: [...tares, unit, _data.calibrationSlope],
       gw: gw,
       gh: gh,
       dpr: _dpr,
       viewStart: mapStart,
       viewSpan: mapSpan,
-      yMin: rawMin,
-      yMax: rawMax,
-      totalSamples: totalSamples,
-      hPad: 0,
-      vPad: 0,
-      maxDirectGapPx: 2 * kSegmentTargetPx,
-      render: (c, start, end, texW) {
-        _drawWaveformColumns(
-          c,
-          texW,
-          gh,
-          start,
-          end - start,
-          rawMin,
-          rawMax,
-          tares,
-        );
-        // drawSqueezedEnvelope spreads the range over exactly texW columns.
-        return texW.toDouble();
-      },
+      yMin: yMin,
+      yMax: yMax,
+      firstUsableSample: oldestSample,
+      sampleAtFor: (ch) => taredDisplaySampleAt(_data, ch, unit),
+      bucketSeriesFor: _data.channel,
+      rawToDisplayFor: (ch) => taredDisplayFromRaw(_data, ch, unit),
+      avgStrokeWidth: 1.0,
+      avgAlpha: 180,
     );
     if (workRemains) _requestRepaint();
 
@@ -1124,41 +1146,6 @@ class _MinimapPainter extends CustomPainter {
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.5;
     canvas.drawRect(Rect.fromLTRB(x1, 0, x2, gh), vpBorder);
-  }
-
-  /// Vector-render samples [rangeStart, rangeStart + rangeSpan) as min/avg/
-  /// max columns squeezed into [pixelWidth] columns. The [SegmentedGraphCache]
-  /// renderer: used both to bake segment textures and to draw uncovered gaps
-  /// (the live-edge sliver) directly to the frame canvas.
-  void _drawWaveformColumns(
-    Canvas canvas,
-    int pixelWidth,
-    double gh,
-    int rangeStart,
-    int rangeSpan,
-    double rawMin,
-    double rawMax,
-    List<double> tares,
-  ) {
-    final dataRange = rawMax - rawMin;
-    for (int i = 0; i < _activeIndices.length; i++) {
-      final ch = _activeIndices[i];
-      final tare = tares[i];
-      final chColor = getChannelColor(ch);
-
-      drawSqueezedEnvelope(
-        canvas,
-        data: _data,
-        channel: ch,
-        pixelWidth: pixelWidth,
-        rangeStart: rangeStart,
-        rangeSpan: rangeSpan,
-        valueToY: (raw) =>
-            (gh - (raw - tare - rawMin) * gh / dataRange).clamp(0.0, gh),
-        avgColor: chColor.withAlpha(180),
-        envColor: chColor.withAlpha(60),
-      );
-    }
   }
 
   @override
@@ -1385,7 +1372,7 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                 if (widget.showMinimap)
                   Minimap(
                     dataSource: widget.data,
-                    activeChannels: widget.settings.activeChannelIndices,
+                    settings: widget.settings,
                     graphCtrl: widget.ctrl,
                   ),
               ],
@@ -1843,14 +1830,49 @@ class VertexBatcher {
 
 /// Render one channel as a min/avg/max envelope across [graphW] pixel columns.
 ///
-/// For each pixel column the samples mapped to it are reduced to min/avg/max via
-/// [sampleAt] (raw per-sample value), then projected with [valueToY]. The shaded
-/// envelope is filled at low alpha and the average is stroked on top.
+/// For each block the samples mapped to it are reduced to min/avg/max, then
+/// projected with [valueToY]. The shaded envelope is filled at low alpha and
+/// the average is stroked on top.
 ///
 /// Blocks are anchored to absolute sample indices so the geometry lands on
 /// the same pixels regardless of scroll, which is what makes it segment-
-/// cacheable; [drawSqueezedEnvelope] is the bucket-accelerated counterpart
-/// used by the minimap.
+/// cacheable.
+///
+/// ## Block reduction: exact vs bucket-accelerated
+///
+/// By default each block is reduced by evaluating [sampleAt] per sample --
+/// exact, but O(samples) per bake, which is too slow when a zoomed-out block
+/// spans thousands of samples. Passing [bucketSeries] + [rawToDisplay]
+/// enables a fast path that aggregates from the channel's precomputed
+/// per-bucket min/max/sum arrays whenever `blockSize >= 2 * bucketSize`.
+///
+/// ACCURACY TRADEOFF (partial block/bucket boundaries) -- the bucket path is
+/// approximate in two ways, both confined to buckets that straddle a block
+/// edge (at most one bucket, i.e. at most half a block, per edge under the
+/// engagement condition):
+///
+///  1. min/max: a block's boundary buckets contribute their FULL bucket
+///     min/max even when the block covers only part of the bucket, so the
+///     envelope can be up to one bucket too wide at block edges --
+///     conservative (an extreme is never dropped, only shown one block
+///     early/late).
+///  2. avg: a partially covered bucket contributes `bucketMean * covered`,
+///     i.e. its mean is assumed uniform across the bucket.
+///
+/// Gap handling also differs between the paths: [sampleAt] returns NaN
+/// inside gaps, so the exact path breaks the polyline there, while the
+/// buckets contain the held values and the fast path draws them (the
+/// hatching marks the range as missing either way).
+///
+/// The exact per-sample path has none of these differences; the derivative
+/// graph always uses it (first differences cannot be reconstructed from
+/// raw-value buckets).
+///
+/// Reduction on the bucket path happens in raw counts and is converted with
+/// [rawToDisplay], which MUST be affine (e.g. tare offset + unit scale) so
+/// the average survives the mapping, and must agree with [sampleAt]
+/// (`sampleAt(j) == rawToDisplay(raw sample j)` outside gaps) so both paths
+/// plot the same series.
 ///
 /// Vertices are flushed in <=4096-float chunks to stay within the web
 /// (Skwasm/Emscripten) stack-allocation limit.
@@ -1863,18 +1885,30 @@ void drawChannelEnvelope(
   required int totalSamples,
   required int firstUsableSample,
   required double Function(int sampleIndex) sampleAt,
-  required double Function(double rawReduced) valueToY,
+  required double Function(double value) valueToY,
   required int clipEnvelopeSamples,
+  double avgStrokeWidth = 1.5,
+  int avgAlpha = 255,
+  int envAlpha = 60,
+  ChannelSeries? bucketSeries,
+  double Function(double raw)? rawToDisplay,
 }) {
   final (avg: avg, env: env) = _envelopeBatchers(
     canvas,
-    avgColor: color,
-    avgStrokeWidth: 1.5,
-    envColor: color.withAlpha(60),
+    avgColor: color.withAlpha(avgAlpha),
+    avgStrokeWidth: avgStrokeWidth,
+    envColor: color.withAlpha(envAlpha),
   );
 
   // Calculate alignment block size
   final int blockSize = blockSizeFor(viewSamples, graphW);
+
+  // Bucket acceleration only pays off (and only stays accurate, see the
+  // ACCURACY TRADEOFF above) once a block spans at least two buckets.
+  final bool useBuckets =
+      bucketSeries != null &&
+      rawToDisplay != null &&
+      blockSize >= 2 * bucketSeries.bucketSize;
 
   // Blocks are anchored to absolute sample 0 (sStart = k * blockSize), NOT to
   // viewStart. This is what lets a block fall on the same pixels regardless of
@@ -1897,18 +1931,66 @@ void drawChannelEnvelope(
     // firstUsableSample are both legitimately shorter.
     assert(sEnd - drawStart >= 1 && sEnd - drawStart <= blockSize);
 
-    double total = 0;
-    double minRaw = double.infinity;
-    double maxRaw = double.negativeInfinity;
+    double minVal = double.infinity;
+    double maxVal = double.negativeInfinity;
+    double avgVal = 0;
     int validSamples = 0;
 
-    for (int j = drawStart; j < sEnd; j++) {
-      final v = sampleAt(j);
-      if (v.isNaN) continue;
-      total += v;
-      if (v < minRaw) minRaw = v;
-      if (v > maxRaw) maxRaw = v;
-      validSamples++;
+    if (useBuckets) {
+      // Bucket-accelerated reduction; approximate at the boundary buckets
+      // (see ACCURACY TRADEOFF in the doc comment).
+      final int bs = bucketSeries.bucketSize;
+      final bucketMins = bucketSeries.bucketMins;
+      final bucketMaxs = bucketSeries.bucketMaxs;
+      final bucketSums = bucketSeries.bucketSums;
+      final int numBuckets = bucketMins.length;
+
+      double totalRaw = 0;
+      double minRaw = double.infinity;
+      double maxRaw = double.negativeInfinity;
+
+      final int bFirst = drawStart ~/ bs;
+      final int bLast = (sEnd - 1) ~/ bs;
+      for (int b = bFirst; b <= bLast; b++) {
+        final int li = b % numBuckets;
+
+        // Only the count is portion-aware; min/max/mean come from the whole
+        // bucket -- this is the boundary approximation.
+        int count = bs;
+        if (b == bFirst) count -= drawStart - b * bs;
+        if (b == bLast) count -= (b + 1) * bs - sEnd;
+        if (count <= 0) continue;
+
+        final int bMin = bucketMins[li];
+        final int bMax = bucketMaxs[li];
+        if (bMin < minRaw) minRaw = bMin.toDouble();
+        if (bMax > maxRaw) maxRaw = bMax.toDouble();
+        totalRaw += bucketSums[li] * count / bs;
+        validSamples += count;
+      }
+
+      if (validSamples > 0) {
+        minVal = rawToDisplay(minRaw);
+        maxVal = rawToDisplay(maxRaw);
+        avgVal = rawToDisplay(totalRaw / validSamples);
+        if (minVal > maxVal) {
+          // A negative display multiplier flipped the ordering.
+          final t = minVal;
+          minVal = maxVal;
+          maxVal = t;
+        }
+      }
+    } else {
+      double total = 0;
+      for (int j = drawStart; j < sEnd; j++) {
+        final v = sampleAt(j);
+        if (v.isNaN) continue;
+        total += v;
+        if (v < minVal) minVal = v;
+        if (v > maxVal) maxVal = v;
+        validSamples++;
+      }
+      if (validSamples > 0) avgVal = total / validSamples;
     }
 
     if (validSamples == 0) {
@@ -1918,11 +2000,9 @@ void drawChannelEnvelope(
       continue;
     }
 
-    final avgVal = total / validSamples;
-
     final avgY = valueToY(avgVal);
-    final minY = valueToY(minRaw);
-    final maxY = valueToY(maxRaw);
+    final minY = valueToY(minVal);
+    final maxY = valueToY(maxVal);
 
     // Absolute X (in this canvas's local space): a baked segment passes its
     // own start as viewStart, so xPos is segment-local and the segment slides
@@ -1948,130 +2028,132 @@ void drawChannelEnvelope(
   avg.flush();
 }
 
-/// Render one channel as a min/avg/max envelope with one block per pixel
-/// column, squeezing the sample range [rangeStart, rangeStart + rangeSpan)
-/// into [pixelWidth] columns.
+/// Per-sample evaluator for [channel]'s tared value in [unit] (NaN marks a
+/// gap sample, breaking the polyline). The exact-path counterpart of
+/// [taredDisplayFromRaw]; used by the force graph and the minimap.
+double Function(int j) taredDisplaySampleAt(
+  GraphDataSource data,
+  int channel,
+  ForceUnit unit,
+) {
+  final s = data.channel(channel);
+  final line = s.data;
+  final tare = s.tare;
+  final bufferCap = data.bufferCapacity;
+  final gaps = data.gaps;
+  final slopeToUnit = unit.multiplierFromRaw(data.calibrationSlope);
+  return (j) {
+    if (gaps.contains(j)) return double.nan; // break the polyline
+    return (line[j % bufferCap] - tare) * slopeToUnit;
+  };
+}
+
+/// Affine raw-counts -> display-units map for [channel] (tare offset + unit
+/// scale). Must agree with [taredDisplaySampleAt] outside gaps; feeds the
+/// bucket fast path of [drawChannelEnvelope].
+double Function(double raw) taredDisplayFromRaw(
+  GraphDataSource data,
+  int channel,
+  ForceUnit unit,
+) {
+  final tare = data.channel(channel).tare;
+  final slopeToUnit = unit.multiplierFromRaw(data.calibrationSlope);
+  return (raw) => (raw - tare) * slopeToUnit;
+}
+
+/// Paint the segment-cached envelope data layer for the window
+/// [viewStart, viewStart + viewSpan) mapped to x in [0, gw): the pipeline
+/// shared by the force graph, derivative graph, and minimap. Handles the
+/// cache configuration (keying, pads, block sizing) and renders one
+/// min/avg/max envelope per active channel via [drawChannelEnvelope].
 ///
-/// This is the bucket-accelerated counterpart of [drawChannelEnvelope], used
-/// by the minimap. Columns spanning many samples aggregate from the channel's
-/// precomputed bucket arrays; columns spanning few (zoomed in past ~2
-/// buckets/column) loop the raw ring buffer to avoid blockiness.
+/// [sampleAtFor] returns the per-sample series evaluator for a channel (in
+/// display units); [bucketSeriesFor]/[rawToDisplayFor] optionally enable the
+/// bucket-accelerated block reduction (see [drawChannelEnvelope] for the
+/// accuracy tradeoff) -- pass null for series that cannot use raw buckets
+/// (e.g. derivatives).
 ///
-/// Reduction happens in raw counts; [valueToY] projects a reduced raw value
-/// (not tare-subtracted) to a pixel Y.
-void drawSqueezedEnvelope(
+/// Returns true when bake work remains; the owner should then schedule
+/// another frame.
+bool paintEnvelopeDataLayer(
   Canvas canvas, {
+  required SegmentedGraphCache cache,
   required GraphDataSource data,
-  required int channel,
-  required int pixelWidth,
-  required int rangeStart,
-  required int rangeSpan,
-  required double Function(double raw) valueToY,
-  required Color avgColor,
-  required Color envColor,
-  double avgStrokeWidth = 1.0,
+  required List<int> activeChannels,
+  required List<Object?> keyExtras,
+  required double gw,
+  required double gh,
+  required double dpr,
+  required int viewStart,
+  required int viewSpan,
+  required double yMin,
+  required double yMax,
+  required int firstUsableSample,
+  required double Function(int j) Function(int channel) sampleAtFor,
+  ChannelSeries? Function(int channel)? bucketSeriesFor,
+  double Function(double raw)? Function(int channel)? rawToDisplayFor,
+  double avgStrokeWidth = 1.5,
+  int avgAlpha = 255,
+  int envAlpha = 60,
 }) {
-  final series = data.channel(channel);
-  final line = series.data;
-  if (line.isEmpty) return;
-
-  final bufferCapacity = data.bufferCapacity;
   final totalSamples = data.totalSamples;
-  final oldestSample = data.oldestSample;
 
-  final (avg: avg, env: env) = _envelopeBatchers(
+  double valueToY(double val) =>
+      (gh - (val - yMin) * gh / (yMax - yMin)).clamp(0.0, gh);
+
+  final int blockSize = blockSizeFor(viewSpan, gw);
+  final double blockPx = blockSize * gw / viewSpan;
+
+  return cache.paint(
     canvas,
-    avgColor: avgColor,
-    avgStrokeWidth: avgStrokeWidth,
-    envColor: envColor,
+    configKey: [...activeChannels, ...keyExtras],
+    gw: gw,
+    gh: gh,
+    dpr: dpr,
+    viewStart: viewStart,
+    viewSpan: viewSpan,
+    yMin: yMin,
+    yMax: yMax,
+    totalSamples: totalSamples,
+    // The recorded polyline overshoots a segment's edges by up to one
+    // block (the join to the neighbor), and one block can be many px when
+    // zoomed in past 1 sample/px -- the horizontal pad must cover it.
+    hPad: math.max(kSegmentImagePad, blockPx + 2),
+    vPad: kSegmentImagePad,
+    // Gaps (live edge, bake backlog after pans/zooms) are always drawn as
+    // vectors; with the bucket-accelerated reduction even history-wide gaps
+    // are cheap enough to render directly.
+    maxDirectGapPx: double.infinity,
+    render: (cCanvas, start, end, texW) {
+      // One block past the segment end joins the polyline to the next
+      // segment; the envelope fill is clipped at the seam so the alpha
+      // fills of adjacent segments never double-blend.
+      final int limit = math.min(end + blockSize, totalSamples);
+      for (final ch in activeChannels) {
+        if (data.channel(ch).data.isEmpty) continue;
+
+        drawChannelEnvelope(
+          cCanvas,
+          color: getChannelColor(ch),
+          graphW: gw,
+          viewStart: start,
+          viewSamples: viewSpan,
+          totalSamples: limit,
+          firstUsableSample: firstUsableSample,
+          sampleAt: sampleAtFor(ch),
+          valueToY: valueToY,
+          clipEnvelopeSamples: end,
+          avgStrokeWidth: avgStrokeWidth,
+          avgAlpha: avgAlpha,
+          envAlpha: envAlpha,
+          bucketSeries: bucketSeriesFor?.call(ch),
+          rawToDisplay: rawToDisplayFor?.call(ch),
+        );
+      }
+      // drawChannelEnvelope maps sample s to (s - start) * gw / viewSpan.
+      return (end - start) * gw / viewSpan;
+    },
   );
-
-  final int bucketSize = series.bucketSize;
-  final bucketMins = series.bucketMins;
-  final bucketMaxs = series.bucketMaxs;
-  final bucketSums = series.bucketSums;
-  final int numBuckets = bucketMins.length;
-
-  for (int px = 0; px < pixelWidth; px++) {
-    final int sStart = rangeStart + px * rangeSpan ~/ pixelWidth;
-    final int sEnd = rangeStart + (px + 1) * rangeSpan ~/ pixelWidth;
-    final int drawStart = math.max(sStart, oldestSample);
-    final int drawEnd = math.min(sEnd, totalSamples);
-
-    if (drawStart >= drawEnd) continue;
-
-    double total = 0;
-    double minRaw = double.infinity;
-    double maxRaw = double.negativeInfinity;
-    int validSamples = 0;
-
-    final int samplesInPixel = drawEnd - drawStart;
-
-    if (samplesInPixel <= bucketSize * 2) {
-      // High-res mode: loop the raw array to avoid blockiness when zoomed in.
-      // Gap samples hold the previous real value, so no exclusion is needed;
-      // the main graph's hatching is the missing-data indicator.
-      for (int j = drawStart; j < drawEnd; j++) {
-        final double valDouble = line[j % bufferCapacity].toDouble();
-        total += valDouble;
-        if (valDouble < minRaw) minRaw = valDouble;
-        if (valDouble > maxRaw) maxRaw = valDouble;
-        validSamples++;
-      }
-    } else {
-      // Squished mode: aggregate from the precomputed bucket arrays.
-      final int bStart = drawStart ~/ bucketSize;
-      final int bEnd = drawEnd ~/ bucketSize;
-
-      for (int b = bStart; b <= bEnd; b++) {
-        final int listIdx = b % numBuckets;
-
-        final double bMin = bucketMins[listIdx].toDouble();
-        final double bMax = bucketMaxs[listIdx].toDouble();
-        if (bMin < minRaw) minRaw = bMin;
-        if (bMax > maxRaw) maxRaw = bMax;
-
-        int count = bucketSize;
-        if (b == bStart) {
-          // Only count the covered portion of the first bucket.
-          final int bucketEndSample = (b + 1) * bucketSize;
-          count = bucketEndSample - drawStart;
-          if (count > bucketSize) count = bucketSize;
-        } else if (b == bEnd) {
-          // Only count the covered portion of the last bucket.
-          final int bucketStartSample = b * bucketSize;
-          count = drawEnd - bucketStartSample;
-          if (count > bucketSize) count = bucketSize;
-        }
-        if (count < 0) count = 0;
-
-        // Approximate the sum contribution of the covered portion.
-        final double avgOfBucket = bucketSums[listIdx] / bucketSize;
-        total += avgOfBucket * count;
-        validSamples += count;
-      }
-    }
-
-    if (validSamples == 0) continue; // defensive; drawStart < drawEnd above
-
-    final avgY = valueToY(total / validSamples);
-    final minY = valueToY(minRaw);
-    final maxY = valueToY(maxRaw);
-
-    final xPos = px.toDouble();
-    avg.add(xPos, avgY);
-
-    env.add(xPos, maxY);
-    env.add(xPos, minY);
-
-    // Flush chunks if we are getting close to the array limits
-    if (env.wouldOverflow(4)) env.flush();
-    if (avg.wouldOverflow(2)) avg.flush();
-  }
-
-  // Flush remaining data
-  env.flush();
-  avg.flush();
 }
 
 // ---------------------------------------------------------------------------
@@ -2192,6 +2274,15 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
   /// sample index, in display units. NaN marks a missing sample.
   double Function(int j) sampleAt(int channel);
 
+  /// Bucket aggregates enabling the fast block reduction for [channel], or
+  /// null to force the exact per-sample path (see [drawChannelEnvelope]).
+  /// Must be paired with [rawToDisplay].
+  ChannelSeries? bucketSeries(int channel) => null;
+
+  /// Affine raw-counts -> display-units map matching [sampleAt]; required by
+  /// the bucket fast path.
+  double Function(double raw)? rawToDisplay(int channel) => null;
+
   /// Y-axis range (display units) for the visible window.
   YAxisRange computeYRange(int viewStart, int viewEnd);
 
@@ -2226,7 +2317,6 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
 
     final activeIndices = _settings.activeChannelIndices;
     final oldestSample = _data.oldestSample;
-    final totalSamples = _data.totalSamples;
 
     final yRange = computeYRange(viewStart, viewEnd);
 
@@ -2285,13 +2375,12 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
     drawOverlay(canvas, graphSz);
 
     // -- Data lines (segment-cached envelope) --
-    final int blockSize = blockSizeFor(viewSamples, graphSz.width);
-    final double blockPx = blockSize * graphSz.width / viewSamples;
-
-    final workRemains = cache.paint(
+    final workRemains = paintEnvelopeDataLayer(
       canvas,
-      configKey: [
-        ...activeIndices,
+      cache: cache,
+      data: _data,
+      activeChannels: activeIndices,
+      keyExtras: [
         ...cacheKeyTares(),
         _settings.displayUnit,
         _data.calibrationSlope,
@@ -2303,39 +2392,10 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       viewSpan: viewSamples,
       yMin: yRange.yMin,
       yMax: yRange.yMax,
-      totalSamples: totalSamples,
-      // The recorded polyline overshoots a segment's edges by up to one
-      // block (the join to the neighbor), and one block can be many px when
-      // zoomed in past 1 sample/px -- the horizontal pad must cover it.
-      hPad: math.max(kSegmentImagePad, blockPx + 2),
-      vPad: kSegmentImagePad,
-      // Gaps (live edge, bake backlog after pans/zooms) are always drawn as
-      // vectors on the main plots; only the minimap blanks its big gaps.
-      maxDirectGapPx: double.infinity,
-      render: (cCanvas, start, end, texW) {
-        // One block past the segment end joins the polyline to the next
-        // segment; the envelope fill is clipped at the seam so the alpha
-        // fills of adjacent segments never double-blend.
-        final int limit = math.min(end + blockSize, totalSamples);
-        for (final ch in activeIndices) {
-          if (_data.channel(ch).data.isEmpty) continue;
-
-          drawChannelEnvelope(
-            cCanvas,
-            color: getChannelColor(ch),
-            graphW: graphSz.width,
-            viewStart: start,
-            viewSamples: viewSamples,
-            totalSamples: limit,
-            firstUsableSample: oldestSample + firstSampleOffset,
-            sampleAt: sampleAt(ch),
-            valueToY: (v) => valueToY(v).clamp(0.0, graphSz.height),
-            clipEnvelopeSamples: end,
-          );
-        }
-        // drawChannelEnvelope maps sample s to (s - start) * gw / viewSamples.
-        return (end - start) * graphSz.width / viewSamples;
-      },
+      firstUsableSample: oldestSample + firstSampleOffset,
+      sampleAtFor: sampleAt,
+      bucketSeriesFor: bucketSeries,
+      rawToDisplayFor: rawToDisplay,
     );
     if (workRemains) _requestRepaint();
   }
@@ -2373,26 +2433,23 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
       .toList();
 
   @override
-  double Function(int j) sampleAt(int channel) {
-    final s = _data.channel(channel);
-    final line = s.data;
-    final tare = s.tare;
-    final bufferCap = _data.bufferCapacity;
-    final gaps = _data.gaps;
-    final slopeToUnit = _settings.displayUnit.multiplierFromRaw(
-      _data.calibrationSlope,
-    );
-    return (j) {
-      if (gaps.contains(j)) return double.nan; // break the polyline
-      return (line[j % bufferCap] - tare) * slopeToUnit;
-    };
-  }
+  double Function(int j) sampleAt(int channel) =>
+      taredDisplaySampleAt(_data, channel, _settings.displayUnit);
+
+  @override
+  ChannelSeries? bucketSeries(int channel) => _data.channel(channel);
+
+  @override
+  double Function(double raw)? rawToDisplay(int channel) =>
+      taredDisplayFromRaw(_data, channel, _settings.displayUnit);
 
   @override
   YAxisRange computeYRange(int viewStart, int viewEnd) {
     // Compute data min/max across active channels in visible window (raw,
     // tare-subtracted) so the noise floor stays a raw-count threshold, then
-    // convert to display units.
+    // convert to display units. Full buckets are folded from the precomputed
+    // aggregates (exact for min/max); only the partial head/tail buckets are
+    // scanned per sample, so the cost is O(window / bucketSize).
     final oldestSample = _data.oldestSample;
     final totalSamples = _data.totalSamples;
     double rawMax = 0;
@@ -2407,13 +2464,37 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
       final bufferCap = _data.bufferCapacity;
       final sScanStart = math.max(viewStart, oldestSample);
       final sScanEnd = math.min(viewEnd, totalSamples);
-      for (int i = sScanStart; i < sScanEnd; i++) {
-        // Gap samples hold a previous real value, so they can never extend
-        // the range: no exclusion needed.
-        final v = line[i % bufferCap] - tare;
-        if (!hasData || v > rawMax) rawMax = v.toDouble();
-        if (!hasData || v < rawMin) rawMin = v.toDouble();
+      if (sScanStart >= sScanEnd) continue;
+
+      void fold(double v) {
+        if (!hasData || v > rawMax) rawMax = v;
+        if (!hasData || v < rawMin) rawMin = v;
         hasData = true;
+      }
+
+      // Gap samples hold a previous real value, so they can never extend
+      // the range: no exclusion needed on either path.
+      void scanRaw(int from, int to) {
+        for (int i = from; i < to; i++) {
+          fold((line[i % bufferCap] - tare).toDouble());
+        }
+      }
+
+      final int bs = s.bucketSize;
+      if (sScanEnd - sScanStart >= 2 * bs) {
+        // First/last bucket indices fully inside the scan range.
+        final int bFirst = (sScanStart + bs - 1) ~/ bs;
+        final int bLastEx = sScanEnd ~/ bs;
+        final int numBuckets = s.bucketMins.length;
+        for (int b = bFirst; b < bLastEx; b++) {
+          final int li = b % numBuckets;
+          fold((s.bucketMins[li] - tare).toDouble());
+          fold((s.bucketMaxs[li] - tare).toDouble());
+        }
+        scanRaw(sScanStart, bFirst * bs);
+        scanRaw(bLastEx * bs, sScanEnd);
+      } else {
+        scanRaw(sScanStart, sScanEnd);
       }
     }
 

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../models/app_settings.dart';
+import '../models/bucket_series.dart';
 import '../models/force_unit.dart';
 import '../models/gap_list.dart';
 
@@ -542,19 +543,6 @@ int blockSizeFor(int viewSamples, double graphW) {
   // pixels. The remainder (viewSamples % blockSize) lands in the short final block.
   return math.max(1, (viewSamples / graphW).floor());
 }
-
-/// Min/max/sum aggregates over fixed [bucketSize]-sample windows of some
-/// integer series (raw values or first differences). Addressed by absolute
-/// bucket index `b = sampleIndex ~/ bucketSize`, stored at `b % mins.length`.
-/// Gap samples hold the previous real value (diff 0), so buckets are always
-/// fully populated and carry no missing-data state -- see the accuracy
-/// tradeoff documented on [drawChannelEnvelope].
-typedef BucketSeries = ({
-  int bucketSize,
-  Int32List mins,
-  Int32List maxs,
-  Int32List sums,
-});
 
 /// A single channel's raw circular-buffer data plus its precomputed extremes,
 /// tare offset, and raw-value [BucketSeries]. Returned by
@@ -1129,9 +1117,11 @@ class _MinimapPainter extends CustomPainter {
       yMin: yMin,
       yMax: yMax,
       firstUsableSample: oldestSample,
-      sampleAtFor: (ch) => taredDisplaySampleAt(_data, ch, unit),
-      bucketSeriesFor: (ch) => _data.channel(ch).buckets,
-      rawToDisplayFor: (ch) => taredDisplayFromRaw(_data, ch, unit),
+      seriesFor: (ch) => EnvelopeSeries.bucketed(
+        sampleAt: taredDisplaySampleAt(_data, ch, unit),
+        buckets: _data.channel(ch).buckets,
+        rawToDisplay: taredDisplayFromRaw(_data, ch, unit),
+      ),
       avgStrokeWidth: 1.0,
       avgAlpha: 180,
     );
@@ -1851,43 +1841,19 @@ class VertexBatcher {
 ///
 /// ## Block reduction: exact vs bucket-accelerated
 ///
-/// By default each block is reduced by evaluating [sampleAt] per sample --
-/// exact, but O(samples) per bake, which is too slow when a zoomed-out block
-/// spans thousands of samples. Passing [bucketSeries] + [rawToDisplay]
-/// enables a fast path that aggregates from the channel's precomputed
-/// per-bucket min/max/sum arrays whenever `blockSize >= 2 * bucketSize`.
-///
-/// ACCURACY TRADEOFF (partial block/bucket boundaries) -- the bucket path is
-/// approximate in two ways, both confined to buckets that straddle a block
-/// edge (at most one bucket, i.e. at most half a block, per edge under the
-/// engagement condition):
-///
-///  1. min/max: a block's boundary buckets contribute their FULL bucket
-///     min/max even when the block covers only part of the bucket, so the
-///     envelope can be up to one bucket too wide at block edges --
-///     conservative (an extreme is never dropped, only shown one block
-///     early/late).
-///  2. avg: a partially covered bucket contributes `bucketMean * covered`,
-///     i.e. its mean is assumed uniform across the bucket.
+/// By default each block is reduced by evaluating [EnvelopeSeries.sampleAt]
+/// per sample ([reduceBlockExact]) -- exact, but O(samples) per bake, which
+/// is too slow when a zoomed-out block spans thousands of samples. A series
+/// built with [EnvelopeSeries.bucketed] switches to [reduceBlockBuckets]
+/// whenever `blockSize >= 2 * bucketSize`; see its doc for the ACCURACY
+/// TRADEOFF at partial bucket boundaries and the ring-wrap handling.
 ///
 /// Gap handling: [paintEnvelopeDataLayer] clips all data ink out of the gap
-/// x-ranges, so neither path draws inside a gap. Within the remaining
-/// (clipped-in) area the paths still differ slightly at gap edges: [sampleAt]
-/// returns NaN inside gaps, so the exact path reduces boundary blocks from
-/// their real samples only, while the buckets contain held values, biasing
-/// the fast path's boundary blocks toward the pre-gap value.
-///
-/// The exact per-sample path has none of these differences. The buckets must
-/// aggregate the SAME series that [sampleAt] evaluates (raw values for the
-/// force graph, first differences for the derivative graph -- diff extremes
-/// cannot be reconstructed from raw-value buckets, hence the dedicated
-/// ingest-time diff buckets).
-///
-/// Reduction on the bucket path happens in raw counts and is converted with
-/// [rawToDisplay], which MUST be affine (e.g. tare offset + unit scale) so
-/// the average survives the mapping, and must agree with [sampleAt]
-/// (`sampleAt(j) == rawToDisplay(raw sample j)` outside gaps) so both paths
-/// plot the same series.
+/// x-ranges, so neither reduction path draws inside a gap. Within the
+/// remaining (clipped-in) area the paths still differ slightly at gap edges:
+/// the exact path excludes gap samples via NaN, while the buckets contain
+/// held values, biasing the fast path's boundary blocks toward the pre-gap
+/// value.
 ///
 /// Vertices are flushed in <=4096-float chunks to stay within the web
 /// (Skwasm/Emscripten) stack-allocation limit.
@@ -1899,14 +1865,12 @@ void drawChannelEnvelope(
   required int viewSamples,
   required int totalSamples,
   required int firstUsableSample,
-  required double Function(int sampleIndex) sampleAt,
+  required EnvelopeSeries series,
   required double Function(double value) valueToY,
   required int clipEnvelopeSamples,
   double avgStrokeWidth = 1.5,
   int avgAlpha = 255,
   int envAlpha = 60,
-  BucketSeries? bucketSeries,
-  double Function(double raw)? rawToDisplay,
 }) {
   final (avg: avg, env: env) = _envelopeBatchers(
     canvas,
@@ -1919,11 +1883,10 @@ void drawChannelEnvelope(
   final int blockSize = blockSizeFor(viewSamples, graphW);
 
   // Bucket acceleration only pays off (and only stays accurate, see the
-  // ACCURACY TRADEOFF above) once a block spans at least two buckets.
-  final bool useBuckets =
-      bucketSeries != null &&
-      rawToDisplay != null &&
-      blockSize >= 2 * bucketSeries.bucketSize;
+  // ACCURACY TRADEOFF on reduceBlockBuckets) once a block spans at least
+  // two buckets.
+  final buckets = series.buckets;
+  final bool useBuckets = buckets != null && blockSize >= 2 * buckets.bucketSize;
 
   // Blocks are anchored to absolute sample 0 (sStart = k * blockSize), NOT to
   // viewStart. This is what lets a block fall on the same pixels regardless of
@@ -1946,78 +1909,20 @@ void drawChannelEnvelope(
     // firstUsableSample are both legitimately shorter.
     assert(sEnd - drawStart >= 1 && sEnd - drawStart <= blockSize);
 
-    double minVal = double.infinity;
-    double maxVal = double.negativeInfinity;
-    double avgVal = 0;
-    int validSamples = 0;
+    final BlockReduction r = useBuckets
+        ? reduceBlockBuckets(series, drawStart, sEnd)
+        : reduceBlockExact(series.sampleAt, drawStart, sEnd);
 
-    if (useBuckets) {
-      // Bucket-accelerated reduction; approximate at the boundary buckets
-      // (see ACCURACY TRADEOFF in the doc comment).
-      final int bs = bucketSeries.bucketSize;
-      final bucketMins = bucketSeries.mins;
-      final bucketMaxs = bucketSeries.maxs;
-      final bucketSums = bucketSeries.sums;
-      final int numBuckets = bucketMins.length;
-
-      double totalRaw = 0;
-      double minRaw = double.infinity;
-      double maxRaw = double.negativeInfinity;
-
-      final int bFirst = drawStart ~/ bs;
-      final int bLast = (sEnd - 1) ~/ bs;
-      for (int b = bFirst; b <= bLast; b++) {
-        final int li = b % numBuckets;
-
-        // Only the count is portion-aware; min/max/mean come from the whole
-        // bucket -- this is the boundary approximation.
-        int count = bs;
-        if (b == bFirst) count -= drawStart - b * bs;
-        if (b == bLast) count -= (b + 1) * bs - sEnd;
-        if (count <= 0) continue;
-
-        final int bMin = bucketMins[li];
-        final int bMax = bucketMaxs[li];
-        if (bMin < minRaw) minRaw = bMin.toDouble();
-        if (bMax > maxRaw) maxRaw = bMax.toDouble();
-        totalRaw += bucketSums[li] * count / bs;
-        validSamples += count;
-      }
-
-      if (validSamples > 0) {
-        minVal = rawToDisplay(minRaw);
-        maxVal = rawToDisplay(maxRaw);
-        avgVal = rawToDisplay(totalRaw / validSamples);
-        if (minVal > maxVal) {
-          // A negative display multiplier flipped the ordering.
-          final t = minVal;
-          minVal = maxVal;
-          maxVal = t;
-        }
-      }
-    } else {
-      double total = 0;
-      for (int j = drawStart; j < sEnd; j++) {
-        final v = sampleAt(j);
-        if (v.isNaN) continue;
-        total += v;
-        if (v < minVal) minVal = v;
-        if (v > maxVal) maxVal = v;
-        validSamples++;
-      }
-      if (validSamples > 0) avgVal = total / validSamples;
-    }
-
-    if (validSamples == 0) {
+    if (r.count == 0) {
       // Entire block is dropped samples. Break the polyline.
       env.flush();
       avg.flush();
       continue;
     }
 
-    final avgY = valueToY(avgVal);
-    final minY = valueToY(minVal);
-    final maxY = valueToY(maxVal);
+    final avgY = valueToY(r.sum / r.count);
+    final minY = valueToY(r.min);
+    final maxY = valueToY(r.max);
 
     // Absolute X (in this canvas's local space): a baked segment passes its
     // own start as viewStart, so xPos is segment-local and the segment slides
@@ -2082,11 +1987,10 @@ double Function(double raw) taredDisplayFromRaw(
 /// cache configuration (keying, pads, block sizing) and renders one
 /// min/avg/max envelope per active channel via [drawChannelEnvelope].
 ///
-/// [sampleAtFor] returns the per-sample series evaluator for a channel (in
-/// display units); [bucketSeriesFor]/[rawToDisplayFor] optionally enable the
-/// bucket-accelerated block reduction (see [drawChannelEnvelope] for the
-/// accuracy tradeoff) -- pass null for series that cannot use raw buckets
-/// (e.g. derivatives).
+/// [seriesFor] returns the per-channel rendering recipe ([EnvelopeSeries]):
+/// the exact per-sample evaluator plus optional bucket acceleration for the
+/// block reduction (see [reduceBlockBuckets] for the accuracy tradeoff) --
+/// use [EnvelopeSeries.exact] for series that cannot use buckets.
 ///
 /// Returns true when bake work remains; the owner should then schedule
 /// another frame.
@@ -2104,9 +2008,7 @@ bool paintEnvelopeDataLayer(
   required double yMin,
   required double yMax,
   required int firstUsableSample,
-  required double Function(int j) Function(int channel) sampleAtFor,
-  BucketSeries? Function(int channel)? bucketSeriesFor,
-  double Function(double raw)? Function(int channel)? rawToDisplayFor,
+  required EnvelopeSeries Function(int channel) seriesFor,
   double avgStrokeWidth = 1.5,
   int avgAlpha = 255,
   int envAlpha = 60,
@@ -2167,14 +2069,12 @@ bool paintEnvelopeDataLayer(
           viewSamples: viewSpan,
           totalSamples: limit,
           firstUsableSample: firstUsableSample,
-          sampleAt: sampleAtFor(ch),
+          series: seriesFor(ch),
           valueToY: valueToY,
           clipEnvelopeSamples: end,
           avgStrokeWidth: avgStrokeWidth,
           avgAlpha: avgAlpha,
           envAlpha: envAlpha,
-          bucketSeries: bucketSeriesFor?.call(ch),
-          rawToDisplay: rawToDisplayFor?.call(ch),
         );
       }
       if (clip != null) cCanvas.restore();
@@ -2277,7 +2177,7 @@ _GraphLayout? _setupGraphFrame(
 /// Handles the pipeline common to both: frame setup, Y-range for the visible
 /// window, axes/grid, zero baseline, missing-data hatching, and the
 /// segment-cached envelope rendering. Subclasses define the series being
-/// plotted -- [sampleAt] (per-channel value in display units), [computeYRange],
+/// plotted -- [series] (per-channel [EnvelopeSeries]), [computeYRange],
 /// [yTickLabel] -- plus layout tweaks and cache-key extras.
 abstract class _TimeSeriesGraphPainter extends CustomPainter {
   final GraphDataSource _data;
@@ -2323,18 +2223,11 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
 
   // --- Series hooks --------------------------------------------------------
 
-  /// Returns the series evaluator for [channel]: the value at an absolute
-  /// sample index, in display units. NaN marks a missing sample.
-  double Function(int j) sampleAt(int channel);
-
-  /// Bucket aggregates enabling the fast block reduction for [channel], or
-  /// null to force the exact per-sample path (see [drawChannelEnvelope]).
-  /// Must be paired with [rawToDisplay].
-  BucketSeries? bucketSeries(int channel) => null;
-
-  /// Affine raw-counts -> display-units map matching [sampleAt]; required by
-  /// the bucket fast path.
-  double Function(double raw)? rawToDisplay(int channel) => null;
+  /// Returns the rendering recipe for [channel]: the per-sample evaluator
+  /// (value at an absolute sample index, in display units; NaN marks a
+  /// missing sample) plus optional bucket acceleration (see
+  /// [EnvelopeSeries.bucketed] for the invariants it must satisfy).
+  EnvelopeSeries series(int channel);
 
   /// Y-axis range (display units) for the visible window.
   YAxisRange computeYRange(int viewStart, int viewEnd);
@@ -2446,9 +2339,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       yMin: yRange.yMin,
       yMax: yRange.yMax,
       firstUsableSample: oldestSample + firstSampleOffset,
-      sampleAtFor: sampleAt,
-      bucketSeriesFor: bucketSeries,
-      rawToDisplayFor: rawToDisplay,
+      seriesFor: series,
     );
     if (workRemains) _requestRepaint();
   }
@@ -2486,23 +2377,19 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
       .toList();
 
   @override
-  double Function(int j) sampleAt(int channel) =>
-      taredDisplaySampleAt(_data, channel, _settings.displayUnit);
-
-  @override
-  BucketSeries? bucketSeries(int channel) => _data.channel(channel).buckets;
-
-  @override
-  double Function(double raw)? rawToDisplay(int channel) =>
-      taredDisplayFromRaw(_data, channel, _settings.displayUnit);
+  EnvelopeSeries series(int channel) => EnvelopeSeries.bucketed(
+    sampleAt: taredDisplaySampleAt(_data, channel, _settings.displayUnit),
+    buckets: _data.channel(channel).buckets,
+    rawToDisplay: taredDisplayFromRaw(_data, channel, _settings.displayUnit),
+  );
 
   @override
   YAxisRange computeYRange(int viewStart, int viewEnd) {
     // Compute data min/max across active channels in visible window (raw,
     // tare-subtracted) so the noise floor stays a raw-count threshold, then
-    // convert to display units. Full buckets are folded from the precomputed
-    // aggregates (exact for min/max); only the partial head/tail buckets are
-    // scanned per sample, so the cost is O(window / bucketSize).
+    // convert to display units. [foldBucketRange] folds full buckets from
+    // the precomputed aggregates (exact for min/max) and per-sample scans
+    // only the partial head/tail, so the cost is O(window / bucketSize).
     final oldestSample = _data.oldestSample;
     final totalSamples = _data.totalSamples;
     double rawMax = 0;
@@ -2527,28 +2414,20 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
 
       // Gap samples hold a previous real value, so they can never extend
       // the range: no exclusion needed on either path.
-      void scanRaw(int from, int to) {
-        for (int i = from; i < to; i++) {
-          fold((line[i % bufferCap] - tare).toDouble());
-        }
-      }
-
-      final int bs = s.buckets.bucketSize;
-      if (sScanEnd - sScanStart >= 2 * bs) {
-        // First/last bucket indices fully inside the scan range.
-        final int bFirst = (sScanStart + bs - 1) ~/ bs;
-        final int bLastEx = sScanEnd ~/ bs;
-        final int numBuckets = s.buckets.mins.length;
-        for (int b = bFirst; b < bLastEx; b++) {
-          final int li = b % numBuckets;
-          fold((s.buckets.mins[li] - tare).toDouble());
-          fold((s.buckets.maxs[li] - tare).toDouble());
-        }
-        scanRaw(sScanStart, bFirst * bs);
-        scanRaw(bLastEx * bs, sScanEnd);
-      } else {
-        scanRaw(sScanStart, sScanEnd);
-      }
+      foldBucketRange(
+        s.buckets,
+        sScanStart,
+        sScanEnd,
+        foldBucket: (bMin, bMax) {
+          fold((bMin - tare).toDouble());
+          fold((bMax - tare).toDouble());
+        },
+        scanExact: (from, to) {
+          for (int i = from; i < to; i++) {
+            fold((line[i % bufferCap] - tare).toDouble());
+          }
+        },
+      );
     }
 
     // Enforce a minimum visible range (noise floor) so the graph isn't degenerate
@@ -2591,47 +2470,50 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
   @override
   int get firstSampleOffset => 1; // first difference needs sample j-1
 
-  @override
-  double Function(int j) sampleAt(int channel) {
+  /// Per-sample first difference in display units per second. A held value
+  /// on either side of the difference would fabricate a flat or spiking
+  /// derivative; break the polyline across gap edges instead.
+  double Function(int j) _sampleAt(int channel) {
     final line = _data.channel(channel).data;
     final bufferCap = _data.bufferCapacity;
     final gaps = _data.gaps;
-    final scale =
-        _settings.displayUnit.multiplierFromRaw(_data.calibrationSlope) *
-        _data.sampleRate;
+    final scale = _displayScale;
     return (j) {
-      // A held value on either side of the difference would fabricate a flat
-      // or spiking derivative; break the polyline across gap edges instead.
       if (gaps.contains(j) || gaps.contains(j - 1)) return double.nan;
       return (line[j % bufferCap] - line[(j - 1) % bufferCap]) * scale;
     };
   }
 
-  @override
-  BucketSeries? bucketSeries(int channel) => _data.diffBuckets(channel);
+  /// Raw-diff -> display-units-per-second multiplier.
+  double get _displayScale =>
+      _settings.displayUnit.multiplierFromRaw(_data.calibrationSlope) *
+      _data.sampleRate;
 
   @override
-  double Function(double raw)? rawToDisplay(int channel) {
-    final scale =
-        _settings.displayUnit.multiplierFromRaw(_data.calibrationSlope) *
-        _data.sampleRate;
-    return (raw) => raw * scale;
+  EnvelopeSeries series(int channel) {
+    final sampleAt = _sampleAt(channel);
+    final buckets = _data.diffBuckets(channel);
+    if (buckets == null) return EnvelopeSeries.exact(sampleAt);
+    final scale = _displayScale;
+    return EnvelopeSeries.bucketed(
+      sampleAt: sampleAt,
+      buckets: buckets,
+      rawToDisplay: (raw) => raw * scale,
+    );
   }
 
   @override
   YAxisRange computeYRange(int viewStart, int viewEnd) {
-    // Derivative min/max (display units) across the visible window. Full
-    // buckets are folded from the precomputed diff aggregates (exact for
-    // min/max); only the partial head/tail buckets are scanned per sample,
-    // so the cost is O(window / bucketSize).
+    // Derivative min/max (display units) across the visible window.
+    // [foldBucketRange] folds full buckets from the precomputed diff
+    // aggregates (exact for min/max) and per-sample scans only the partial
+    // head/tail, so the cost is O(window / bucketSize).
     double dMin = 0;
     double dMax = 0;
     bool first = true;
     final startI = math.max(viewStart, _data.oldestSample + 1);
     final endI = math.min(viewEnd, _data.totalSamples);
-    final scale =
-        _settings.displayUnit.multiplierFromRaw(_data.calibrationSlope) *
-        _data.sampleRate;
+    final scale = _displayScale;
 
     void fold(double d) {
       if (first || d < dMin) dMin = d;
@@ -2642,7 +2524,7 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
     for (final ch in _settings.activeChannelIndices) {
       if (_data.channel(ch).data.isEmpty) continue;
       if (startI >= endI) continue;
-      final valueAt = sampleAt(ch);
+      final valueAt = _sampleAt(ch);
 
       void scanExact(int from, int to) {
         for (int i = from; i < to; i++) {
@@ -2653,22 +2535,21 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
       }
 
       final buckets = _data.diffBuckets(ch);
-      if (buckets != null && endI - startI >= 2 * buckets.bucketSize) {
-        final int bs = buckets.bucketSize;
-        // First/last bucket indices fully inside the scan range. Folding
-        // both scaled bounds keeps this correct under a negative scale.
-        final int bFirst = (startI + bs - 1) ~/ bs;
-        final int bLastEx = endI ~/ bs;
-        final int numBuckets = buckets.mins.length;
-        for (int b = bFirst; b < bLastEx; b++) {
-          final int li = b % numBuckets;
-          fold(buckets.mins[li] * scale);
-          fold(buckets.maxs[li] * scale);
-        }
-        scanExact(startI, bFirst * bs);
-        scanExact(bLastEx * bs, endI);
-      } else {
+      if (buckets == null) {
         scanExact(startI, endI);
+      } else {
+        foldBucketRange(
+          buckets,
+          startI,
+          endI,
+          // Folding both scaled bounds keeps this correct under a negative
+          // scale.
+          foldBucket: (bMin, bMax) {
+            fold(bMin * scale);
+            fold(bMax * scale);
+          },
+          scanExact: scanExact,
+        );
       }
     }
     return _computeYRange(dMin, dMax);

--- a/test/bucket_ingest_test.dart
+++ b/test/bucket_ingest_test.dart
@@ -1,0 +1,209 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dynamite_app/models/bucket_series.dart';
+import 'package:dynamite_app/models/gap_list.dart';
+import 'package:dynamite_app/services/data_hub.dart';
+import 'package:dynamite_app/services/session_storage.dart';
+
+/// Locks the live/session ingest mirror: DataHub's streaming ingest and
+/// SessionData's load-time pass must produce byte-identical value and diff
+/// buckets for the same sample stream (including gaps), because the
+/// renderers treat the two sources interchangeably.
+void main() {
+  group('ingestDiff', () {
+    final gaps = GapList()..append(10, 20);
+
+    test('is 0 for the very first sample', () {
+      expect(
+        ingestDiff(sampleIndex: 0, value: 123, prevValue: 999, gaps: gaps),
+        0,
+      );
+    });
+
+    test('is the first difference for ordinary samples', () {
+      expect(
+        ingestDiff(sampleIndex: 5, value: 123, prevValue: 100, gaps: gaps),
+        23,
+      );
+    });
+
+    test('is 0 at the gap-exit sample (jump spans the gap)', () {
+      // Sample 20 is the first real sample after the gap [10, 20).
+      expect(
+        ingestDiff(sampleIndex: 20, value: 5000, prevValue: 100, gaps: gaps),
+        0,
+      );
+    });
+
+    test('is 0 inside a gap by construction (held - held)', () {
+      // Inside the gap the caller feeds the held value as both value and
+      // prevValue, so the rule and the arithmetic agree.
+      expect(
+        ingestDiff(sampleIndex: 15, value: 100, prevValue: 100, gaps: gaps),
+        0,
+      );
+    });
+  });
+
+  group('BucketAccumulator', () {
+    test('reset-or-fold matches a brute-force reference', () {
+      final rng = math.Random(7);
+      const bs = 10;
+      const numBuckets = 8;
+      final acc = BucketAccumulator(bucketSize: bs, numBuckets: numBuckets);
+      const n = 134; // wraps the 80-sample ring, ends mid-bucket
+      final all = List<int>.generate(n, (_) => rng.nextInt(2001) - 1000);
+      for (int i = 0; i < n; i++) {
+        acc.add(i, all[i]);
+      }
+
+      final s = acc.series;
+      expect(s.samples, n);
+
+      // Every bucket index whose slot has not been overwritten must hold the
+      // exact aggregates of its samples.
+      const int bNow = (n - 1) ~/ bs;
+      for (int b = math.max(0, bNow - numBuckets + 1); b <= bNow; b++) {
+        final from = b * bs;
+        final to = math.min((b + 1) * bs, n);
+        final expected = all.sublist(from, to);
+        final li = b % numBuckets;
+        expect(s.mins[li], expected.reduce(math.min), reason: 'bucket $b min');
+        expect(s.maxs[li], expected.reduce(math.max), reason: 'bucket $b max');
+        expect(
+          s.sums[li],
+          expected.reduce((a, x) => a + x),
+          reason: 'bucket $b sum',
+        );
+      }
+    });
+
+    test('reset restarts ingest from sample 0', () {
+      final acc = BucketAccumulator(bucketSize: 10, numBuckets: 4);
+      acc.add(0, 5);
+      acc.add(1, 7);
+      acc.reset();
+      expect(acc.series.samples, 0);
+      acc.add(0, -3); // would assert if ingest were not restarted
+      expect(acc.series.samples, 1);
+      expect(acc.series.mins[0], -3);
+    });
+  });
+
+  group('DataHub vs SessionData bucket mirror', () {
+    test('same stream (with gaps) produces identical buckets', () {
+      const int n = 12345;
+      const int channels = DataHub.numAdcChannels;
+      final rng = math.Random(42);
+
+      final hub = DataHub();
+      final recorded = List.generate(channels, (_) => Int32List(n));
+      final lastVal = List<int>.filled(channels, 0);
+      final frame = Int32List(channels);
+
+      while (hub.totalSamples < n) {
+        final t = hub.totalSamples;
+        // A few dropped ranges at fixed points in the stream.
+        if (t == 500 || t == 5000 || t == 9999) {
+          final count = 30 + rng.nextInt(200);
+          hub.addDroppedFrames(count);
+          for (int d = 0; d < count && t + d < n; d++) {
+            for (int ch = 0; ch < channels; ch++) {
+              recorded[ch][t + d] = lastVal[ch]; // held value
+            }
+          }
+          continue;
+        }
+        for (int ch = 0; ch < channels; ch++) {
+          final v = (ch + 1) * 1000 + rng.nextInt(20001) - 10000;
+          frame[ch] = v;
+          lastVal[ch] = v;
+          recorded[ch][t] = v;
+        }
+        hub.addSampleFrame(frame);
+      }
+      expect(hub.totalSamples, n);
+
+      final sess = SessionData(
+        channels: recorded,
+        sampleRate: DataHub.samplesPerSec,
+        sampleCount: n,
+        calibrationSlope: 1.0,
+        calibrationOffset: 0,
+        tares: List.filled(channels, 0.0),
+        gaps: GapList.fromJson(hub.gaps.toJson()),
+      );
+
+      final int sessBuckets = ((n - 1) ~/ sess.bucketSize) + 1;
+      for (int ch = 0; ch < channels; ch++) {
+        final hubVal = hub.valueBuckets[ch].series;
+        final hubDiff = hub.diffBuckets[ch].series;
+        final sessVal = sess.valueBuckets[ch].series;
+        final sessDiff = sess.diffBuckets[ch].series;
+
+        expect(hubVal.samples, n);
+        expect(sessVal.samples, n);
+        expect(hubVal.bucketSize, sessVal.bucketSize);
+
+        // n << hub capacity, so hub slot index == absolute bucket index.
+        for (int b = 0; b < sessBuckets; b++) {
+          expect(hubVal.mins[b], sessVal.mins[b], reason: 'ch $ch val min $b');
+          expect(hubVal.maxs[b], sessVal.maxs[b], reason: 'ch $ch val max $b');
+          expect(hubVal.sums[b], sessVal.sums[b], reason: 'ch $ch val sum $b');
+          expect(hubDiff.mins[b], sessDiff.mins[b], reason: 'ch $ch dif min $b');
+          expect(hubDiff.maxs[b], sessDiff.maxs[b], reason: 'ch $ch dif max $b');
+          expect(hubDiff.sums[b], sessDiff.sums[b], reason: 'ch $ch dif sum $b');
+        }
+      }
+    });
+
+    test('gap-exit jump is suppressed in the diff buckets on both sides', () {
+      const int channels = DataHub.numAdcChannels;
+      final hub = DataHub();
+      final frame = Int32List(channels);
+
+      void feed(int value, int count) {
+        for (int i = 0; i < count; i++) {
+          frame.fillRange(0, channels, value);
+          hub.addSampleFrame(frame);
+        }
+      }
+
+      feed(100, 150); // constant before the gap
+      hub.addDroppedFrames(50); // held at 100
+      feed(5000, 150); // constant after: only the gap-exit sample jumps
+      final int n = hub.totalSamples;
+
+      final recorded = List.generate(channels, (_) {
+        final line = Int32List(n);
+        line.fillRange(0, 200, 100); // 150 real + 50 held
+        line.fillRange(200, n, 5000);
+        return line;
+      });
+      final sess = SessionData(
+        channels: recorded,
+        sampleRate: DataHub.samplesPerSec,
+        sampleCount: n,
+        calibrationSlope: 1.0,
+        calibrationOffset: 0,
+        tares: List.filled(channels, 0.0),
+        gaps: GapList.fromJson(hub.gaps.toJson()),
+      );
+
+      // Constant segments + suppressed gap-exit diff => every diff bucket is
+      // exactly zero everywhere, despite the 100 -> 5000 jump.
+      final int buckets = ((n - 1) ~/ 100) + 1;
+      for (final acc in [hub.diffBuckets[0], sess.diffBuckets[0]]) {
+        final s = acc.series;
+        for (int b = 0; b < buckets; b++) {
+          expect(s.mins[b], 0, reason: 'diff min bucket $b');
+          expect(s.maxs[b], 0, reason: 'diff max bucket $b');
+          expect(s.sums[b], 0, reason: 'diff sum bucket $b');
+        }
+      }
+    });
+  });
+}

--- a/test/envelope_reduction_test.dart
+++ b/test/envelope_reduction_test.dart
@@ -1,0 +1,178 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dynamite_app/models/bucket_series.dart';
+
+/// Locks the documented invariants of the two block-reduction paths used by
+/// drawChannelEnvelope:
+///  * bucket-aligned, gap-free blocks reduce identically on both paths
+///    (including the newest, partially filled bucket);
+///  * misaligned blocks are conservative for min/max and exact in count;
+///  * ring-wrapped (aliased) bucket slots are never read.
+void main() {
+  const int bs = 10;
+  const int numBuckets = 8; // ring capacity: 80 samples
+
+  /// Builds a bucketed series over [all] with an affine display map
+  /// `(raw - tare) * k`, ingesting every sample through a BucketAccumulator.
+  EnvelopeSeries buildSeries(List<int> all, {double tare = 0, double k = 1}) {
+    final acc = BucketAccumulator(bucketSize: bs, numBuckets: numBuckets);
+    for (int i = 0; i < all.length; i++) {
+      acc.add(i, all[i]);
+    }
+    return EnvelopeSeries.bucketed(
+      sampleAt: (j) => (all[j] - tare) * k,
+      buckets: acc.series,
+      rawToDisplay: (raw) => (raw - tare) * k,
+    );
+  }
+
+  List<int> randomData(int n, int seed) {
+    final rng = math.Random(seed);
+    return List<int>.generate(n, (_) => rng.nextInt(2001) - 1000);
+  }
+
+  void expectSameReduction(BlockReduction a, BlockReduction b) {
+    expect(a.count, b.count);
+    expect(a.min, closeTo(b.min, 1e-9));
+    expect(a.max, closeTo(b.max, 1e-9));
+    expect(a.sum, closeTo(b.sum, 1e-6));
+  }
+
+  group('reduceBlockExact', () {
+    test('excludes NaN (gap) samples', () {
+      final values = <double>[1, 2, double.nan, 4];
+      final r = reduceBlockExact((j) => values[j], 0, 4);
+      expect(r.count, 3);
+      expect(r.min, 1);
+      expect(r.max, 4);
+      expect(r.sum, 7);
+    });
+
+    test('reports count 0 for an all-gap block', () {
+      final r = reduceBlockExact((_) => double.nan, 0, 10);
+      expect(r.count, 0);
+    });
+  });
+
+  group('reduceBlockBuckets vs reduceBlockExact', () {
+    test('bucket-aligned full blocks agree exactly', () {
+      final all = randomData(130, 1);
+      final series = buildSeries(all, tare: 12.5, k: 0.25);
+      // Valid range after wrap: samples [50, 130); buckets 5..12 live.
+      for (int from = 60; from + 20 <= 130; from += 20) {
+        expectSameReduction(
+          reduceBlockBuckets(series, from, from + 20),
+          reduceBlockExact(series.sampleAt, from, from + 20),
+        );
+      }
+    });
+
+    test('newest partially filled bucket is weighted exactly', () {
+      final all = randomData(134, 2); // bucket 13 holds only 4 samples
+      final series = buildSeries(all, tare: -3, k: 2);
+      expectSameReduction(
+        reduceBlockBuckets(series, 120, 134),
+        reduceBlockExact(series.sampleAt, 120, 134),
+      );
+    });
+
+    test('negative display multiplier keeps min <= max and exact avg', () {
+      final all = randomData(130, 3);
+      final series = buildSeries(all, tare: 5, k: -0.5);
+      final b = reduceBlockBuckets(series, 60, 100);
+      final e = reduceBlockExact(series.sampleAt, 60, 100);
+      expectSameReduction(b, e);
+      expect(b.min, lessThanOrEqualTo(b.max));
+    });
+
+    test('misaligned blocks: conservative min/max, exact count', () {
+      final all = randomData(130, 4);
+      final series = buildSeries(all);
+      for (final (from, to) in [(63, 97), (61, 89), (66, 130)]) {
+        final b = reduceBlockBuckets(series, from, to);
+        final e = reduceBlockExact(series.sampleAt, from, to);
+        expect(b.count, e.count);
+        expect(b.min, lessThanOrEqualTo(e.min), reason: 'min conservative');
+        expect(b.max, greaterThanOrEqualTo(e.max), reason: 'max conservative');
+        // The boundary-approximated average stays inside the envelope.
+        final avg = b.sum / b.count;
+        expect(avg, greaterThanOrEqualTo(b.min));
+        expect(avg, lessThanOrEqualTo(b.max));
+      }
+    });
+
+    test('aliased head bucket is reduced exactly, never from the stale slot', () {
+      // Deterministic poison: old data is a constant 10; the wrapped live
+      // edge writes huge values into the slot the oldest visible bucket
+      // would hash to. Reading the stale slot would drag max to ~10133.
+      const int n = 134;
+      final all = List<int>.generate(n, (i) => i < 80 ? 10 : 10000 + i);
+      final series = buildSeries(all);
+      // bNow = 13, firstValidBucket = 6; oldest retained sample = 54.
+      // Block [55, 70): samples 55..69 are all 10; bucket 5's slot (5 % 8)
+      // now holds bucket 13's data (10130..10133).
+      final b = reduceBlockBuckets(series, 55, 70);
+      final e = reduceBlockExact(series.sampleAt, 55, 70);
+      expectSameReduction(b, e);
+      expect(b.max, 10); // would be 10133 if the stale slot were read
+    });
+  });
+
+  group('foldBucketRange', () {
+    void bruteAndFold(List<int> all, int start, int end) {
+      final acc = BucketAccumulator(bucketSize: bs, numBuckets: numBuckets);
+      for (int i = 0; i < all.length; i++) {
+        acc.add(i, all[i]);
+      }
+
+      int foldedMin = 1 << 40;
+      int foldedMax = -(1 << 40);
+      int scanned = 0;
+      void fold(int v) {
+        if (v < foldedMin) foldedMin = v;
+        if (v > foldedMax) foldedMax = v;
+      }
+
+      foldBucketRange(
+        acc.series,
+        start,
+        end,
+        foldBucket: (bMin, bMax) {
+          fold(bMin);
+          fold(bMax);
+        },
+        scanExact: (from, to) {
+          for (int i = from; i < to; i++) {
+            fold(all[i]);
+            scanned++;
+          }
+        },
+      );
+
+      final window = all.sublist(start, end);
+      expect(foldedMin, window.reduce(math.min), reason: '[$start, $end) min');
+      expect(foldedMax, window.reduce(math.max), reason: '[$start, $end) max');
+      // The whole point: at most one partial bucket scanned per edge.
+      expect(scanned, lessThanOrEqualTo(math.min(end - start, 2 * bs)));
+    }
+
+    test('matches brute-force min/max over random windows', () {
+      final all = randomData(134, 5);
+      // Windows constrained to the retained range [54, 134).
+      final rng = math.Random(6);
+      for (int i = 0; i < 200; i++) {
+        final start = 54 + rng.nextInt(70);
+        final end = start + 1 + rng.nextInt(134 - start - 1) + 1;
+        bruteAndFold(all, start, math.min(end, 134));
+      }
+    });
+
+    test('small windows fall back to a single exact scan', () {
+      final all = randomData(134, 7);
+      bruteAndFold(all, 100, 100 + 2 * bs - 1); // just under the threshold
+      bruteAndFold(all, 130, 134);
+    });
+  });
+}


### PR DESCRIPTION
Force graph, derivative graph, and minimap now share one segment-cached envelope renderer.
Adds ingest-time diff buckets, gap clipping, ring-wrap correctness fixes, and tests