### PR TITLE
Replace DataHub.onSamplesAppended with a typed listener list

### DIFF
--- a/lib/services/adc_packet_decoder.dart
+++ b/lib/services/adc_packet_decoder.dart
@@ -45,7 +45,8 @@ class AdcPacketDecoder {
   /// Parse one BLE ADC-feed notification packet into the hub.
   ///
   /// Data is always buffered for live display; recording observes the hub via
-  /// [DataHub.onSamplesAppended] (fired from [DataHub.commitBatch]).
+  /// [DataHub.addSamplesAppendedListener] (notified from
+  /// [DataHub.commitBatch]).
   void onDataPacket(Uint8List data) {
     if (data.isEmpty) {
       debugPrint("data isEmpty");

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -7,6 +7,11 @@ import '../models/bucket_series.dart';
 import '../models/force_unit.dart';
 import '../models/gap_list.dart';
 
+/// Invoked by [DataHub.commitBatch] with the exact slice of samples appended
+/// by the decoder for one packet ([startIdx] is the logical index of the
+/// first new sample).
+typedef SamplesAppendedListener = void Function(int startIdx, int count);
+
 /// Storage and derived statistics for the live ADC stream.
 ///
 /// This class owns the ring buffer, minimap buckets, tare state and the
@@ -76,11 +81,19 @@ class DataHub extends ChangeNotifier {
   /// buffer holds the held previous value across these ranges.
   final GapList gaps = GapList();
 
-  /// Invoked by [commitBatch] with the exact slice of samples appended by the
-  /// decoder for one packet ([startIdx] is the logical index of the first new
-  /// sample). This is how [RecordingController] observes new data without the
-  /// hub knowing anything about recording.
-  void Function(int startIdx, int count)? onSamplesAppended;
+  /// Observers notified by [commitBatch] with the exact slice of samples
+  /// appended by the decoder for one packet. This is how
+  /// [RecordingController] observes new data without the hub knowing anything
+  /// about recording. [ObserverList] (the same mechanism [ChangeNotifier]
+  /// uses) keeps removal-during-dispatch safe.
+  final ObserverList<SamplesAppendedListener> _samplesAppendedListeners =
+      ObserverList<SamplesAppendedListener>();
+
+  void addSamplesAppendedListener(SamplesAppendedListener listener) =>
+      _samplesAppendedListeners.add(listener);
+
+  void removeSamplesAppendedListener(SamplesAppendedListener listener) =>
+      _samplesAppendedListeners.remove(listener);
 
   DataHub() {
     clear();
@@ -170,13 +183,15 @@ class DataHub extends ChangeNotifier {
     }
   }
 
-  /// Close out one decoded packet: fire [onSamplesAppended] for the slice
-  /// appended since [startIdx] (the caller snapshots [totalSamples] before
-  /// decoding) and notify listeners once per packet.
+  /// Close out one decoded packet: notify [SamplesAppendedListener]s of the
+  /// slice appended since [startIdx] (the caller snapshots [totalSamples]
+  /// before decoding) and notify listeners once per packet.
   void commitBatch(int startIdx) {
     final int count = totalSamples - startIdx;
     if (count > 0) {
-      onSamplesAppended?.call(startIdx, count);
+      for (final listener in _samplesAppendedListeners) {
+        listener(startIdx, count);
+      }
     }
     gaps.pruneBefore(totalSamples - maxDataSz); // ring-wrap hygiene
     notifyListeners();

--- a/lib/services/recording_controller.dart
+++ b/lib/services/recording_controller.dart
@@ -40,7 +40,8 @@ final class StartSessionFailed extends StartSessionResult {
 /// writer, and finalizing in [stopSession] — plus the in-progress flag the UI
 /// keys off. The UI only toggles and reports outcomes.
 ///
-/// It observes the [DataHub] via [DataHub.onSamplesAppended] to stream exact
+/// It observes the [DataHub] via [DataHub.addSamplesAppendedListener] to
+/// stream exact
 /// sample slices to storage, and listens to the [BleLinkManager] for the two
 /// link transitions that affect data integrity:
 ///  * streaming ends — a session in progress is properly finalized (not
@@ -67,7 +68,7 @@ class RecordingController extends ChangeNotifier {
        _linkManager = linkManager,
        _decoder = decoder,
        _events = events {
-    _dataHub.onSamplesAppended = _onSamplesAppended;
+    _dataHub.addSamplesAppendedListener(_onSamplesAppended);
     _linkManager.addListener(_onLinkChanged);
   }
 
@@ -207,9 +208,7 @@ class RecordingController extends ChangeNotifier {
   @override
   void dispose() {
     _linkManager.removeListener(_onLinkChanged);
-    if (_dataHub.onSamplesAppended == _onSamplesAppended) {
-      _dataHub.onSamplesAppended = null;
-    }
+    _dataHub.removeSamplesAppendedListener(_onSamplesAppended);
     super.dispose();
   }
 }

--- a/test/data_hub_test.dart
+++ b/test/data_hub_test.dart
@@ -124,7 +124,7 @@ void main() {
     test('recordings observe the samples appended during a tare', () {
       final hub = DataHub();
       final appended = <int>[];
-      hub.onSamplesAppended = (start, count) => appended.add(count);
+      hub.addSamplesAppendedListener((start, count) => appended.add(count));
 
       // Mimic the decoder's per-packet pattern.
       void packet(int value, int frames) {

--- a/test/recording_controller_test.dart
+++ b/test/recording_controller_test.dart
@@ -73,8 +73,8 @@ void main() {
       expect(recording.sessionInProgress, isTrue);
 
       // Record a few frames so the finalized session has data. The controller
-      // streams hub slices to the writer via onSamplesAppended, fired by
-      // commitBatch once per (simulated) packet.
+      // streams hub slices to the writer via the samples-appended listener,
+      // notified by commitBatch once per (simulated) packet.
       const n = 10;
       final frame = Int32List(DataHub.numAdcChannels);
       for (var i = 0; i < n; i++) {


### PR DESCRIPTION
## Summary

`DataHub.onSamplesAppended` was a single-slot public callback field:
last assignment won, silently. `RecordingController` is its only
subscriber today, but the failure mode was disproportionate — a second
feature assigning the field would have detached recording mid-stream
with no error, silently losing session data. This PR turns the hook
into a proper multi-subscriber listener list, removing the footgun at
zero cost.

## Changes

- `DataHub`: new `SamplesAppendedListener` typedef; the public field
  is replaced by an `ObserverList` with `add/removeSamplesAppendedListener`
  (the same dispatch mechanism `ChangeNotifier` uses internally, so
  removal-during-dispatch is safe). `commitBatch` now notifies every
  subscriber.
- `RecordingController`: the constructor subscribes with `add...`, and
  `dispose()`'s identity-check-then-null guard becomes a plain
  `remove...` — it can no longer detach someone else's listener.
- Doc references updated (`adc_packet_decoder`, class docs); tests
  re-pointed to the add API. Existing `dispose` tear-downs exercise
  the removal path.