### PR TITLE
Snapshot recording slices at call time, latch full-ring storage lag

### DIFF
--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -313,10 +313,23 @@ class SessionData {
 ///
 /// All DB writes are serialized through [_writeQueue] so concurrent (unawaited)
 /// [appendData] calls and the finalizing [flush] cannot interleave or reorder
-/// chunks. The first write error is latched in [writeError] rather than thrown
+/// chunks. The queue serializes ONLY the writes: [appendData] snapshots its
+/// sample slice synchronously at call time, so a stalled queue can never
+/// observe ring-buffer slots the producer has since overwritten. If storage
+/// nonetheless falls a full ring behind, an error is latched (see
+/// [appendData]) so the backlog — and its memory — stops growing and the
+/// failure is surfaced instead of recording into the void.
+///
+/// The first write error is latched in [writeError] rather than thrown
 /// into the void, so the caller can surface it.
 class LiveSessionWriter {
-  LiveSessionWriter(this.sessionId, this.tare);
+  LiveSessionWriter(
+    this.sessionId,
+    this.tare, {
+    @visibleForTesting
+    Future<void> Function(int sessionId, int chunkIndex, Uint8List data)?
+    chunkSink,
+  }) : _chunkSink = chunkSink;
 
   final int sessionId;
 
@@ -350,37 +363,70 @@ class LiveSessionWriter {
   /// Serializes all DB writes. Each enqueued op awaits the previous one.
   Future<void> _writeQueue = Future.value();
 
+  /// Test seam: when set, chunk payloads go here instead of
+  /// [AppDatabase.insertChunk], so tests can stall and observe writes without
+  /// opening a real database. Resolved lazily so constructing a writer never
+  /// touches the database singleton.
+  final Future<void> Function(int sessionId, int chunkIndex, Uint8List data)?
+  _chunkSink;
+
   /// Flush whenever the staging buffer reaches ~this many bytes
-  /// (~2 s at 1 kHz, 2 ch, 4 B/value).
+  /// (~1 s at 1 kHz, 4 ch, 4 B/value).
   static const int _flushThreshold = 16384;
 
   /// Append [count] samples starting at ring-buffer logical index [startIdx].
   /// Returns when this slice has been buffered (and flushed, if the threshold
   /// was crossed). Safe to call without awaiting; calls are serialized.
+  ///
+  /// The slice is copied out of the ring buffer SYNCHRONOUSLY: hub state is
+  /// only guaranteed fresh at call time, and the enqueued op runs only after
+  /// prior DB writes drain — by which point the producer may have advanced
+  /// far enough to overwrite these slots. Snapshotting here makes the copy
+  /// correct no matter how long the queue stalls; the queue then only
+  /// serializes staging and the DB write.
   Future<void> appendData(DataHub dataHub, int startIdx, int count) {
-    // Capture this slice's gap ranges synchronously (hub state is only
-    // guaranteed fresh at call time), rebased to session-relative indices.
+    // Capture this slice's gap ranges synchronously, rebased to
+    // session-relative indices.
     final int origin = _originIdx ??= startIdx;
     for (final (s, e) in dataHub.gaps.rangesIn(startIdx, startIdx + count)) {
       gaps.append(s - origin, e - origin);
     }
+
+    // Snapshot the sample slice before enqueueing.
+    const numLines = DataHub.numAdcChannels;
+    final buffer = ByteData(count * numLines * 4);
+    int offset = 0;
+    for (int s = startIdx; s < startIdx + count; s++) {
+      for (int ch = 0; ch < numLines; ch++) {
+        buffer.setInt32(
+          offset,
+          dataHub.rawData[ch][s % DataHub.maxDataSz],
+          Endian.little,
+        );
+        offset += 4;
+      }
+    }
+    final bytes = buffer.buffer.asUint8List();
+
     return _enqueue(() async {
       if (writeError != null) return;
-      const numLines = DataHub.numAdcChannels;
-      final buffer = ByteData(count * numLines * 4);
-      int offset = 0;
-      for (int s = startIdx; s < startIdx + count; s++) {
-        for (int ch = 0; ch < numLines; ch++) {
-          buffer.setInt32(
-            offset,
-            dataHub.rawData[ch][s % DataHub.maxDataSz],
-            Endian.little,
-          );
-          offset += 4;
-        }
+      // Backpressure latch: if storage has fallen a full ring behind, the
+      // producer has overwritten this slice's slots (the snapshot above is
+      // still correct, but the backlog of snapshots grows ~16 KB/s while the
+      // stall lasts). Latch an error so the session auto-stops loudly via the
+      // existing hasError path instead of leaking memory into a wedged sink.
+      if (startIdx < dataHub.totalSamples - DataHub.maxDataSz) {
+        writeError ??= StateError(
+          'Storage fell more than the ring capacity (${DataHub.maxDataSz} '
+          'samples) behind the live stream; aborting recording',
+        );
+        debugPrint(
+          'Session storage backpressure tripped (session $sessionId): '
+          '$writeError',
+        );
+        return;
       }
 
-      final bytes = buffer.buffer.asUint8List();
       // Update peak/sample-count via the same scan logic recovery uses.
       _agg.scan(bytes, tare);
       totalSamplesRecorded = _agg.samples;
@@ -405,7 +451,11 @@ class LiveSessionWriter {
     final dataToSave = _staging.takeBytes();
     final chunkIdx = _chunkIndex++;
     try {
-      await AppDatabase.instance.insertChunk(sessionId, chunkIdx, dataToSave);
+      await (_chunkSink ?? AppDatabase.instance.insertChunk)(
+        sessionId,
+        chunkIdx,
+        dataToSave,
+      );
     } catch (e) {
       // Latch the first failure; stop accumulating so we don't grow unbounded
       // after the sink has gone away (e.g. disk full / web quota exceeded).

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -52,6 +53,103 @@ void main() {
 
       expect(writer.totalSamplesRecorded, n);
       expect(writer.peakRaw, -1000 + n - 1);
+    });
+  });
+
+  group('LiveSessionWriter ring-buffer safety', () {
+    void pumpSamples(DataHub hub, Int32List frame, int count, int value) {
+      for (int ch = 0; ch < channels; ch++) {
+        frame[ch] = value;
+      }
+      for (int i = 0; i < count; i++) {
+        hub.addSampleFrame(frame);
+      }
+    }
+
+    test('a slice is snapshotted at call time, not at dequeue time', () async {
+      final saved = <Uint8List>[];
+      final writer = LiveSessionWriter(
+        1,
+        Float64List(channels),
+        chunkSink: (sessionId, chunkIndex, data) async => saved.add(data),
+      );
+      final hub = DataHub();
+      final frame = Int32List(channels);
+      const n = 50;
+      for (int i = 0; i < n; i++) {
+        for (int ch = 0; ch < channels; ch++) {
+          frame[ch] = i;
+        }
+        hub.addSampleFrame(frame);
+      }
+
+      // Enqueue, then keep the producer busy before the queued op can drain
+      // (it runs in a microtask, which this synchronous pump never yields to).
+      unawaited(writer.appendData(hub, 0, n));
+      pumpSamples(hub, frame, 1000, 100000); // much larger values, no wrap
+
+      await writer.flush();
+      expect(writer.hasError, isFalse);
+      expect(writer.totalSamplesRecorded, n);
+      expect(writer.peakRaw, n - 1); // not 100000: the slice was snapshotted
+
+      // The persisted chunk holds the call-time values, byte for byte.
+      expect(saved, hasLength(1));
+      final stored = ByteData.sublistView(saved.single);
+      expect(stored.lengthInBytes, n * channels * 4);
+      for (int s = 0; s < n; s++) {
+        for (int ch = 0; ch < channels; ch++) {
+          expect(stored.getInt32((s * channels + ch) * 4, Endian.little), s);
+        }
+      }
+    });
+
+    test('a full-ring storage stall latches an error and truncates the '
+        'recording instead of persisting wrapped data', () async {
+      final gate = Completer<void>();
+      final entered = Completer<void>();
+      final saved = <Uint8List>[];
+      var sinkCalls = 0;
+      final writer = LiveSessionWriter(
+        1,
+        Float64List(channels),
+        chunkSink: (sessionId, chunkIndex, data) async {
+          sinkCalls++;
+          if (!entered.isCompleted) entered.complete();
+          await gate.future; // wedge every chunk write until released
+          saved.add(data);
+        },
+      );
+      final hub = DataHub();
+      final frame = Int32List(channels);
+
+      // Fill the staging buffer past the 16 KB flush threshold so the first
+      // chunk write goes in flight and blocks inside the sink.
+      const chunkSamples = 2048; // 2048 * 4 ch * 4 B = 32 KB > 16 KB
+      pumpSamples(hub, frame, chunkSamples, 7);
+      unawaited(writer.appendData(hub, 0, chunkSamples));
+      await entered.future; // the queue is now stuck behind the gated write
+
+      // Enqueue one more slice, then simulate the producer running for a
+      // whole ring while storage stays stalled: this slice's ring slots get
+      // overwritten before its queued op ever runs.
+      pumpSamples(hub, frame, 100, 42);
+      unawaited(writer.appendData(hub, chunkSamples, 100));
+      pumpSamples(hub, frame, DataHub.maxDataSz, 66666); // ring wrap
+
+      gate.complete();
+      await writer.flush();
+
+      // The backpressure latch must trip on the stale slice: it is dropped
+      // (never reaches the sink), the error is latched for the controller's
+      // auto-stop path, and only the pre-stall chunk was persisted.
+      expect(writer.hasError, isTrue);
+      expect(writer.writeError, isA<StateError>());
+      expect(writer.totalSamplesRecorded, chunkSamples);
+      expect(writer.peakRaw, 7); // wrapped (66666) data never scanned
+      expect(sinkCalls, 1);
+      expect(saved, hasLength(1));
+      expect(saved.single.lengthInBytes, chunkSamples * channels * 4);
     });
   });
 }


### PR DESCRIPTION
`LiveSessionWriter.appendData` copied samples out of the `DataHub` ring buffer *inside the queued write closure*, not at call time. Since calls are unawaited (`RecordingController._onSamplesAppended`), the copy only ran after prior DB writes drained. A sufficiently stalled write queue let the 10-minute ring wrap underneath it, and the closure silently persisted overwritten (wrong) samples — no error latched, session finalized "successfully."

This PR snapshots each slice synchronously at call time, so the write queue serializes only the DB write, and adds a backpressure latch so a pathological stall fails loudly instead of leaking memory.

- The ring holds `maxDataSz` (600k samples, 10 min @ 1 kHz); slot `s % maxDataSz` is valid only while `s >= totalSamples - maxDataSz`.
- Gaps were already captured synchronously (the code even notes hub state is only fresh at call time) — the sample payload was the one thing that wasn't.

## Change

Snapshot at call time: `appendData` copies the slice into a `ByteData` before enqueueing. The closure now only scans/stages/writes the snapshot and never touches hub state. Same total copies and allocations as before — the work just isn't deferrable anymore (a per-packet copy is microseconds).

At dequeue, if `startIdx < totalSamples - maxDataSz`, latch a `StateError` into `writeError` and drop the slice. Post-snapshot this condition no longer implies corruption — it bounds the snapshot backlog (~16 KB/s at 4 ch) and converts an unbounded stall into the existing auto-stop + `RecordingStorageError` path, truncating cleanly at the last persisted chunk. It correctly does *not* false-fire after a stream reset (`clear()` zeroes `totalSamples`).

## Tests

New `ring-buffer safety` group in `test/session_storage_test.dart`, enabled by a small `@visibleForTesting chunkSink` seam on the writer (resolved lazily; production path unchanged):

- **Snapshot at call time** — enqueue, pump 1000 larger samples before the microtask queue drains, then verify the persisted chunk is byte-for-byte the call-time values.
- **Full-ring stall** — a gated sink wedges the first chunk write while the producer runs a full ring past an enqueued slice; asserts the latch trips, only the pre-stall chunk is persisted, and wrapped data is never scanned. On the old code this scenario silently persisted wrapped samples.