### PR TITLE
Fix cross-device data splicing, zero-biased peaks, and tare time-warp

### DIFF
--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -83,6 +83,8 @@ class _LiveTabState extends State<LiveTab> {
   bool _showDerivative = false;
   _LiveDataSource? _dataSource;
   DataHub? _hub;
+  BleLinkManager? _link;
+  bool _wasStreaming = false;
 
   @override
   void didChangeDependencies() {
@@ -96,10 +98,39 @@ class _LiveTabState extends State<LiveTab> {
       _dataSource?.dispose();
       _dataSource = _LiveDataSource(hub);
     }
+    // Same for the link manager (also an app-lifetime singleton): listen for
+    // new device streams so the viewport can follow the fresh trace.
+    final link = context.read<BleLinkManager>();
+    if (_link != link) {
+      _link?.removeListener(_onLinkEdge);
+      _link = link;
+      _wasStreaming = link.isStreaming;
+      _link!.addListener(_onLinkEdge);
+    }
+  }
+
+  /// A new device stream means the hub was just cleared (see
+  /// [RecordingController]): drop any stale pan/zoom window and follow the
+  /// live edge. Without this, a user-panned (non-live) window survives the
+  /// disconnect and [GraphController.effectiveRange] would clamp the stale
+  /// window against a now-empty buffer (inverted clamp limits -> throw).
+  void _onLinkEdge() {
+    final link = _link!;
+    final hub = _hub!;
+    if (link.isStreaming && !_wasStreaming) {
+      _graphCtrl.goLive(
+        totalSamples: hub.totalSamples,
+        oldestSample: hub.totalSamples > DataHub.maxDataSz
+            ? hub.totalSamples - DataHub.maxDataSz
+            : 0,
+      );
+    }
+    _wasStreaming = link.isStreaming;
   }
 
   @override
   void dispose() {
+    _link?.removeListener(_onLinkEdge);
     _dataSource?.dispose();
     _graphCtrl.dispose();
     super.dispose();

--- a/lib/services/adc_packet_decoder.dart
+++ b/lib/services/adc_packet_decoder.dart
@@ -26,7 +26,8 @@ class AdcPacketDecoder {
 
   /// Forget the last seen packet counter so the next packet is not diffed
   /// against a stale value (which would report spurious dropped samples).
-  /// Called on link teardown and at recording start/stop.
+  /// Called when a new device stream starts (see [RecordingController]) and
+  /// at recording start/stop.
   void resetContinuity() {
     _prevSampleCount = -1;
   }

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -28,6 +28,13 @@ class DataHub extends ChangeNotifier {
   static const int bucketSize = 100;
   static const int numBuckets = maxDataSz ~/ bucketSize;
 
+  /// "No sample seen yet" sentinels for [rawMax]/[rawMin]: int32 min/max, so
+  /// the first real sample always replaces them. Initializing to 0 instead
+  /// would bias the extremes toward zero (a never-positive channel would
+  /// report a peak of `0 - tare`). ADC values are 24-bit, well inside int32.
+  static const int _noMaxYet = -0x80000000;
+  static const int _noMinYet = 0x7FFFFFFF;
+
   final Float64List tare = Float64List(numAdcChannels);
   final Float64List _runningTotal = Float64List(numAdcChannels);
   final Int32List rawMax = Int32List(numAdcChannels);
@@ -75,19 +82,33 @@ class DataHub extends ChangeNotifier {
   /// hub knowing anything about recording.
   void Function(int startIdx, int count)? onSamplesAppended;
 
+  DataHub() {
+    clear();
+  }
+
+  /// Reset every per-stream accumulation: ring position, peaks, tare, gaps
+  /// and buckets. Invoked from the constructor and by [RecordingController]
+  /// each time a new device stream starts, so two connections (or two
+  /// devices) never splice into one trace and "Peak" never survives a
+  /// disconnect.
+  ///
+  /// Deliberately does NOT touch [deviceCalibration]: a connecting device's
+  /// calibration is read during post-connect setup, BEFORE the streaming
+  /// transition that triggers this reset.
   void clear() {
     _tareCount = 0;
     totalSamples = 0;
     gaps.clear();
     for (int i = 0; i < numAdcChannels; ++i) {
-      rawMax[i] = 0;
-      rawMin[i] = 0;
+      rawMax[i] = _noMaxYet;
+      rawMin[i] = _noMinYet;
       tare[i] = 0;
       _runningTotal[i] = 0;
       _currentRaw[i] = 0;
       valueBuckets[i].reset();
       diffBuckets[i].reset();
     }
+    notifyListeners();
   }
 
   bool get taring => (_tareCount > 0);
@@ -101,21 +122,24 @@ class DataHub extends ChangeNotifier {
     }
   }
 
-  /// Append one decoded sample (one value per channel). While a tare is in
-  /// progress the values are accumulated into the tare average instead of the
-  /// ring buffer (and [totalSamples] does not advance).
+  /// Append one decoded sample (one value per channel). Samples are always
+  /// buffered and [totalSamples] always advances — including while a tare is
+  /// in progress, so taring never warps the stream's timeline or punches an
+  /// unmarked hole in an ongoing recording. A tare only re-zeros the display
+  /// offset: while taring, each real frame is ADDITIONALLY accumulated into
+  /// the tare average.
   void addSampleFrame(Int32List values) {
     assert(values.length >= numAdcChannels);
     for (int i = 0; i < numAdcChannels; ++i) {
       final int val = values[i];
       _currentRaw[i] = val;
+      // Always buffer data for live display.
+      _addData(val, i);
       if (taring) {
         _addTare(val, i);
-      } else {
-        // Always buffer data for live display.
-        _addData(val, i);
       }
     }
+    totalSamples++;
 
     if (taring) {
       _tareCount--;
@@ -125,8 +149,6 @@ class DataHub extends ChangeNotifier {
           _runningTotal[i] = 0;
         }
       }
-    } else {
-      totalSamples++;
     }
   }
 
@@ -134,10 +156,10 @@ class DataHub extends ChangeNotifier {
   /// counter): append the range to [gaps] and hold each channel's last value
   /// ([_currentRaw]) in the ring buffer so the stored data stays magic-free.
   /// Capped at [maxDataSz] to avoid a huge injection loop if the device
-  /// reboots and the counter jumps. Skipped while taring, matching
-  /// [addSampleFrame] (totalSamples does not advance during a tare).
+  /// reboots and the counter jumps. Held samples are real ring-buffer time
+  /// (they advance [totalSamples]) but are NOT real readings, so they are
+  /// never accumulated into an in-progress tare average.
   void addDroppedFrames(int count) {
-    if (taring) return;
     final int toInject = math.min(count, maxDataSz);
     gaps.append(totalSamples, totalSamples + toInject);
     for (int d = 0; d < toInject; d++) {
@@ -177,16 +199,22 @@ class DataHub extends ChangeNotifier {
     return unit.fromRaw(rawTared.toDouble(), deviceCalibration.slope);
   }
 
-  /// Get peak force for a given ADC channel in the specified unit.
+  /// Get peak force for a given ADC channel in the specified unit. Returns 0
+  /// before the first sample arrives ([rawMax] still holds its sentinel).
   double peakForce(int adcChannel, ForceUnit unit) {
-    if (adcChannel < 0 || adcChannel >= numAdcChannels) return 0;
+    if (adcChannel < 0 || adcChannel >= numAdcChannels || totalSamples == 0) {
+      return 0;
+    }
     final rawTared = rawMax[adcChannel] - tare[adcChannel];
     return unit.fromRaw(rawTared.toDouble(), deviceCalibration.slope);
   }
 
-  /// Get minimum (most negative) force for a given ADC channel in the specified unit.
+  /// Get minimum (most negative) force for a given ADC channel in the
+  /// specified unit. Returns 0 before the first sample arrives.
   double minForce(int adcChannel, ForceUnit unit) {
-    if (adcChannel < 0 || adcChannel >= numAdcChannels) return 0;
+    if (adcChannel < 0 || adcChannel >= numAdcChannels || totalSamples == 0) {
+      return 0;
+    }
     final rawTared = rawMin[adcChannel] - tare[adcChannel];
     return unit.fromRaw(rawTared.toDouble(), deviceCalibration.slope);
   }

--- a/lib/services/recording_controller.dart
+++ b/lib/services/recording_controller.dart
@@ -12,8 +12,15 @@ import 'session_storage.dart';
 /// in-progress flag the UI keys off.
 ///
 /// It observes the [DataHub] via [DataHub.onSamplesAppended] to stream exact
-/// sample slices to storage, and listens to the [BleLinkManager] so a session
-/// is properly finalized (not orphaned) if the link drops mid-recording.
+/// sample slices to storage, and listens to the [BleLinkManager] for the two
+/// link transitions that affect data integrity:
+///  * streaming ends — a session in progress is properly finalized (not
+///    orphaned) if the link drops mid-recording;
+///  * streaming starts — the hub is reset ([DataHub.clear]) and packet
+///    continuity is restarted, so the ring buffer, peaks, tare and gaps of a
+///    previous connection never splice into the new device's trace (and the
+///    new stream's first packet counter is never diffed against the previous
+///    device's, which would inject a spurious gap).
 ///
 /// Storage failures are surfaced as a [RecordingStorageError] on [AppEvents]
 /// (emitted from [stopSession], the single finalization path).
@@ -35,12 +42,16 @@ class RecordingController extends ChangeNotifier {
   final BleLinkManager _linkManager;
   final AppEvents _events;
 
-  /// Needed only to reset packet-continuity tracking at session boundaries so
-  /// the first packet of a session isn't diffed against a stale counter.
+  /// Needed to reset packet-continuity tracking at stream/session boundaries
+  /// so the first packet after a boundary isn't diffed against a stale counter.
   final AdcPacketDecoder _decoder;
 
   bool _sessionInProgress = false;
   bool get sessionInProgress => _sessionInProgress;
+
+  /// Link state at the previous [_onLinkChanged] notification; used to detect
+  /// the not-streaming -> streaming edge (a new device stream starting).
+  bool _wasStreaming = false;
 
   LiveSessionWriter? _sessionWriter;
 
@@ -98,14 +109,25 @@ class RecordingController extends ChangeNotifier {
     }
   }
 
-  /// If the link stops streaming while a session is in progress (unexpected
-  /// disconnect, failed teardown, …), run the normal stop path so the writer
-  /// is flushed and the session finalized instead of being orphaned until the
-  /// next app launch's crash recovery.
+  /// React to the two link transitions that affect data integrity (see the
+  /// class doc): a dropped link finalizes any in-progress session; a freshly
+  /// started stream resets the hub and packet continuity.
   void _onLinkChanged() {
-    if (_sessionInProgress && !_linkManager.isStreaming) {
+    final bool streaming = _linkManager.isStreaming;
+    if (_sessionInProgress && !streaming) {
       unawaited(stopSession());
     }
+    if (streaming && !_wasStreaming) {
+      // New device stream. Clear the previous stream's ring buffer, peaks,
+      // tare and gaps so two connections never splice into one trace, and
+      // restart continuity so the new stream's first packet isn't diffed
+      // against the old stream's counter. Runs on stream entry (not on
+      // disconnect) so a recording being finalized after an unexpected drop
+      // can still read the old ring data while it flushes.
+      _dataHub.clear();
+      _decoder.resetContinuity();
+    }
+    _wasStreaming = streaming;
   }
 
   @override

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -65,7 +65,9 @@ class SessionStorage {
       writer.sessionId,
       sampleCount: writer.totalSamplesRecorded,
       durationMs: (writer.totalSamplesRecorded * 1000) ~/ DataHub.samplesPerSec,
-      peakForceRaw: writer.peakRaw,
+      // A session that captured no samples leaves peakRaw at -infinity; that
+      // must not reach the DB (or the session list's peak display).
+      peakForceRaw: writer.peakRaw.isFinite ? writer.peakRaw : 0.0,
       peakForceChannel: writer.peakChannel,
       gaps: writer.gaps.toJson(),
     );
@@ -171,7 +173,12 @@ class _ChunkAggregate {
 
   final int channelCount;
   int samples = 0;
-  double peakRaw = 0.0;
+
+  /// Starts at -infinity so the first real sample always replaces it; a
+  /// never-positive stream must report its (negative) true max, not 0.
+  /// Callers persisting this must guard the no-samples case (see
+  /// [SessionStorage.finalizeSession]).
+  double peakRaw = double.negativeInfinity;
   int peakChannel = 0;
 
   void scan(Uint8List bytes, Float64List tare) {
@@ -275,11 +282,13 @@ class SessionData {
     }
   }
 
-  /// Get peak raw value for a given channel.
+  /// Get peak raw value for a given channel. Seeded from the first sample so
+  /// a never-positive channel reports its true (negative) max, not 0.
   int peakRaw(int ch) {
-    int peak = 0;
     final data = channels[ch];
-    for (int i = 0; i < sampleCount; i++) {
+    if (sampleCount == 0) return 0;
+    int peak = data[0];
+    for (int i = 1; i < sampleCount; i++) {
       if (data[i] > peak) peak = data[i];
     }
     return peak;

--- a/test/data_hub_test.dart
+++ b/test/data_hub_test.dart
@@ -1,0 +1,166 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dynamite_app/models/force_unit.dart';
+import 'package:dynamite_app/services/data_hub.dart';
+
+/// Unit tests for the hub's per-stream lifecycle (peaks, tare, reset). Uses
+/// [ForceUnit.raw] throughout so forces equal tare-adjusted raw counts.
+void main() {
+  const int channels = DataHub.numAdcChannels;
+
+  Int32List frameOf(int value) =>
+      Int32List(channels)..fillRange(0, channels, value);
+
+  void feed(DataHub hub, Int32List frame, int count) {
+    for (int i = 0; i < count; i++) {
+      hub.addSampleFrame(frame);
+    }
+  }
+
+  group('peaks', () {
+    test('an untouched hub reports zero peak/min, not sentinel garbage', () {
+      final hub = DataHub();
+      for (int ch = 0; ch < channels; ch++) {
+        expect(hub.peakForce(ch, ForceUnit.raw), 0);
+        expect(hub.minForce(ch, ForceUnit.raw), 0);
+      }
+    });
+
+    test('a never-positive channel reports its true (negative) peak', () {
+      final hub = DataHub();
+      final frame = Int32List(channels);
+      // Least negative = -50 (the true max), most negative = -300.
+      for (final v in [-100, -300, -50, -200]) {
+        frame[0] = v;
+        hub.addSampleFrame(frame);
+      }
+      expect(hub.peakForce(0, ForceUnit.raw), -50);
+      expect(hub.minForce(0, ForceUnit.raw), -300);
+    });
+
+    test('a never-negative channel reports its true (positive) min', () {
+      final hub = DataHub();
+      final frame = Int32List(channels);
+      for (final v in [100, 300, 50, 200]) {
+        frame[0] = v;
+        hub.addSampleFrame(frame);
+      }
+      expect(hub.peakForce(0, ForceUnit.raw), 300);
+      expect(hub.minForce(0, ForceUnit.raw), 50);
+    });
+
+    test('peaks are tare-adjusted at read time', () {
+      final hub = DataHub();
+      feed(hub, frameOf(1000), 10);
+      hub.requestTare();
+      feed(hub, frameOf(1000), 1024); // completes the tare at 1000
+      expect(hub.peakForce(0, ForceUnit.raw), 0);
+      expect(hub.minForce(0, ForceUnit.raw), 0);
+    });
+  });
+
+  group('clear', () {
+    test('resets every per-stream accumulation and notifies', () {
+      final hub = DataHub();
+      var notified = 0;
+      hub.addListener(() => notified++);
+
+      feed(hub, frameOf(1000), 50);
+      hub.addDroppedFrames(20);
+      hub.requestTare();
+      feed(hub, frameOf(2000), 1024); // tare completes at 2000
+      expect(hub.totalSamples, 50 + 20 + 1024);
+      expect(hub.gaps.isEmpty, isFalse);
+
+      hub.clear();
+      expect(notified, greaterThan(0));
+      expect(hub.totalSamples, 0);
+      expect(hub.gaps.isEmpty, isTrue);
+      expect(hub.taring, isFalse);
+      expect(hub.tare[0], 0);
+      expect(hub.peakForce(0, ForceUnit.raw), 0);
+      expect(hub.minForce(0, ForceUnit.raw), 0);
+      expect(hub.valueBuckets[0].series.samples, 0);
+      expect(hub.diffBuckets[0].series.samples, 0);
+
+      // New data starts a fresh timeline; the old extremes are gone.
+      feed(hub, frameOf(-500), 10);
+      expect(hub.totalSamples, 10);
+      expect(hub.rawData[0][0], -500);
+      expect(hub.peakForce(0, ForceUnit.raw), -500);
+    });
+
+    test('aborts an in-progress tare', () {
+      final hub = DataHub();
+      feed(hub, frameOf(100), 10);
+      hub.requestTare();
+      feed(hub, frameOf(100), 10);
+      expect(hub.taring, isTrue);
+
+      hub.clear();
+      expect(hub.taring, isFalse);
+      expect(hub.tare[0], 0);
+    });
+  });
+
+  group('tare', () {
+    test('does not freeze the stream timeline', () {
+      final hub = DataHub();
+      feed(hub, frameOf(100), 100);
+      hub.requestTare();
+      feed(hub, frameOf(500), 1024);
+
+      // Every tare-window sample was buffered and counted.
+      expect(hub.totalSamples, 100 + 1024);
+      expect(hub.rawData[0][100], 500); // first tare sample is in the ring
+      expect(hub.rawData[0][100 + 1023], 500);
+      expect(hub.taring, isFalse);
+      expect(hub.tare[0], 500);
+      expect(hub.currentForce(0, ForceUnit.raw), 0); // 500 - 500
+    });
+
+    test('recordings observe the samples appended during a tare', () {
+      final hub = DataHub();
+      final appended = <int>[];
+      hub.onSamplesAppended = (start, count) => appended.add(count);
+
+      // Mimic the decoder's per-packet pattern.
+      void packet(int value, int frames) {
+        final start = hub.totalSamples;
+        feed(hub, frameOf(value), frames);
+        hub.commitBatch(start);
+      }
+
+      packet(100, 20);
+      hub.requestTare();
+      packet(500, 1024);
+
+      expect(appended, [20, 1024]);
+      expect(hub.totalSamples, 20 + 1024);
+    });
+
+    test(
+      'drops during a tare advance time and record gaps but never pollute the average',
+      () {
+        final hub = DataHub();
+        feed(hub, frameOf(1000), 100);
+        hub.requestTare();
+        hub.addDroppedFrames(20); // held at 1000, mid-tare
+        feed(hub, frameOf(500), 1024); // the 1024 REAL tare samples
+
+        expect(hub.taring, isFalse);
+        // Only real frames fed the average: exactly 500, despite 20 held
+        // 1000s inside the window.
+        expect(hub.tare[0], 500);
+        // The drop is ordinary timeline: gap range + held values + counted.
+        expect(hub.totalSamples, 100 + 20 + 1024);
+        expect(hub.gaps.contains(100), isTrue);
+        expect(hub.gaps.contains(119), isTrue);
+        expect(hub.gaps.contains(120), isFalse);
+        expect(hub.rawData[0][110], 1000); // held value inside the gap
+      },
+    );
+  });
+}

--- a/test/graph_controller_test.dart
+++ b/test/graph_controller_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:dynamite_app/services/data_hub.dart';
 import 'package:dynamite_app/widgets/graph_components.dart';
 
 /// Unit tests for the [GraphController] viewport state machine. It is pure
@@ -170,6 +171,36 @@ void main() {
       expect(count, 2);
       ctrl.goLive(totalSamples: 1000, oldestSample: 0);
       expect(count, 3);
+    });
+  });
+
+  /// The viewport-side half of the per-stream reset: when a new device stream
+  /// clears the hub, the live tab snaps the controller back to live follow
+  /// via [GraphController.goLive]. These tests document why that call must
+  /// happen.
+  group('GraphController across a stream reset', () {
+    test('a stale panned window throws against an empty buffer', () {
+      // The crash the reset prevents: a non-live window from the previous
+      // stream clamped against a cleared hub has inverted clamp limits.
+      final ctrl = GraphController(minLiveSpan: 20000);
+      ctrl.setWindow(100000, 200000); // user panned deep into history
+      expect(() => ctrl.effectiveRange(0, 0), throwsArgumentError);
+    });
+
+    test('goLive restores a safe live-follow range', () {
+      final ctrl = GraphController(minLiveSpan: 20000);
+      ctrl.setWindow(100000, 200000);
+
+      ctrl.goLive(totalSamples: 0, oldestSample: 0);
+
+      final (start, end) = ctrl.effectiveRange(
+        0,
+        0,
+        bufferCapacity: DataHub.maxDataSz,
+      );
+      expect(ctrl.isLive, isTrue);
+      expect(end, 0);
+      expect(start, -20000);
     });
   });
 }

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -1,0 +1,57 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dynamite_app/services/data_hub.dart';
+import 'package:dynamite_app/services/session_storage.dart';
+
+/// Peak-bias tests for the storage side: a never-positive stream must report
+/// its true (negative) max, both for loaded sessions and for the live
+/// writer's streaming aggregate. No DB is touched: the writer's append stays
+/// under its flush threshold, so nothing is ever persisted.
+void main() {
+  const int channels = DataHub.numAdcChannels;
+
+  group('SessionData.peakRaw', () {
+    SessionData makeSession(List<int> values) => SessionData(
+      channels: [
+        for (int ch = 0; ch < channels; ch++) Int32List.fromList(values),
+      ],
+      sampleRate: DataHub.samplesPerSec,
+      sampleCount: values.length,
+      calibrationSlope: 1.0,
+      calibrationOffset: 0,
+      tares: List.filled(channels, 0.0),
+    );
+
+    test('a never-positive channel reports its true (negative) peak', () {
+      final sess = makeSession([-100, -300, -50, -200]);
+      expect(sess.peakRaw(0), -50);
+    });
+
+    test('an empty session reports 0', () {
+      final sess = makeSession(const []);
+      expect(sess.peakRaw(0), 0);
+    });
+  });
+
+  group('LiveSessionWriter peak scan', () {
+    test('a never-positive stream yields a negative stored peak', () async {
+      final hub = DataHub();
+      final frame = Int32List(channels);
+      const n = 50;
+      for (int i = 0; i < n; i++) {
+        for (int ch = 0; ch < channels; ch++) {
+          frame[ch] = -1000 + i; // least negative: -951 at i = 49
+        }
+        hub.addSampleFrame(frame);
+      }
+
+      final writer = LiveSessionWriter(1, Float64List(channels));
+      await writer.appendData(hub, 0, n);
+
+      expect(writer.totalSamplesRecorded, n);
+      expect(writer.peakRaw, -1000 + n - 1);
+    });
+  });
+}

--- a/test/stream_reset_test.dart
+++ b/test/stream_reset_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import 'package:dynamite_app/services/adc_packet_decoder.dart';
+import 'package:dynamite_app/services/app_events.dart';
+import 'package:dynamite_app/services/ble_link_manager.dart';
+import 'package:dynamite_app/services/data_hub.dart';
+import 'package:dynamite_app/services/mockble.dart';
+import 'package:dynamite_app/services/recording_controller.dart';
+
+/// The hub must start fresh on every new device stream: connecting (even to
+/// the same device) clears the previous stream's ring buffer, peaks and gaps,
+/// and restarts packet-continuity tracking so the new stream's first packet
+/// isn't diffed against the old stream's counter.
+///
+/// Same mock-BLE + fakeAsync harness as mockble_test.dart, with a
+/// [RecordingController] added — its link observation performs the reset.
+void main() {
+  // The mock device that advertises the ADC service (see _generateServices).
+  const deviceId = '2';
+
+  (DataHub, BleLinkManager, VoidCallback) wire({required FakeAsync async}) {
+    UniversalBle.setInstance(MockBlePlatform.instance);
+    final events = AppEvents();
+    final hub = DataHub();
+    final decoder = AdcPacketDecoder(hub);
+    final link = BleLinkManager(events: events)
+      ..onAdcData = decoder.onDataPacket
+      ..onCalibrationData = decoder.onCalibrationPacket;
+    final recording = RecordingController(
+      dataHub: hub,
+      linkManager: link,
+      decoder: decoder,
+      events: events,
+    );
+
+    return (
+      hub,
+      link,
+      () {
+        recording.dispose();
+        // Best-effort disconnect so the mock's timers are cancelled and the
+        // singleton is left idle for the next test.
+        unawaited(link.disconnectSelectedDevice());
+        async.elapse(const Duration(seconds: 4));
+      },
+    );
+  }
+
+  test('reconnecting resets the hub (no splice, no spurious gap)', () {
+    fakeAsync((async) {
+      MockBlePlatform.instance.dropEveryNPackets = 0;
+      final (hub, link, teardown) = wire(async: async);
+
+      unawaited(link.connectToDevice(deviceId));
+      // connect(1s) + discoverServices(1s) + read calibration(1s) = 3s before
+      // notifications begin; then ~1s of 20ms packets.
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isTrue);
+      final firstCount = hub.totalSamples;
+      expect(firstCount, greaterThan(0));
+
+      unawaited(link.disconnectSelectedDevice());
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isFalse);
+      // Disconnect alone does not clear: a recording being finalized after a
+      // drop may still be reading the ring buffer.
+      expect(hub.totalSamples, firstCount);
+
+      unawaited(link.connectToDevice(deviceId));
+      // Setup again takes ~3s before notifications resume; just past it only
+      // a few packets of the NEW stream can have arrived.
+      async.elapse(const Duration(milliseconds: 3200));
+      expect(link.isStreaming, isTrue);
+      expect(hub.totalSamples, greaterThan(0));
+      expect(hub.totalSamples, lessThan(firstCount));
+      // Continuity was restarted: the mock's counter reset produced no
+      // spurious drop.
+      expect(hub.gaps.isEmpty, isTrue);
+
+      teardown();
+    });
+  });
+}


### PR DESCRIPTION
Clear DataHub (ring buffer, peaks, tare, gaps) and restart packet continuity when a new device stream starts; snap the live graph viewport back to live-follow (a stale panned window could throw).

Init raw extremes to int32 min/max (session storage: -inf) so all-negative streams report true peaks instead of 0 - tare.

Keep buffering during tare so recordings stay wall-clock correct; tare now only re-zeros the display offset.