### PR TITLE
Compute session detail stats once at load instead of per build

### DIFF
--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -214,7 +214,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 values: [
                   for (int ch = 0; ch < data.channels.length; ch++)
                     unit.fromRaw(
-                      data.peakRaw(ch).toDouble() - data.tares[ch],
+                      data.maxs[ch] - data.tares[ch],
                       data.calibrationSlope,
                     ),
                 ],
@@ -268,8 +268,8 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 for (int ch = 0; ch < data.channels.length; ch++) ...[
                   const Divider(height: 16),
                   Text(
-                    _parseChannelLabels(_session.channelLabels).length > ch
-                        ? _parseChannelLabels(_session.channelLabels)[ch]
+                    storedLabels.length > ch
+                        ? storedLabels[ch]
                         : 'Channel ${ch + 1}',
                     style: TextStyle(
                       fontWeight: FontWeight.w500,
@@ -280,7 +280,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                     label: 'Peak',
                     value: settings.displayUnit.format(
                       settings.displayUnit.fromRaw(
-                        data.peakRaw(ch).toDouble() - data.tares[ch],
+                        data.maxs[ch] - data.tares[ch],
                         data.calibrationSlope,
                       ),
                     ),

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -220,6 +220,13 @@ class SessionData {
   final List<double> mins;
   final List<double> maxs;
 
+  /// Per-channel raw-value sums, computed once on construction; the source
+  /// for [averageRaw]. Accumulated in double: integer-exact while
+  /// |sum| < 2^53 (~2^30 samples of 24-bit data -- ~4.6 h at 64 ksps full
+  /// scale, ~12 days at 1 ksps); beyond that it rounds gradually, staying
+  /// orders of magnitude below ADC noise for any achievable session.
+  final List<double> sums;
+
   /// Per-channel bucket aggregates over [bucketSize]-sample windows of the
   /// raw values. Mirrors DataHub's live buckets (same [BucketAccumulator])
   /// so the graphs can downsample cheaply. Gap samples hold the previous
@@ -244,7 +251,8 @@ class SessionData {
     GapList? gaps,
   }) : gaps = gaps ?? GapList(),
        mins = List.filled(channels.length, 0.0),
-       maxs = List.filled(channels.length, 0.0) {
+       maxs = List.filled(channels.length, 0.0),
+       sums = List.filled(channels.length, 0.0) {
     final int numBuckets = (sampleCount == 0)
         ? 0
         : ((sampleCount - 1) ~/ bucketSize) + 1;
@@ -261,11 +269,13 @@ class SessionData {
       if (sampleCount == 0) continue;
       double mn = double.infinity;
       double mx = double.negativeInfinity;
+      double sum = 0;
 
       for (int i = 0; i < sampleCount; i++) {
         final v = channels[ch][i];
         if (v < mn) mn = v.toDouble();
         if (v > mx) mx = v.toDouble();
+        sum += v;
 
         final int diff = ingestDiff(
           sampleIndex: i,
@@ -279,18 +289,13 @@ class SessionData {
       }
       mins[ch] = mn;
       maxs[ch] = mx;
+      sums[ch] = sum;
     }
   }
 
-  /// Get average raw value for a given channel.
-  double averageRaw(int ch) {
-    double sum = 0;
-    final data = channels[ch];
-    for (int i = 0; i < sampleCount; i++) {
-      sum += data[i];
-    }
-    return sum / sampleCount;
-  }
+  /// Get average raw value for a given channel, from the sum accumulated
+  /// at construction. NaN for an empty session, matching a literal scan.
+  double averageRaw(int ch) => sums[ch] / sampleCount;
 
   /// Duration in seconds.
   double get durationSeconds => sampleCount / sampleRate;

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -282,18 +282,6 @@ class SessionData {
     }
   }
 
-  /// Get peak raw value for a given channel. Seeded from the first sample so
-  /// a never-positive channel reports its true (negative) max, not 0.
-  int peakRaw(int ch) {
-    final data = channels[ch];
-    if (sampleCount == 0) return 0;
-    int peak = data[0];
-    for (int i = 1; i < sampleCount; i++) {
-      if (data[i] > peak) peak = data[i];
-    }
-    return peak;
-  }
-
   /// Get average raw value for a given channel.
   double averageRaw(int ch) {
     double sum = 0;

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -13,7 +13,7 @@ import 'package:dynamite_app/services/session_storage.dart';
 void main() {
   const int channels = DataHub.numAdcChannels;
 
-  group('SessionData.peakRaw', () {
+  group('SessionData.maxs', () {
     SessionData makeSession(List<int> values) => SessionData(
       channels: [
         for (int ch = 0; ch < channels; ch++) Int32List.fromList(values),
@@ -27,12 +27,12 @@ void main() {
 
     test('a never-positive channel reports its true (negative) peak', () {
       final sess = makeSession([-100, -300, -50, -200]);
-      expect(sess.peakRaw(0), -50);
+      expect(sess.maxs[0], -50);
     });
 
     test('an empty session reports 0', () {
       final sess = makeSession(const []);
-      expect(sess.peakRaw(0), 0);
+      expect(sess.maxs[0], 0);
     });
   });
 


### PR DESCRIPTION
## Summary

The session detail screen ran O(n) work on every rebuild: `SessionData.peakRaw()`/`averageRaw()` each scanned all samples (3 scans x 4 channels per `build()`), and `_parseChannelLabels` re-decoded the labels JSON twice per channel per rebuild despite the parsed list already being in scope. This PR moves all display stats to values computed once, keeping behavior bit-identical.

## Changes

**Commit 1 — peaks and labels**
- Detail screen peak rows (header table + statistics) now read the constructor-precomputed `SessionData.maxs[ch]` instead of calling `peakRaw(ch)`. Values are identical in all cases: `maxs[ch]` is the exact double of the max int32 sample, and both return 0 for an empty session (edge cases pinned by the existing tests, re-pointed from `peakRaw` to `maxs`).
- Deleted `SessionData.peakRaw()`; the same reduction was being computed twice in the same class (constructor scan + on-demand method). The graph side of this screen already consumes precomputed `mins`/`maxs` for this reason.
- Statistics section reuses the `storedLabels` list parsed at the top of `_buildContent` instead of re-parsing the JSON twice per channel.

**Commit 2 — averages**
- `SessionData` accumulates a per-channel `sums` (double) in its existing constructor pass — no extra scan, no new branches — and `averageRaw()` becomes an O(1) `sums[ch] / sampleCount` lookup. Semantics preserved exactly: same double accumulator in the same order (bit-identical results), and the empty-session case still yields NaN with no guard branch.

After both commits, nothing in the detail screen's `build()` scans sample data.

## Future-proofing note (64 ksps / multi-hour sessions)

Verified against a 64 ksps x 24 h x 4 ch anchor (~5.5e9 samples/channel): the double sum stays integer-exact while |sum| < 2^53 (~2^30 samples of 24-bit data, ~4.6 h at 64 ksps full scale) and degrades to at worst ~4 raw counts of error in the paranoid saturated-sensor case beyond that — orders of magnitude below ADC noise. No int32/rate assumptions introduced; when high-rate support lands, `sums` can migrate from load-time to ingest-time computation (writer-side, like `_ChunkAggregate` peaks) behind this same API without touching call sites. The field comment documents the exactness bound.

## Testing

- `flutter test`: 94/94 pass (peak edge-case tests re-pointed to `maxs`; `averageRaw` API unchanged so no test churn there).
- `flutter analyze`: no issues.
