### PR TITLE
Make RecordingController own the session lifecycle start-to-finish

### DIFF
--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -9,7 +9,6 @@ import '../services/ble_link_manager.dart';
 import '../services/data_hub.dart';
 import '../services/database.dart';
 import '../services/recording_controller.dart';
-import '../services/session_storage.dart';
 import '../screens/app_shell.dart';
 import '../widgets/channel_stats_table.dart';
 import '../widgets/graph_components.dart';
@@ -142,8 +141,6 @@ class _LiveTabState extends State<LiveTab> {
 
   Future<void> _onToggleRecord() async {
     final recording = context.read<RecordingController>();
-    final hub = context.read<DataHub>();
-    final settings = context.read<AppSettings>();
 
     if (recording.sessionInProgress) {
       final result = await recording.stopSession();
@@ -154,11 +151,7 @@ class _LiveTabState extends State<LiveTab> {
       // On a storage error stopSession already emitted a RecordingStorageError
       // (surfaced by the shell), so only announce a cleanly saved session.
       if (result.error == null && sessionId != null) {
-        // Need to get the name we used when starting
-        final session = await AppDatabase.instance.sessionById(sessionId);
-        if (!mounted) return;
-        final sessionName = session?.name ?? 'Session';
-
+        final sessionName = result.name ?? 'Session';
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: const Text('Session saved'),
@@ -174,40 +167,35 @@ class _LiveTabState extends State<LiveTab> {
         );
       }
     } else {
-      if (hub.taring) {
-        // A tare is still averaging; recording now would persist a zero tare.
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Taring in progress — try again in a moment'),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-        return;
-      }
+      final settings = context.read<AppSettings>();
+      final result = await recording.startSession(
+        channelLabels: settings.channelLabels,
+        visibleChannels: settings.activeChannels,
+      );
 
-      final now = DateTime.now();
-      final autoName =
-          '${now.month}/${now.day} ${now.hour}:${now.minute.toString().padLeft(2, '0')}';
+      if (!mounted) return;
 
-      try {
-        final writer = await SessionStorage.startSession(
-          dataHub: hub,
-          name: autoName,
-          channelLabels: settings.channelLabels,
-          visibleChannels: settings.activeChannels,
-        );
-        await recording.startSession(writer);
-      } catch (e) {
-        if (mounted) {
+      switch (result) {
+        case StartSessionOk() || null:
+          // Recording (or already was, which the button state prevents). No
+          // announcement on start.
+          break;
+        case StartSessionTareInProgress():
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Taring in progress — try again in a moment'),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        case StartSessionFailed(:final error):
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text('Failed to start recording: $e'),
+              content: Text('Failed to start recording: $error'),
               behavior: SnackBarBehavior.floating,
               persist: true,
               showCloseIcon: true,
             ),
           );
-        }
       }
     }
   }

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
+import 'package:flutter/foundation.dart';
 
 part 'database.g.dart';
 
@@ -49,6 +50,13 @@ class AppDatabase extends _$AppDatabase {
 
   static AppDatabase? _instance;
   static AppDatabase get instance => _instance ??= AppDatabase._();
+
+  /// For testing: swap the shared instance (e.g. an in-memory DB built with
+  /// [AppDatabase.forTesting]) so static storage APIs like `SessionStorage`
+  /// hit the test database. Pair with [closeInstance] in tearDown so the next
+  /// [instance] access re-opens the default connection.
+  @visibleForTesting
+  static set instance(AppDatabase? db) => _instance = db;
 
   /// For testing: create with a custom executor.
   factory AppDatabase.forTesting(QueryExecutor executor) =>

--- a/lib/services/recording_controller.dart
+++ b/lib/services/recording_controller.dart
@@ -8,8 +8,37 @@ import 'ble_link_manager.dart';
 import 'data_hub.dart';
 import 'session_storage.dart';
 
-/// Owns the recording session lifecycle: the [LiveSessionWriter] and the
-/// in-progress flag the UI keys off.
+/// Outcome of [RecordingController.startSession]. The outcomes are mutually
+/// exclusive, so they form a sealed type the caller switches exhaustively —
+/// unlike [RecordingController.stopSession]'s result, whose fields are
+/// independent of each other (a record).
+sealed class StartSessionResult {
+  const StartSessionResult();
+}
+
+/// The session is recording.
+final class StartSessionOk extends StartSessionResult {
+  const StartSessionOk();
+}
+
+/// Refused: a tare is still averaging, and recording now would persist a zero
+/// tare. Transient — retry once the tare completes.
+final class StartSessionTareInProgress extends StartSessionResult {
+  const StartSessionTareInProgress();
+}
+
+/// Session creation (the DB row / writer) threw; nothing was latched, so the
+/// controller is still idle.
+final class StartSessionFailed extends StartSessionResult {
+  const StartSessionFailed(this.error);
+
+  final Object error;
+}
+
+/// Owns the recording session lifecycle start to finish: creating the session
+/// row and [LiveSessionWriter] in [startSession], streaming samples to the
+/// writer, and finalizing in [stopSession] — plus the in-progress flag the UI
+/// keys off. The UI only toggles and reports outcomes.
 ///
 /// It observes the [DataHub] via [DataHub.onSamplesAppended] to stream exact
 /// sample slices to storage, and listens to the [BleLinkManager] for the two
@@ -22,8 +51,12 @@ import 'session_storage.dart';
 ///    new stream's first packet counter is never diffed against the previous
 ///    device's, which would inject a spurious gap).
 ///
-/// Storage failures are surfaced as a [RecordingStorageError] on [AppEvents]
-/// (emitted from [stopSession], the single finalization path).
+/// Failures are reported two ways, by audience: [startSession] refuses or
+/// fails in response to the user who just tapped record, so its outcomes are
+/// returned for a local snackbar; a storage failure latching mid-recording is
+/// surfaced as a [RecordingStorageError] on [AppEvents] (emitted from
+/// [stopSession], the single finalization path), since the tab that started
+/// the session may no longer be mounted.
 class RecordingController extends ChangeNotifier {
   RecordingController({
     required DataHub dataHub,
@@ -55,28 +88,69 @@ class RecordingController extends ChangeNotifier {
 
   LiveSessionWriter? _sessionWriter;
 
-  Future<void> startSession(LiveSessionWriter writer) async {
+  /// Display name of the in-progress session, latched by [startSession] so
+  /// [stopSession] can hand it back to the UI without a DB lookup.
+  String? _sessionName;
+
+  /// Start a new recording session: create the session row and its writer
+  /// (via [SessionStorage.startSession]) and latch them here.
+  ///
+  /// [name] is the session's display name; null auto-names it from the wall
+  /// clock (e.g. `7/20 14:05`). [channelLabels] and [visibleChannels] are
+  /// persisted for display only (see [SessionStorage.startSession]).
+  ///
+  /// Outcomes are returned, not thrown, so the caller (the live tab's record
+  /// button) can snackbar them locally; null means a session was already in
+  /// progress (a no-op the UI prevents by toggling on [sessionInProgress]).
+  Future<StartSessionResult?> startSession({
+    String? name,
+    required List<String> channelLabels,
+    required List<bool> visibleChannels,
+  }) async {
     assert(_linkManager.isStreaming);
-    if (_sessionInProgress) return;
+    if (_sessionInProgress) return null;
+    // A tare is still averaging; recording now would persist a zero tare.
+    if (_dataHub.taring) return const StartSessionTareInProgress();
+
+    final sessionName = name ?? _autoSessionName(DateTime.now());
+    final LiveSessionWriter writer;
+    try {
+      writer = await SessionStorage.startSession(
+        dataHub: _dataHub,
+        name: sessionName,
+        channelLabels: channelLabels,
+        visibleChannels: visibleChannels,
+      );
+    } catch (e) {
+      return StartSessionFailed(e);
+    }
 
     _sessionWriter = writer;
+    _sessionName = sessionName;
     _sessionInProgress = true;
     _decoder.resetContinuity();
     notifyListeners();
+    return const StartSessionOk();
   }
 
+  /// Default session name from the wall clock, e.g. `7/20 14:05`.
+  static String _autoSessionName(DateTime now) =>
+      '${now.month}/${now.day} ${now.hour}:${now.minute.toString().padLeft(2, '0')}';
+
   /// Stop the current recording and finalize it. Returns the saved session id
-  /// (or null if nothing was recording) and any write error the storage writer
-  /// latched (non-null means the session may be truncated).
+  /// and name (or nulls if nothing was recording) and any write error the
+  /// storage writer latched (non-null means the session may be truncated).
   ///
   /// This is the single place a storage failure is surfaced to the user (as a
   /// [RecordingStorageError] on [AppEvents]); callers only use the returned
   /// error to branch (e.g. suppress the "Session saved" notice).
-  Future<({int? sessionId, Object? error})> stopSession() async {
+  Future<({int? sessionId, String? name, Object? error})> stopSession() async {
     if (_sessionInProgress) {
       _sessionInProgress = false;
       final writer = _sessionWriter;
+      final name = _sessionName;
       _sessionWriter = null;
+      _sessionName = null;
       _decoder.resetContinuity();
       notifyListeners();
 
@@ -87,10 +161,10 @@ class RecordingController extends ChangeNotifier {
         if (error != null) {
           _events.emit(RecordingStorageError(error));
         }
-        return (sessionId: writer.sessionId, error: error);
+        return (sessionId: writer.sessionId, name: name, error: error);
       }
     }
-    return (sessionId: null, error: null);
+    return (sessionId: null, name: null, error: null);
   }
 
   /// Slice of freshly decoded samples, straight from the decoder (via the

--- a/test/recording_controller_test.dart
+++ b/test/recording_controller_test.dart
@@ -1,0 +1,112 @@
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import 'package:dynamite_app/services/adc_packet_decoder.dart';
+import 'package:dynamite_app/services/app_events.dart';
+import 'package:dynamite_app/services/ble_link_manager.dart';
+import 'package:dynamite_app/services/data_hub.dart';
+import 'package:dynamite_app/services/database.dart';
+import 'package:dynamite_app/services/mockble.dart';
+import 'package:dynamite_app/services/recording_controller.dart';
+
+/// [RecordingController] owns the session lifecycle start to finish: it
+/// creates the session (via SessionStorage) on start, refuses to start while
+/// a tare is averaging, and hands the session name back on stop so the UI
+/// never touches storage.
+///
+/// startSession asserts the link is streaming (the live tab only shows the
+/// record button while streaming), so these tests fake that one state rather
+/// than driving a mock connection.
+void main() {
+  setUp(() {
+    // Satisfy BleLinkManager's startup availability query without platform
+    // channels (same harness as widget_test).
+    UniversalBle.setInstance(MockBlePlatform.instance);
+    MockBlePlatform.instance.dropEveryNPackets = 0;
+  });
+
+  (RecordingController, DataHub) wire() {
+    final events = AppEvents();
+    final hub = DataHub();
+    final decoder = AdcPacketDecoder(hub);
+    final recording = RecordingController(
+      dataHub: hub,
+      linkManager: _StreamingLink(events: events),
+      decoder: decoder,
+      events: events,
+    );
+    addTearDown(recording.dispose);
+    return (recording, hub);
+  }
+
+  test('startSession refuses while a tare is averaging', () async {
+    final (recording, hub) = wire();
+
+    hub.requestTare();
+    expect(hub.taring, isTrue);
+
+    final result = await recording.startSession(
+      channelLabels: const ['a', 'b', 'c', 'd'],
+      visibleChannels: const [true, true, false, false],
+    );
+
+    expect(result, isA<StartSessionTareInProgress>());
+    expect(recording.sessionInProgress, isFalse);
+  });
+
+  test(
+    'start creates the session row; stop finalizes it and returns its name',
+    () async {
+      AppDatabase.instance = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(AppDatabase.closeInstance);
+
+      final (recording, hub) = wire();
+
+      final start = await recording.startSession(
+        channelLabels: const ['Load Cell 1', 'Load Cell 2', 'Ch 3', 'Ch 4'],
+        visibleChannels: const [true, true, false, false],
+      );
+      expect(start, isA<StartSessionOk>());
+      expect(recording.sessionInProgress, isTrue);
+
+      // Record a few frames so the finalized session has data. The controller
+      // streams hub slices to the writer via onSamplesAppended, fired by
+      // commitBatch once per (simulated) packet.
+      const n = 10;
+      final frame = Int32List(DataHub.numAdcChannels);
+      for (var i = 0; i < n; i++) {
+        frame[0] = 1000 + i;
+        hub.addSampleFrame(frame);
+      }
+      hub.commitBatch(0);
+
+      final stop = await recording.stopSession();
+      expect(recording.sessionInProgress, isFalse);
+      expect(stop.error, isNull);
+      expect(stop.sessionId, isNotNull);
+
+      // The saved row carries the auto-generated name, and stop hands it back
+      // directly — the caller never re-queries the DB for it.
+      final saved = await AppDatabase.instance.sessionById(stop.sessionId!);
+      expect(saved, isNotNull);
+      expect(saved!.isCompleted, isTrue);
+      expect(saved.sampleCount, n);
+      expect(saved.name, matches(RegExp(r'^\d+/\d+ \d+:\d{2}$')));
+      expect(stop.name, saved.name);
+      expect(saved.channelLabels, '["Load Cell 1","Load Cell 2","Ch 3","Ch 4"]');
+    },
+  );
+}
+
+/// A [BleLinkManager] that reports a streaming link, so
+/// [RecordingController.startSession]'s streaming precondition holds without
+/// driving a mock connection.
+class _StreamingLink extends BleLinkManager {
+  _StreamingLink({required super.events});
+
+  @override
+  bool get isStreaming => true;
+}


### PR DESCRIPTION
startSession now creates the session row and writer itself (taking an optional name plus channel labels/visible channels), auto-names sessions, and refuses to start while a tare is averaging; outcomes are returned as a sealed StartSessionResult the live tab switches into snackbars. stopSession returns the session name, so the tab no longer re-queries the DB to populate the "Session saved" snackbar. Adds controller tests and a @visibleForTesting AppDatabase.instance setter so the SessionStorage singleton can be swapped for an in-memory DB.