### PR TITLE
Reduce hot restart exceptions in browser due to BLE

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -6,12 +8,23 @@ import 'services/adc_packet_decoder.dart';
 import 'services/app_events.dart';
 import 'services/ble_link_manager.dart';
 import 'services/data_hub.dart';
+// Debug-only hot-restart hook: on web, BLE notification listeners and timers
+// survive a hot restart, so each generation registers a cleanup that the next
+// generation runs first thing in main(). No-op stub on native platforms.
+import 'services/hot_restart_cleanup_stub.dart'
+    if (dart.library.js_interop) 'services/hot_restart_cleanup_web.dart';
 import 'services/recording_controller.dart';
 import 'services/session_storage.dart';
 import 'screens/app_shell.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // Silence and tear down the previous hot-restart generation's BLE link
+  // (web debug only) BEFORE anything else, so its stale notification stream
+  // stops spamming the disposed engine view and its GATT connection is
+  // released for us to reconnect. Runs before session recovery so a recording
+  // interrupted by the restart is finalized by the recovery pass below.
+  runPreviousHotRestartCleanup();
   // Repair any sessions left incomplete by a crash before the UI reads the
   // session list, so partial sessions are finalized (or pruned) first.
   await SessionStorage.recoverIncompleteSessions();
@@ -33,6 +46,21 @@ void main() async {
     decoder: decoder,
     events: appEvents,
   );
+
+  // Hand the NEXT hot-restart generation a way to tear this one down (web
+  // debug only). Fire-and-forget: the callbacks are silenced synchronously
+  // inside shutdownForHotRestart; the GATT disconnect completes async.
+  registerHotRestartCleanup(() {
+    unawaited(linkManager.shutdownForHotRestart());
+  });
+  // Layer 2 (web debug only): the engine view is disposed by
+  // `ext.flutter.disassemble` BEFORE the new generation boots, so packets
+  // arriving during module reload would spam "disposed EngineFlutterView"
+  // assertions. The filter catches the first one in THIS (soon-to-be-stale)
+  // generation, silences the feed immediately, and swallows the spam.
+  installHotRestartErrorFilter(() {
+    unawaited(linkManager.shutdownForHotRestart());
+  });
 
   runApp(
     MultiProvider(

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -705,4 +705,43 @@ class BleLinkManager extends ChangeNotifier {
     // never interprets feed bytes itself.
     onAdcData?.call(data);
   }
+
+  /// Tear down this (now stale) generation's BLE link after a hot restart on
+  /// web. Invoked by the NEXT generation's `main()` via the hot-restart
+  /// cleanup hook (see `hot_restart_cleanup_web.dart`) — browser-side BLE
+  /// notification listeners and timers survive a web hot restart, so without
+  /// this the old decoder/DataHub keep running and try to render into the
+  /// disposed engine view.
+  ///
+  /// Order matters: the data callbacks are nulled FIRST (synchronously) so the
+  /// notifyListeners → scheduleFrame chain stops immediately; the async GATT
+  /// teardown then releases the browser-level connection so the new generation
+  /// can find and reconnect the device. Deliberately does NOT call
+  /// [notifyListeners] — the only listeners are the disposed widget tree.
+  Future<void> shutdownForHotRestart() async {
+    onAdcData = null;
+    onCalibrationData = null;
+    _demoSource?.stop();
+    _stopRssiPolling();
+    _cooldownTimer?.cancel();
+    _cooldownTimer = null;
+    // Supersede any in-flight post-connect setup pass so it bails out.
+    _setupGeneration++;
+
+    // Best-effort from here: the app is being torn down, so failures are
+    // irrelevant — just make sure they can't propagate.
+    try {
+      if (_isScanning) {
+        await UniversalBle.stopScan();
+      }
+      if (_link.isLinkUp && !_link.isDemoDevice) {
+        await UniversalBle.disconnect(
+          _link.deviceId,
+          timeout: disconnectTimeout,
+        );
+      }
+    } catch (_) {
+      // Swallow: stale-generation teardown must never surface errors.
+    }
+  }
 }

--- a/lib/services/hot_restart_cleanup_stub.dart
+++ b/lib/services/hot_restart_cleanup_stub.dart
@@ -1,0 +1,13 @@
+/// Non-web implementation of the hot-restart cleanup hook: a no-op.
+///
+/// On native platforms a hot restart tears down the whole Dart isolate, so
+/// nothing from the previous generation survives and no cleanup is needed.
+/// See `hot_restart_cleanup_web.dart` for the web story and the conditional
+/// import site in `main.dart`.
+library;
+
+void runPreviousHotRestartCleanup() {}
+
+void registerHotRestartCleanup(void Function() cleanup) {}
+
+void installHotRestartErrorFilter(void Function() onViewDisposed) {}

--- a/lib/services/hot_restart_cleanup_web.dart
+++ b/lib/services/hot_restart_cleanup_web.dart
@@ -1,0 +1,95 @@
+/// Web implementation of the hot-restart cleanup hook.
+///
+/// Problem: on web, a hot restart re-runs `main()` in a fresh "generation" of
+/// the app, but browser-side resources registered by the previous generation —
+/// in particular Web Bluetooth `characteristicvaluechanged` listeners and
+/// pending timers — survive. Those stale listeners keep pumping BLE packets
+/// through the OLD generation's decoder/DataHub, whose `notifyListeners()`
+/// tries to schedule frames on the now-disposed engine view, producing an
+/// endless storm of "Trying to render a disposed EngineFlutterView" assertions.
+/// The stale GATT connection can also prevent the new generation from
+/// reconnecting (a connected device may stop advertising).
+///
+/// Fix, layer 1 (new generation): each generation stashes a cleanup closure on
+/// `globalThis`. At the very start of `main()`, the new generation invokes the
+/// previous generation's closure (which still holds live references to the old
+/// BLE objects) so it can silence its callbacks and disconnect, then registers
+/// its own closure for the NEXT restart.
+///
+/// Fix, layer 2 (old generation): the view is disposed by the tooling's
+/// `ext.flutter.disassemble` call BEFORE module reload even starts, so packets
+/// arriving during the reload window (hundreds of ms) already assert — before
+/// any new-generation code can run. No app-side hook exists for that moment
+/// (the engine's `registerHotRestartListener` is `dart:_engine`-internal), so
+/// [installHotRestartErrorFilter] intercepts the very first
+/// "disposed EngineFlutterView" assertion via [FlutterError.onError], silences
+/// the stale feed right then, and swallows the teardown spam.
+///
+/// Both layers are debug-only: hot restart doesn't exist in release, so we
+/// keep the production `window` object and error handling untouched.
+library;
+
+import 'dart:js_interop';
+
+import 'package:flutter/foundation.dart';
+
+/// Property on `globalThis` holding the previous generation's cleanup closure.
+@JS('__dsHotRestartCleanup')
+external JSFunction? get _storedCleanup;
+
+@JS('__dsHotRestartCleanup')
+external set _storedCleanup(JSFunction? value);
+
+/// Invoke (and clear) the cleanup left behind by the previous hot-restart
+/// generation, if any. Call this first thing in `main()`.
+void runPreviousHotRestartCleanup() {
+  if (!kDebugMode) return;
+  final JSFunction? previous = _storedCleanup;
+  if (previous != null) {
+    _storedCleanup = null;
+    previous.callAsFunction();
+  }
+}
+
+/// Register this generation's [cleanup] to be run by the NEXT generation's
+/// `main()` after a hot restart. Fire-and-forget: [cleanup] should kick off
+/// teardown synchronously (e.g. null out data callbacks) and may finish the
+/// rest (disconnect) asynchronously.
+void registerHotRestartCleanup(void Function() cleanup) {
+  if (!kDebugMode) return;
+  _storedCleanup = cleanup.toJS;
+}
+
+/// Filter [FlutterError.onError] so the hot-restart teardown window is silent.
+///
+/// When a hot restart begins, the tooling's `ext.flutter.disassemble` call
+/// disposes the engine view immediately, but the OLD generation keeps running
+/// until modules finish reloading. Every BLE packet in that window drives
+/// `notifyListeners → markNeedsBuild → scheduleFrame → drawFrame`, which
+/// asserts with "Trying to render a disposed EngineFlutterView". That
+/// assertion is therefore the earliest app-observable signal that a restart
+/// is in flight: on the first one we run [onViewDisposed] (which silences the
+/// stale BLE feed) and swallow it — and any repeats — instead of dumping them
+/// to the console. Every other error passes through to the previous handler
+/// unchanged.
+///
+/// Narrowly scoped on purpose: debug builds only (release has no hot
+/// restart), and only assertions naming `EngineFlutterView` disposal — a
+/// condition a correctly running single-view app can never produce.
+void installHotRestartErrorFilter(void Function() onViewDisposed) {
+  if (!kDebugMode) return;
+  final FlutterExceptionHandler? previousHandler = FlutterError.onError;
+  bool triggered = false;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    final Object exception = details.exception;
+    if (exception is AssertionError &&
+        exception.toString().contains('disposed EngineFlutterView')) {
+      if (!triggered) {
+        triggered = true;
+        onViewDisposed();
+      }
+      return; // Hot-restart teardown in progress: suppress the spam.
+    }
+    previousHandler?.call(details);
+  };
+}


### PR DESCRIPTION
On the web, when debugging and hitting "hot restart", old BLE sessions persist into the reloaded new session. This leads to a slew of exceptions, slowdowns, and some weird behaviors.

This PR fixes that.