### PR TITLE
Read precomputed stats in session detail, drop the Average row

### DIFF
--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -285,15 +285,6 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                       ),
                     ),
                   ),
-                  _StatRow(
-                    label: 'Average',
-                    value: settings.displayUnit.format(
-                      settings.displayUnit.fromRaw(
-                        data.averageRaw(ch) - data.tares[ch],
-                        data.calibrationSlope,
-                      ),
-                    ),
-                  ),
                 ],
               ],
             ),

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -214,7 +214,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 values: [
                   for (int ch = 0; ch < data.channels.length; ch++)
                     unit.fromRaw(
-                      data.peakRaw(ch).toDouble() - data.tares[ch],
+                      data.maxs[ch] - data.tares[ch],
                       data.calibrationSlope,
                     ),
                 ],
@@ -268,8 +268,8 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 for (int ch = 0; ch < data.channels.length; ch++) ...[
                   const Divider(height: 16),
                   Text(
-                    _parseChannelLabels(_session.channelLabels).length > ch
-                        ? _parseChannelLabels(_session.channelLabels)[ch]
+                    storedLabels.length > ch
+                        ? storedLabels[ch]
                         : 'Channel ${ch + 1}',
                     style: TextStyle(
                       fontWeight: FontWeight.w500,
@@ -280,7 +280,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                     label: 'Peak',
                     value: settings.displayUnit.format(
                       settings.displayUnit.fromRaw(
-                        data.peakRaw(ch).toDouble() - data.tares[ch],
+                        data.maxs[ch] - data.tares[ch],
                         data.calibrationSlope,
                       ),
                     ),

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -282,18 +282,6 @@ class SessionData {
     }
   }
 
-  /// Get peak raw value for a given channel. Seeded from the first sample so
-  /// a never-positive channel reports its true (negative) max, not 0.
-  int peakRaw(int ch) {
-    final data = channels[ch];
-    if (sampleCount == 0) return 0;
-    int peak = data[0];
-    for (int i = 1; i < sampleCount; i++) {
-      if (data[i] > peak) peak = data[i];
-    }
-    return peak;
-  }
-
   /// Get average raw value for a given channel.
   double averageRaw(int ch) {
     double sum = 0;

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -282,16 +282,6 @@ class SessionData {
     }
   }
 
-  /// Get average raw value for a given channel.
-  double averageRaw(int ch) {
-    double sum = 0;
-    final data = channels[ch];
-    for (int i = 0; i < sampleCount; i++) {
-      sum += data[i];
-    }
-    return sum / sampleCount;
-  }
-
   /// Duration in seconds.
   double get durationSeconds => sampleCount / sampleRate;
 }

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -13,7 +13,7 @@ import 'package:dynamite_app/services/session_storage.dart';
 void main() {
   const int channels = DataHub.numAdcChannels;
 
-  group('SessionData.peakRaw', () {
+  group('SessionData.maxs', () {
     SessionData makeSession(List<int> values) => SessionData(
       channels: [
         for (int ch = 0; ch < channels; ch++) Int32List.fromList(values),
@@ -27,12 +27,12 @@ void main() {
 
     test('a never-positive channel reports its true (negative) peak', () {
       final sess = makeSession([-100, -300, -50, -200]);
-      expect(sess.peakRaw(0), -50);
+      expect(sess.maxs[0], -50);
     });
 
     test('an empty session reports 0', () {
       final sess = makeSession(const []);
-      expect(sess.peakRaw(0), 0);
+      expect(sess.maxs[0], 0);
     });
   });
 


### PR DESCRIPTION
## Summary

The session detail screen ran O(n) work on every rebuild: `SessionData.peakRaw()`/`averageRaw()` each scanned all samples per `build()`, and `_parseChannelLabels` re-decoded the labels JSON twice per channel per rebuild despite the parsed list already being in scope. This PR makes the screen read only precomputed values — and drops the Average stat entirely, since it isn't needed.

Supersedes #108 (same peaks/labels commit; replaces the sums-precompute commit with straight removal of the average).

## Changes

**Commit 1 — peaks and labels** (unchanged from #108)
- Detail screen peak rows (header table + statistics) now read the constructor-precomputed `SessionData.maxs[ch]` instead of calling `peakRaw(ch)`. Values are identical in all cases: `maxs[ch]` is the exact double of the max int32 sample, and both return 0 for an empty session (edge cases pinned by the existing tests, re-pointed from `peakRaw` to `maxs`).
- Deleted `SessionData.peakRaw()`; the same reduction was being computed twice in the same class (constructor scan + on-demand method). The graph side of this screen already consumes precomputed `mins`/`maxs` for this reason.
- Statistics section reuses the `storedLabels` list parsed at the top of `_buildContent` instead of re-parsing the JSON twice per channel.

**Commit 2 — remove the Average stat**
- The per-channel Average row is removed from the statistics section: it has no current use, and the whole-session mean was the app's last O(n) stat. `SessionData.averageRaw()` goes with it (its only call site).
- Future windowed statistics don't need a whole-session scalar: the bucket layer already accumulates per-bucket sums (`BucketAccumulator`), and `reduceBlockBuckets`/`BlockReduction` already compute window means for the renderers — that's where windowed-average code would live.

After both commits, nothing in the detail screen's `build()` scans sample data, and `SessionData` has exactly one way to get each stat it still has.