### PR TITLE
Reduce state and duplication across graph, BLE UI, and session screens

### DIFF
--- a/lib/models/force_unit.dart
+++ b/lib/models/force_unit.dart
@@ -28,15 +28,8 @@ enum ForceUnit {
   double fromKgf(double kgf) => kgf * _kgfMultiplier;
 
   /// Convert a raw ADC value to this unit, given the kgf/raw slope
-  double fromRaw(double rawTared, double calibrationSlope) {
-    if (this == ForceUnit.mV) {
-      return rawTared * rawToMvMultiplier;
-    }
-    if (this == ForceUnit.raw) {
-      return rawTared;
-    }
-    return rawTared * calibrationSlope * _kgfMultiplier;
-  }
+  double fromRaw(double rawTared, double calibrationSlope) =>
+      rawTared * multiplierFromRaw(calibrationSlope);
 
   /// Get the multiplier from raw ADC counts to this unit
   double multiplierFromRaw(double calibrationSlope) {

--- a/lib/screens/app_shell.dart
+++ b/lib/screens/app_shell.dart
@@ -28,6 +28,15 @@ class AppShellState extends State<AppShell> {
   int _currentIndex = 0;
   StreamSubscription<AppEvent>? _eventsSub;
 
+  /// Last wakelock state pushed to the plugin, so [_syncWakelock] only calls
+  /// the platform channel on an actual edge (the link manager notifies on
+  /// every RSSI poll; enabling repeatedly would be a pointless side effect).
+  bool? _wakelockApplied;
+
+  /// App-lifetime singletons driving the wakelock; captured in [initState].
+  late final AppSettings _settings = context.read<AppSettings>();
+  late final BleLinkManager _link = context.read<BleLinkManager>();
+
   static const _tabs = [
     _TabDef(icon: Icons.show_chart, label: 'Live'),
     _TabDef(icon: Icons.folder_open, label: 'Sessions'),
@@ -39,28 +48,27 @@ class AppShellState extends State<AppShell> {
   void initState() {
     super.initState();
     _eventsSub = context.read<AppEvents>().stream.listen(_onAppEvent);
+    // Keep the screen awake while a device stream is live and the setting is
+    // on. Both inputs are app-lifetime singletons; the listener only reacts
+    // to actual edges.
+    _settings.addListener(_syncWakelock);
+    _link.addListener(_syncWakelock);
+    _syncWakelock();
   }
 
   @override
   void dispose() {
     unawaited(_eventsSub?.cancel());
+    _settings.removeListener(_syncWakelock);
+    _link.removeListener(_syncWakelock);
     super.dispose();
   }
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-
-    final settings = context.watch<AppSettings>();
-    final bleManager = context.watch<BleLinkManager>();
-
-    final shouldKeepAwake = settings.wakelockEnabled && bleManager.isStreaming;
-
-    if (shouldKeepAwake) {
-      unawaited(WakelockPlus.enable());
-    } else {
-      unawaited(WakelockPlus.disable());
-    }
+  void _syncWakelock() {
+    final target = _settings.wakelockEnabled && _link.isStreaming;
+    if (target == _wakelockApplied) return;
+    _wakelockApplied = target;
+    unawaited(target ? WakelockPlus.enable() : WakelockPlus.disable());
   }
 
   void _onAppEvent(AppEvent event) {

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -48,18 +48,9 @@ class _DevicesTabState extends State<DevicesTab> {
     // Usable connection (services discovered + ADC feed streaming). "Connected"
     // in the UI means this — not merely that a GATT link exists.
     final isStreaming = bt.isStreaming;
-    // GATT link is up but post-connect setup is still running ("Setting up…").
-    final isSettingUp = bt.isSettingUp;
     // The link is up (setting up OR streaming) — the connected card is shown for
     // both so the user can see progress and cancel a stuck setup.
     final isLinkUp = bt.selectedDeviceId.isNotEmpty;
-    // A link is "busy" whenever it is mid-transition, active, or cooling down
-    // after a disconnect; device-row Connect buttons stay disabled until the
-    // link returns to idle. This is what prevents the disconnect→reconnect
-    // double-click race — including the web post-disconnect settle window where
-    // the stack isn't yet ready to accept a fresh connection.
-    final isBusy =
-        isLinkUp || bt.isConnecting || bt.isDisconnecting || bt.isCoolingDown;
     // The specific device currently in its post-disconnect cooldown window (web
     // only); its row shows "Please wait…" instead of "Connect".
     final coolingDownDeviceId = bt.isCoolingDown ? bt.link.deviceId : '';
@@ -81,14 +72,10 @@ class _DevicesTabState extends State<DevicesTab> {
                   children: [
                     Flexible(
                       child: BluetoothIndicator(
-                        isScanning: bt.isScanning,
-                        isConnecting: bt.isConnecting,
-                        isSettingUp: isSettingUp,
-                        isConnected: isStreaming,
-                        isDisconnecting: bt.isDisconnecting,
-                        isCoolingDown: bt.isCoolingDown,
-                        hasDevices: bt.devices.isNotEmpty,
+                        linkState: bt.link.state,
                         state: bt.bluetoothState,
+                        isScanning: bt.isScanning,
+                        hasDevices: bt.devices.isNotEmpty,
                       ),
                     ),
                     const SizedBox(width: 8),
@@ -193,7 +180,7 @@ class _DevicesTabState extends State<DevicesTab> {
                   // disconnecting) so we never issue a connect against a link
                   // that is still tearing down — this is the fix for needing a
                   // second Connect click right after Disconnect.
-                  onPressed: isBusy
+                  onPressed: bt.linkBusy
                       ? null
                       : () async {
                           try {
@@ -231,7 +218,7 @@ class _DevicesTabState extends State<DevicesTab> {
               title: const Text('Demo Device'),
               subtitle: const Text('Simulated data — no hardware'),
               trailing: FilledButton(
-                onPressed: isBusy
+                onPressed: bt.linkBusy
                     ? null
                     : () async {
                         try {

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -11,6 +11,7 @@ import '../services/database.dart';
 import '../services/recording_controller.dart';
 import '../screens/app_shell.dart';
 import '../widgets/channel_stats_table.dart';
+import '../widgets/dialogs.dart';
 import '../widgets/graph_components.dart';
 
 // ---------------------------------------------------------------------------
@@ -82,8 +83,10 @@ class _LiveTabState extends State<LiveTab> {
   bool _showDerivative = false;
   _LiveDataSource? _dataSource;
   DataHub? _hub;
-  BleLinkManager? _link;
-  bool _wasStreaming = false;
+
+  /// Last seen hub sample count; a decrease means the hub was cleared for a
+  /// new device stream (see [RecordingController]).
+  int _lastTotalSamples = 0;
 
   @override
   void didChangeDependencies() {
@@ -93,43 +96,33 @@ class _LiveTabState extends State<LiveTab> {
     // singleton, so the identity check below only fires once.
     final hub = context.read<DataHub>();
     if (_hub != hub) {
+      _hub?.removeListener(_onHubChanged);
       _hub = hub;
+      _lastTotalSamples = hub.totalSamples;
+      hub.addListener(_onHubChanged);
       _dataSource?.dispose();
       _dataSource = _LiveDataSource(hub);
     }
-    // Same for the link manager (also an app-lifetime singleton): listen for
-    // new device streams so the viewport can follow the fresh trace.
-    final link = context.read<BleLinkManager>();
-    if (_link != link) {
-      _link?.removeListener(_onLinkEdge);
-      _link = link;
-      _wasStreaming = link.isStreaming;
-      _link!.addListener(_onLinkEdge);
-    }
   }
 
-  /// A new device stream means the hub was just cleared (see
-  /// [RecordingController]): drop any stale pan/zoom window and follow the
-  /// live edge. Without this, a user-panned (non-live) window survives the
-  /// disconnect and [GraphController.effectiveRange] would clamp the stale
-  /// window against a now-empty buffer (inverted clamp limits -> throw).
-  void _onLinkEdge() {
-    final link = _link!;
+  /// A hub reset (its sample count only ever increases otherwise) means a new
+  /// device stream just cleared the previous trace: drop any stale pan/zoom
+  /// window and follow the fresh live edge. Without this, a user-panned
+  /// (non-live) window survives the disconnect and
+  /// [GraphController.effectiveRange] would clamp the stale window against a
+  /// now-empty buffer (inverted clamp limits -> throw).
+  void _onHubChanged() {
     final hub = _hub!;
-    if (link.isStreaming && !_wasStreaming) {
-      _graphCtrl.goLive(
-        totalSamples: hub.totalSamples,
-        oldestSample: hub.totalSamples > DataHub.maxDataSz
-            ? hub.totalSamples - DataHub.maxDataSz
-            : 0,
-      );
+    final total = hub.totalSamples;
+    if (total < _lastTotalSamples) {
+      _graphCtrl.goLive(totalSamples: total, oldestSample: 0);
     }
-    _wasStreaming = link.isStreaming;
+    _lastTotalSamples = total;
   }
 
   @override
   void dispose() {
-    _link?.removeListener(_onLinkEdge);
+    _hub?.removeListener(_onHubChanged);
     _dataSource?.dispose();
     _graphCtrl.dispose();
     super.dispose();
@@ -201,37 +194,15 @@ class _LiveTabState extends State<LiveTab> {
   }
 
   Future<void> _showRenameDialog(int sessionId, String currentName) async {
-    final controller = TextEditingController(text: currentName);
-    final newName = await showDialog<String>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Name this session'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: const InputDecoration(
-            labelText: 'Session name',
-            border: OutlineInputBorder(),
-          ),
-          onSubmitted: (val) => Navigator.of(ctx).pop(val),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(controller.text),
-            child: const Text('Save'),
-          ),
-        ],
-      ),
+    final newName = await showTextPrompt(
+      context,
+      title: 'Name this session',
+      label: 'Session name',
+      initial: currentName,
     );
-
     if (newName != null && newName.isNotEmpty) {
       await AppDatabase.instance.renameSession(sessionId, newName);
     }
-    controller.dispose();
   }
 
   @override

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -12,7 +12,9 @@ import '../models/bucket_series.dart';
 import '../models/gap_list.dart';
 import '../services/database.dart';
 import '../services/session_storage.dart';
+import '../utils/format.dart';
 import '../widgets/channel_stats_table.dart';
+import '../widgets/dialogs.dart';
 import '../widgets/graph_components.dart';
 
 class SessionDetailScreen extends StatefulWidget {
@@ -66,9 +68,8 @@ class _SessionDataSource implements GraphDataSource {
 }
 
 class _SessionDetailScreenState extends State<SessionDetailScreen> {
-  SessionData? _data;
-  bool _loading = true;
-  String? _error;
+  /// Load state of the session's sample data (see [_LoadState]).
+  _LoadState _loadState = const _Loading();
 
   late Session _session;
   final GraphController _graphCtrl = GraphController();
@@ -89,18 +90,13 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
 
   /// Parse the JSON-encoded per-channel visibility stored on a [Session]
   /// row. Missing or malformed entries fall back to visible.
-  static List<bool> _parseVisibleChannels(String json, int channelCount) {
-    final result = List<bool>.filled(channelCount, true);
-    try {
-      final List<dynamic> decoded = jsonDecode(json);
-      for (int i = 0; i < channelCount && i < decoded.length; i++) {
-        result[i] = decoded[i] == true;
-      }
-    } catch (e) {
-      debugPrint('Failed to parse session visible channels "$json": $e');
-    }
-    return result;
-  }
+  static List<bool> _parseVisibleChannels(String json, int channelCount) =>
+      parseJsonColumn(
+        json,
+        channelCount,
+        convert: (e) => e == true,
+        fallback: (_) => true,
+      );
 
   void _onToggleChannel(int index) {
     setState(() => _visibleChannels[index] = !_visibleChannels[index]);
@@ -122,34 +118,10 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     try {
       final data = await SessionStorage.loadSession(_session);
       if (!mounted) return;
-      setState(() {
-        _data = data;
-        _loading = false;
-      });
+      setState(() => _loadState = _Ready(data));
     } catch (e) {
       if (!mounted) return;
-      setState(() {
-        _error = e.toString();
-        _loading = false;
-      });
-    }
-  }
-
-  List<String> _parseChannelLabels(String jsonLabels) {
-    try {
-      final List<dynamic> decoded = jsonDecode(jsonLabels);
-      return decoded.map((e) => e.toString()).toList();
-    } catch (e) {
-      // Fallback for older sessions that saved labels via .toString() -> "[A, B]"
-      final trimmed = jsonLabels.trim();
-      if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
-        return trimmed
-            .substring(1, trimmed.length - 1)
-            .split(',')
-            .map((e) => e.trim())
-            .toList();
-      }
-      return [];
+      setState(() => _loadState = _Failed(e));
     }
   }
 
@@ -178,23 +150,28 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
           ),
         ],
       ),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : _error != null
-          ? Center(child: Text('Error: $_error'))
-          : _buildContent(settings),
+      body: switch (_loadState) {
+        _Loading() => const Center(child: CircularProgressIndicator()),
+        _Failed(:final error) => Center(child: Text('Error: $error')),
+        // A session without chunks (e.g. deleted externally) has nothing to
+        // show; loadSession returns null there.
+        _Ready(data: null) => const Center(
+          child: Text('No recorded data for this session'),
+        ),
+        _Ready(:final data) => _buildContent(settings, data!),
+      },
     );
   }
 
-  Widget _buildContent(AppSettings settings) {
-    final data = _data!;
+  Widget _buildContent(AppSettings settings, SessionData data) {
     final unit = settings.displayUnit;
 
-    final storedLabels = _parseChannelLabels(_session.channelLabels);
-    final channelLabels = [
-      for (int ch = 0; ch < data.channels.length; ch++)
-        storedLabels.length > ch ? storedLabels[ch] : 'Ch ${ch + 1}',
-    ];
+    final channelLabels = parseJsonColumn(
+      _session.channelLabels,
+      data.channels.length,
+      convert: (e) => e.toString(),
+      fallback: (i) => 'Ch ${i + 1}',
+    );
 
     return SingleChildScrollView(
       child: Column(
@@ -256,7 +233,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 const SizedBox(height: 8),
                 _StatRow(
                   label: 'Duration',
-                  value: _formatDuration(
+                  value: formatDuration(
                     Duration(milliseconds: _session.durationMs),
                   ),
                 ),
@@ -268,9 +245,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 for (int ch = 0; ch < data.channels.length; ch++) ...[
                   const Divider(height: 16),
                   Text(
-                    storedLabels.length > ch
-                        ? storedLabels[ch]
-                        : 'Channel ${ch + 1}',
+                    channelLabels[ch],
                     style: TextStyle(
                       fontWeight: FontWeight.w500,
                       color: getChannelColor(ch),
@@ -337,114 +312,52 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
       case 'notes':
         await _showNotesDialog();
       case 'export_csv':
-        if (_data != null) await _exportCsv(_data!);
+        final state = _loadState;
+        if (state is _Ready && state.data != null) {
+          await _exportCsv(state.data!);
+        }
       case 'delete':
         await _deleteAndPop();
     }
   }
 
-  Future<void> _showRenameDialog() async {
-    final controller = TextEditingController(text: _session.name);
-    final newName = await showDialog<String>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Rename session'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: const InputDecoration(
-            labelText: 'Session name',
-            border: OutlineInputBorder(),
-          ),
-          onSubmitted: (val) => Navigator.of(ctx).pop(val),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(controller.text),
-            child: const Text('Save'),
-          ),
-        ],
-      ),
-    );
-    controller.dispose();
+  /// Re-read the session row after a metadata edit so the UI reflects it.
+  Future<void> _reloadSession() async {
+    final updated = await AppDatabase.instance.sessionById(_session.id);
+    if (updated != null && mounted) {
+      setState(() => _session = updated);
+    }
+  }
 
+  Future<void> _showRenameDialog() async {
+    final newName = await showTextPrompt(
+      context,
+      title: 'Rename session',
+      label: 'Session name',
+      initial: _session.name,
+    );
     if (newName != null && newName.isNotEmpty) {
       await AppDatabase.instance.renameSession(_session.id, newName);
-      // Reload session from DB
-      final updated = await AppDatabase.instance.sessionById(_session.id);
-      if (updated != null && mounted) {
-        setState(() => _session = updated);
-      }
+      await _reloadSession();
     }
   }
 
   Future<void> _showNotesDialog() async {
-    final controller = TextEditingController(text: _session.notes);
-    final newNotes = await showDialog<String>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Edit notes'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          maxLines: 5,
-          decoration: const InputDecoration(
-            labelText: 'Notes',
-            border: OutlineInputBorder(),
-            alignLabelWithHint: true,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(controller.text),
-            child: const Text('Save'),
-          ),
-        ],
-      ),
+    final newNotes = await showTextPrompt(
+      context,
+      title: 'Edit notes',
+      label: 'Notes',
+      initial: _session.notes,
+      maxLines: 5,
     );
-    controller.dispose();
-
     if (newNotes != null) {
       await AppDatabase.instance.setSessionNotes(_session.id, newNotes);
-      final updated = await AppDatabase.instance.sessionById(_session.id);
-      if (updated != null && mounted) {
-        setState(() => _session = updated);
-      }
+      await _reloadSession();
     }
   }
 
   Future<void> _deleteAndPop() async {
-    final confirm = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete session?'),
-        content: const Text('This cannot be undone.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(ctx).colorScheme.error,
-              foregroundColor: Theme.of(ctx).colorScheme.onError,
-            ),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
-    );
-
-    if (confirm == true) {
+    if (await showDeleteConfirm(context, what: _session.name)) {
       await AppDatabase.instance.deleteSession(_session.id);
       if (mounted) Navigator.of(context).pop();
     }
@@ -512,14 +425,30 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
       ).showSnackBar(SnackBar(content: Text('Exported to $savedTo')));
     }
   }
+}
 
-  static String _formatDuration(Duration d) {
-    if (d.inMinutes >= 1) {
-      final sec = d.inSeconds % 60;
-      return '${d.inMinutes}m ${sec}s';
-    }
-    return '${d.inSeconds}s';
-  }
+// -- Load state --
+
+/// Load state for the session's sample data: still loading, failed, or ready
+/// (data null means the session has no chunks).
+sealed class _LoadState {
+  const _LoadState();
+}
+
+final class _Loading extends _LoadState {
+  const _Loading();
+}
+
+final class _Failed extends _LoadState {
+  const _Failed(this.error);
+
+  final Object error;
+}
+
+final class _Ready extends _LoadState {
+  const _Ready(this.data);
+
+  final SessionData? data;
 }
 
 // -- Stat row widget --

--- a/lib/screens/sessions_tab.dart
+++ b/lib/screens/sessions_tab.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 import '../models/app_settings.dart';
 import '../models/force_unit.dart';
 import '../services/database.dart';
+import '../utils/format.dart';
+import '../widgets/dialogs.dart';
 import 'session_detail_screen.dart';
 
 class SessionsTab extends StatefulWidget {
@@ -119,29 +121,7 @@ class _SessionsTabState extends State<SessionsTab> {
   }
 
   Future<void> _deleteSession(Session session) async {
-    final confirm = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete session?'),
-        content: Text('Delete "${session.name}"? This cannot be undone.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(ctx).colorScheme.error,
-              foregroundColor: Theme.of(ctx).colorScheme.onError,
-            ),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
-    );
-
-    if (confirm == true) {
+    if (await showDeleteConfirm(context, what: session.name)) {
       await AppDatabase.instance.deleteSession(session.id);
     }
   }
@@ -165,7 +145,7 @@ class _SessionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final duration = Duration(milliseconds: session.durationMs);
-    final durationStr = _formatDuration(duration);
+    final durationStr = formatDuration(duration);
     final peakDisplay = unit.format(
       unit.fromRaw(session.peakForceRaw.toDouble(), calibrationSlope),
     );
@@ -192,7 +172,7 @@ class _SessionCard extends StatelessWidget {
             style: const TextStyle(fontWeight: FontWeight.w500),
           ),
           subtitle: Text(
-            '${_formatDate(session.createdAt)} · $durationStr\n'
+            '${formatDate(session.createdAt)} · $durationStr\n'
             'Peak: $peakDisplay · ${session.channelCount} ch',
           ),
           isThreeLine: true,
@@ -200,31 +180,5 @@ class _SessionCard extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  static String _formatDuration(Duration d) {
-    if (d.inMinutes >= 1) {
-      final sec = d.inSeconds % 60;
-      return '${d.inMinutes}m ${sec}s';
-    }
-    return '${d.inSeconds}s';
-  }
-
-  static String _formatDate(DateTime dt) {
-    const months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    return '${months[dt.month - 1]} ${dt.day}, ${dt.year}';
   }
 }

--- a/lib/services/adc_packet_decoder.dart
+++ b/lib/services/adc_packet_decoder.dart
@@ -48,8 +48,16 @@ class AdcPacketDecoder {
   /// [DataHub.addSamplesAppendedListener] (notified from
   /// [DataHub.commitBatch]).
   void onDataPacket(Uint8List data) {
-    if (data.isEmpty) {
-      debugPrint("data isEmpty");
+    // A decodable packet holds the 2-byte counter plus at least
+    // nwAdcNumSamples full frames (extra trailing bytes are ignored, matching
+    // the fixed-size loop below). Anything shorter — e.g. a truncated
+    // notification from a firmware bug — is dropped rather than parsed:
+    // indexing past the end would throw in release builds.
+    const int minLength = nwHeaderSize + nwAdcNumSamples * nwAdcSampleLength;
+    if (data.length < minLength) {
+      debugPrint(
+        'Dropping short ADC packet: ${data.length} B (need $minLength B)',
+      );
       return;
     }
 
@@ -73,7 +81,6 @@ class AdcPacketDecoder {
       packetStart < nwHeaderSize + nwAdcNumSamples * nwAdcSampleLength;
       packetStart += nwAdcSampleLength
     ) {
-      assert(packetStart + nwAdcSampleLength <= data.length);
       for (int i = 0; i < nwNumAdcChan; ++i) {
         final int baseIndex = packetStart + i * 3;
         _frame[i] =

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -205,6 +205,13 @@ class BleLinkManager extends ChangeNotifier {
   /// device. Connect stays blocked while this is true.
   bool get isCoolingDown => _link.isCoolingDown;
 
+  /// A link is "busy" whenever it is mid-transition, active, or cooling down
+  /// after a disconnect; device-row Connect buttons stay disabled until the
+  /// link returns to idle. This is what prevents the disconnect→reconnect
+  /// double-click race — including the web post-disconnect settle window where
+  /// the stack isn't yet ready to accept a fresh connection.
+  bool get linkBusy => _link.state != BtLinkState.idle;
+
   /// Device id of the active link whenever the GATT link is up (during setup or
   /// while streaming); empty otherwise.
   String get selectedDeviceId => _link.isLinkUp ? _link.deviceId : '';
@@ -686,21 +693,22 @@ class BleLinkManager extends ChangeNotifier {
       return;
     }
     for (final characteristic in service.characteristics) {
-      if ((characteristic.uuid == btChrAdcFeedId) &&
-          characteristic.properties.contains(CharacteristicProperty.notify)) {
-        onCalibrationData?.call(
-          await UniversalBle.read(deviceId, service.uuid, btChrCalibration),
-        );
-        await UniversalBle.subscribeNotifications(
-          deviceId,
-          service.uuid,
-          characteristic.uuid,
-        );
-        // The link's transition to the usable [BtLinkState.streaming] state is
-        // driven by the caller ([_onConnectionChange]) once this returns and the
-        // generation guard confirms the pass wasn't superseded.
-        return;
+      if (characteristic.uuid != btChrAdcFeedId ||
+          !characteristic.properties.contains(CharacteristicProperty.notify)) {
+        continue;
       }
+      onCalibrationData?.call(
+        await UniversalBle.read(deviceId, service.uuid, btChrCalibration),
+      );
+      await UniversalBle.subscribeNotifications(
+        deviceId,
+        service.uuid,
+        characteristic.uuid,
+      );
+      // The link's transition to the usable [BtLinkState.streaming] state is
+      // driven by the caller ([_onConnectionChange]) once this returns and the
+      // generation guard confirms the pass wasn't superseded.
+      return;
     }
   }
 

--- a/lib/services/bt_device_config.dart
+++ b/lib/services/bt_device_config.dart
@@ -1,7 +1,5 @@
 const bool useMockBt = false;
 
-// const btDeviceUUID = "E4:B0:63:81:5B:19";
-const btGattId = "a659ee73-460b-45d5-8e63-ab6bf0825942";
 const btServiceId = "e331016b-6618-4f8f-8997-1a2c7c9e5fa3";
 const btChrAdcFeedId = "beb5483e-36e1-4688-b7f5-ea07361b26a8";
 const btChrCalibration = "10adce11-68a6-450b-9810-ca11b39fd283";

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -15,7 +15,7 @@ typedef SamplesAppendedListener = void Function(int startIdx, int count);
 /// Storage and derived statistics for the live ADC stream.
 ///
 /// This class owns the ring buffer, minimap buckets, tare state and the
-/// analytics the UI reads (current/peak/min force, derivative, AC RMS). It
+/// analytics the UI reads (current/peak/min force and the derivative). It
 /// knows nothing about BLE or the wire format: decoded samples arrive through
 /// [addSampleFrame] / [addDroppedFrames] (fed by [AdcPacketDecoder]) and each
 /// packet is closed out with [commitBatch].

--- a/lib/services/mockble.dart
+++ b/lib/services/mockble.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 import 'dart:typed_data';
-import 'dart:convert';
 
-import 'package:cross_file/cross_file.dart';
 import 'package:universal_ble/universal_ble.dart';
 
 import 'adc_protocol.dart';
@@ -19,7 +17,6 @@ class MockBlePlatform extends UniversalBlePlatform {
     _setupListeners();
     // Always have a synthetic feed available synchronously so [connect] never
     // blocks on file I/O (which would stall under a fake-async test clock).
-    // [loadMockDataFile] can later override this with real captured samples.
     _mockData
       ..clear()
       ..addAll(_generateSyntheticFrames(2000));
@@ -255,50 +252,6 @@ class MockBlePlatform extends UniversalBlePlatform {
 
   void _setupListeners() {
     //onValueChange = (String deviceId, String characteristicId, Uint8List value) {};
-  }
-
-  /// Optionally override the synthetic feed with real captured samples from a
-  /// text file (one JSON object per line, `{"channels": [c0,c1,c2,c3]}`).
-  ///
-  /// This is an explicit opt-in for replaying recorded data: [connect] never
-  /// awaits this, so the feed always has the synthetic frames ready even if the
-  /// file is missing or unreadable. On success the data cursor is reset so the
-  /// next subscription starts from the first captured sample.
-  Future<void> loadMockDataFile(String path) async {
-    final loaded = <Uint8List>[];
-    try {
-      final String mem = await XFile(path).readAsString(encoding: ascii);
-      for (final String s in mem.split('\n')) {
-        if (s.isEmpty) continue;
-        final Map<String, dynamic> parsedLine = json.decode(
-          s.replaceAll("'", '"'),
-        );
-        final adcSamples = List<int>.from(parsedLine['channels']);
-        assert(adcSamples.length == nwNumAdcChan);
-        loaded.add(_packSampleList(adcSamples));
-      }
-    } catch (_) {
-      // Could not read/parse the file: keep the existing synthetic feed.
-      return;
-    }
-    if (loaded.isNotEmpty) {
-      _mockData
-        ..clear()
-        ..addAll(loaded);
-      _mockDataCount = 0;
-    }
-  }
-
-  /// Pack a list of channel values (24-bit signed) into the 12-byte wire sample.
-  static Uint8List _packSampleList(List<int> ch) {
-    final out = Uint8List(nwAdcSampleLength);
-    for (int i = 0; i < nwNumAdcChan && i < ch.length; ++i) {
-      final v = ch[i] & 0xFFFFFF;
-      out[i * 3] = v & 0xFF;
-      out[i * 3 + 1] = (v >> 8) & 0xFF;
-      out[i * 3 + 2] = (v >> 16) & 0xFF;
-    }
-    return out;
   }
 
   /// Pack 4 channel values (24-bit signed) into the 12-byte wire sample.

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -151,18 +151,46 @@ class SessionStorage {
 
   /// Parse the JSON-encoded per-channel tares stored on a [Session] row.
   /// Missing or malformed entries fall back to zero.
-  static Float64List _parseTares(String json, int channelCount) {
-    final tares = Float64List(channelCount);
-    try {
-      final List<dynamic> parsed = jsonDecode(json);
-      for (int i = 0; i < channelCount && i < parsed.length; i++) {
-        tares[i] = (parsed[i] as num).toDouble();
-      }
-    } catch (e) {
-      debugPrint('Failed to parse session tares "$json": $e');
-    }
-    return tares;
+  static Float64List _parseTares(String json, int channelCount) =>
+      Float64List.fromList(
+        parseJsonColumn(
+          json,
+          channelCount,
+          convert: (e) => (e as num).toDouble(),
+          fallback: (_) => 0.0,
+        ),
+      );
+}
+
+/// Parse a JSON-encoded list column into exactly [count] entries: entry i is
+/// [convert] applied to the i-th decoded element, or [fallback] when the
+/// document is malformed, shorter than [count], or the element fails to
+/// convert. Session metadata columns (tares, channel labels, visible
+/// channels) are display-only, so a corrupt value degrades to defaults
+/// instead of throwing.
+List<T> parseJsonColumn<T>(
+  String json,
+  int count, {
+  required T Function(Object? decoded) convert,
+  required T Function(int index) fallback,
+}) {
+  List<dynamic>? parsed;
+  try {
+    final decoded = jsonDecode(json);
+    if (decoded is List) parsed = decoded;
+  } catch (e) {
+    debugPrint('Failed to parse session metadata "$json": $e');
   }
+  T entry(int i) {
+    if (parsed == null || i >= parsed.length) return fallback(i);
+    try {
+      return convert(parsed[i]);
+    } catch (_) {
+      return fallback(i);
+    }
+  }
+
+  return [for (int i = 0; i < count; i++) entry(i)];
 }
 
 /// Scans interleaved int32 chunk bytes, accumulating sample count and the

--- a/lib/utils/format.dart
+++ b/lib/utils/format.dart
@@ -1,0 +1,30 @@
+/// Shared display formatters for the session screens.
+library;
+
+/// "45s" below a minute, "3m 12s" above.
+String formatDuration(Duration d) {
+  if (d.inMinutes >= 1) {
+    final sec = d.inSeconds % 60;
+    return '${d.inMinutes}m ${sec}s';
+  }
+  return '${d.inSeconds}s';
+}
+
+/// "Jul 20, 2026".
+String formatDate(DateTime dt) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[dt.month - 1]} ${dt.day}, ${dt.year}';
+}

--- a/lib/widgets/bt_icon.dart
+++ b/lib/widgets/bt_icon.dart
@@ -3,70 +3,74 @@ import 'package:flutter/material.dart';
 
 import 'package:universal_ble/universal_ble.dart' show AvailabilityState;
 
+import '../services/ble_link_manager.dart' show BtLinkState;
+
+/// Compact Bluetooth status readout (icon + hint text, with a spinner while
+/// anything is in flight). Driven directly by the per-device link state plus
+/// the global adapter availability and scan flag — no derived flags to keep
+/// in sync at the call site.
 class BluetoothIndicator extends StatelessWidget {
-  final bool isScanning;
-  final bool isConnecting;
-  final bool isSettingUp;
-  final bool isConnected;
-  final bool isDisconnecting;
-  final bool isCoolingDown;
-  final bool hasDevices;
+  /// State of the single active device link.
+  final BtLinkState linkState;
+
+  /// Radio/adapter availability.
   final AvailabilityState state;
+
+  final bool isScanning;
+
+  /// Any discovered devices in the list (for the idle hint).
+  final bool hasDevices;
 
   const BluetoothIndicator({
     super.key,
-    required this.isScanning,
+    required this.linkState,
     required this.state,
-    this.isConnecting = false,
-    this.isSettingUp = false,
-    this.isConnected = false,
-    this.isDisconnecting = false,
-    this.isCoolingDown = false,
+    this.isScanning = false,
     this.hasDevices = false,
   });
 
   @override
   Widget build(BuildContext context) {
     (IconData, Color, String) indicator() {
-      // Order matters: most definite / in-progress states first.
-      if (isDisconnecting) {
-        return const (
-          Icons.bluetooth_searching,
-          Colors.lightBlue,
-          'Disconnecting…',
-        );
-      }
-      if (isCoolingDown) {
-        // Web: the link has torn down but the stack isn't ready to reconnect
-        // yet. Connect stays disabled through this settle window.
-        return const (
-          Icons.bluetooth_searching,
-          Colors.lightBlue,
-          'Almost ready…',
-        );
-      }
-      if (isConnected) {
-        return const (
-          Icons.bluetooth_connected,
-          Colors.blueAccent,
-          'Connected',
-        );
-      }
-      if (isSettingUp) {
-        // GATT link is up but service discovery / ADC subscription is still in
-        // progress. Not usable yet.
-        return const (
-          Icons.bluetooth_searching,
-          Colors.lightBlue,
-          'Setting up…',
-        );
-      }
-      if (isConnecting) {
-        return const (
-          Icons.bluetooth_searching,
-          Colors.lightBlue,
-          'Connecting…',
-        );
+      // Link states first: any active link or transition outranks scan and
+      // adapter status.
+      switch (linkState) {
+        case BtLinkState.disconnecting:
+          return const (
+            Icons.bluetooth_searching,
+            Colors.lightBlue,
+            'Disconnecting…',
+          );
+        case BtLinkState.cooldown:
+          // Web: the link has torn down but the stack isn't ready to reconnect
+          // yet. Connect stays disabled through this settle window.
+          return const (
+            Icons.bluetooth_searching,
+            Colors.lightBlue,
+            'Almost ready…',
+          );
+        case BtLinkState.streaming:
+          return const (
+            Icons.bluetooth_connected,
+            Colors.blueAccent,
+            'Connected',
+          );
+        case BtLinkState.connected:
+          // GATT link is up but service discovery / ADC subscription is still
+          // in progress. Not usable yet.
+          return const (
+            Icons.bluetooth_searching,
+            Colors.lightBlue,
+            'Setting up…',
+          );
+        case BtLinkState.connecting:
+          return const (
+            Icons.bluetooth_searching,
+            Colors.lightBlue,
+            'Connecting…',
+          );
+        case BtLinkState.idle:
+          break; // Fall through to scan / adapter status.
       }
       if (isScanning) {
         // On web the device list lives in the browser's own picker popup, not
@@ -134,12 +138,11 @@ class BluetoothIndicator extends StatelessWidget {
 
     final (IconData icon, Color color, String label) = indicator();
     const double size = 32;
+    // Spinner while anything is in flight (scanning or a link transition);
+    // the steady "streaming" state gets the plain connected icon.
     final bool showSpinner =
         isScanning ||
-        isConnecting ||
-        isSettingUp ||
-        isDisconnecting ||
-        isCoolingDown;
+        (linkState != BtLinkState.idle && linkState != BtLinkState.streaming);
 
     final iconStack = Stack(
       clipBehavior: Clip.none,

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+/// Shared dialog helpers: one text prompt and one delete confirmation, used by
+/// the live tab, the session list and the session detail screen.
+
+/// Prompt for a single text value. Returns the entered text (which may be
+/// empty), or null when cancelled. Single-line prompts submit on Enter;
+/// multi-line ones (e.g. notes) confirm via the Save button only.
+Future<String?> showTextPrompt(
+  BuildContext context, {
+  required String title,
+  required String label,
+  String initial = '',
+  int maxLines = 1,
+}) async {
+  final controller = TextEditingController(text: initial);
+  final result = await showDialog<String>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text(title),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        maxLines: maxLines,
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          alignLabelWithHint: maxLines > 1,
+        ),
+        onSubmitted: maxLines == 1
+            ? (val) => Navigator.of(ctx).pop(val)
+            : null,
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(controller.text),
+          child: const Text('Save'),
+        ),
+      ],
+    ),
+  );
+  controller.dispose();
+  return result;
+}
+
+/// Ask the user to confirm deleting the session named [what]. Returns true
+/// only when confirmed.
+Future<bool> showDeleteConfirm(BuildContext context, {required String what}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Delete session?'),
+      content: Text('Delete "$what"? This cannot be undone.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(true),
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(ctx).colorScheme.error,
+            foregroundColor: Theme.of(ctx).colorScheme.onError,
+          ),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+  return confirmed ?? false;
+}

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -611,67 +611,103 @@ class _NeverListenable extends Listenable {
 // Graph viewport controller (shared between force graph, derivative, minimap)
 // ---------------------------------------------------------------------------
 
+/// Viewport state of a [GraphController]: either following the live (right)
+/// edge or parked on a fixed window. Kept as a union so the two states can't
+/// mix (e.g. a stale window start silently carried while live).
+sealed class GraphViewport {
+  const GraphViewport();
+}
+
+/// Following the live edge. [span] locks the visible window to a fixed sample
+/// count; null means "show everything" (auto-expanding squeeze).
+final class GraphLive extends GraphViewport {
+  const GraphLive([this.span]);
+
+  final int? span;
+}
+
+/// Parked on the fixed window [start, end) (absolute sample indices).
+final class GraphWindow extends GraphViewport {
+  const GraphWindow(this.start, this.end);
+
+  final int start;
+  final int end;
+}
+
 class GraphController extends ChangeNotifier {
   final int minLiveSpan;
 
   GraphController({this.minLiveSpan = 0})
-    : _liveSpan = minLiveSpan > 0 ? minLiveSpan : null;
+    : _viewport = minLiveSpan > 0 ? GraphLive(minLiveSpan) : const GraphLive();
 
-  /// Start of visible window in samples.
-  int _viewStart = 0;
-  int get viewStart => _viewStart;
-
-  /// End of visible window in samples. Null means "follow live edge".
-  int? _viewEnd;
-  int? get viewEnd => _viewEnd;
+  GraphViewport _viewport;
 
   /// Whether we're following the live edge (auto-scroll with new data).
-  bool _isLive = true;
-  bool get isLive => _isLive;
+  bool get isLive => _viewport is GraphLive;
 
-  /// When in live mode and zoomed in, this is the fixed span to show
-  /// from the right edge. Null means "show all data from _viewStart" (up to 10 minutes).
-  int? _liveSpan;
-  int? get liveSpan => _liveSpan;
+  /// When in live mode and zoomed in, the fixed span shown from the right
+  /// edge. Null means "show all data" (auto-expanding up to buffer capacity).
+  int? get liveSpan => switch (_viewport) {
+    GraphLive(:final span) => span,
+    GraphWindow() => null,
+  };
+
+  /// Start of the visible window in samples; 0 in live mode (the live range
+  /// is derived by [effectiveRange], never stored).
+  int get viewStart => switch (_viewport) {
+    GraphWindow(:final start) => start,
+    GraphLive() => 0,
+  };
+
+  /// End of the visible window in samples; null in live mode.
+  int? get viewEnd => switch (_viewport) {
+    GraphWindow(:final end) => end,
+    GraphLive() => null,
+  };
 
   /// Snap to live mode -- follow the right edge.
   /// If [span] is provided, locks to that scrolling window.
-  /// If not provided, it intelligently decides between full view or default scrolling window.
+  /// If not provided, derives the lock from the current window (or keeps the
+  /// existing lock when already live).
   void goLive({
     int? span,
     required int totalSamples,
     required int oldestSample,
   }) {
+    final int? lockedSpan;
     if (span != null) {
       // Explicitly lock to a span (used by zoom out when it hits max)
-      _liveSpan = span;
-    } else if (_viewEnd != null) {
-      final currentSpan = _viewEnd! - _viewStart;
-      if (currentSpan < totalSamples - oldestSample) {
-        // User is zoomed in to a specific window, lock to it
-        _liveSpan = currentSpan;
-      } else if (currentSpan > minLiveSpan) {
-        // They zoomed out to see all available data (beyond minLiveSpan);
-        // they want to see everything auto-expand.
-        _liveSpan = null;
-      } else {
-        // They zoomed out, but we don't have much data yet. Lock to minimum
-        // span so it cleanly starts scrolling once it hits 20s.
-        _liveSpan = minLiveSpan;
+      lockedSpan = span;
+    } else {
+      switch (_viewport) {
+        case GraphLive(:final span):
+          // Already live (e.g. a fresh stream resetting the view): keep the
+          // current lock.
+          lockedSpan = span;
+        case GraphWindow(:final start, :final end):
+          final currentSpan = end - start;
+          if (currentSpan < totalSamples - oldestSample) {
+            // User is zoomed in to a specific window, lock to it
+            lockedSpan = currentSpan;
+          } else if (currentSpan > minLiveSpan) {
+            // They zoomed out to see all available data (beyond minLiveSpan);
+            // they want to see everything auto-expand.
+            lockedSpan = null;
+          } else {
+            // They zoomed out, but we don't have much data yet. Lock to minimum
+            // span so it cleanly starts scrolling once it hits 20s.
+            lockedSpan = minLiveSpan;
+          }
       }
     }
 
-    _isLive = true;
-    _viewEnd = null;
+    _viewport = GraphLive(lockedSpan);
     notifyListeners();
   }
 
   /// Set a specific visible window (exits live mode).
   void setWindow(int start, int end) {
-    _viewStart = start;
-    _viewEnd = end;
-    _isLive = false;
-    _liveSpan = null;
+    _viewport = GraphWindow(start, end);
     notifyListeners();
   }
 
@@ -681,15 +717,16 @@ class GraphController extends ChangeNotifier {
     int oldestSample, {
     int? bufferCapacity,
   }) {
-    if (_isLive || _viewEnd == null) {
-      final int maxSpan = math.max(minLiveSpan, totalSamples - oldestSample);
-      int span = _liveSpan ?? maxSpan;
-      if (bufferCapacity != null && span > bufferCapacity) {
-        span = bufferCapacity;
-      }
-      return (totalSamples - span, totalSamples);
+    switch (_viewport) {
+      case GraphLive(:final span):
+        int s = span ?? math.max(minLiveSpan, totalSamples - oldestSample);
+        if (bufferCapacity != null && s > bufferCapacity) {
+          s = bufferCapacity;
+        }
+        return (totalSamples - s, totalSamples);
+      case GraphWindow(:final start, :final end):
+        return (start, end.clamp(start + 1, totalSamples));
     }
-    return (_viewStart, _viewEnd!.clamp(_viewStart + 1, totalSamples));
   }
 
   /// Whether the current window covers all available data.
@@ -716,19 +753,14 @@ class GraphController extends ChangeNotifier {
       newStart = minStart;
       newEnd = newStart + span;
     }
+
+    // Park on the window; if it reaches the right edge, snap to live instead
+    // (goLive derives the locked span from the window set here).
+    _viewport = GraphWindow(newStart, newEnd);
     if (newEnd >= totalSamples) {
-      // Snap to live if the window reaches the right edge. goLive derives the
-      // locked span from the window set here.
-      _viewStart = newStart;
-      _viewEnd = newEnd;
       goLive(totalSamples: totalSamples, oldestSample: oldestSample);
       return;
     }
-
-    _viewStart = newStart;
-    _viewEnd = newEnd;
-    _isLive = false;
-    _liveSpan = null;
     notifyListeners();
   }
 
@@ -771,9 +803,8 @@ class GraphController extends ChangeNotifier {
 
     if (newEnd >= totalSamples) {
       // At the right edge -- enter/stay live. Unlike applyWindow, a zoom that
-      // hits max span means "show everything" (liveSpan = null, auto-expand).
-      _viewStart = totalSamples - span; // Force right-align
-      _viewEnd = totalSamples;
+      // hits max span means "show everything" (no locked span, auto-expand).
+      _viewport = GraphWindow(totalSamples - span, totalSamples);
       goLive(
         span: span >= maxSpan ? null : span,
         totalSamples: totalSamples,
@@ -782,10 +813,7 @@ class GraphController extends ChangeNotifier {
       return;
     }
 
-    _viewStart = newStart;
-    _viewEnd = newEnd;
-    _isLive = false;
-    _liveSpan = null;
+    _viewport = GraphWindow(newStart, newEnd);
     notifyListeners();
   }
 
@@ -839,7 +867,7 @@ class GraphController extends ChangeNotifier {
       focalFraction,
       baseStart: s,
       baseSpan: span,
-      anchorLiveEdge: _isLive,
+      anchorLiveEdge: isLive,
       totalSamples: totalSamples,
       oldestSample: oldestSample,
     );
@@ -847,10 +875,7 @@ class GraphController extends ChangeNotifier {
 
   /// Reset to show all data in live mode (fully zoomed out).
   void reset() {
-    _viewStart = 0;
-    _viewEnd = null;
-    _liveSpan = null;
-    _isLive = true;
+    _viewport = const GraphLive();
     notifyListeners();
   }
 }
@@ -894,6 +919,44 @@ void _handleGraphPointerScroll(
 }
 
 // ---------------------------------------------------------------------------
+// Bake pump (shared repaint driver for the rolling segment bake)
+// ---------------------------------------------------------------------------
+
+/// Extra repaint driver for the rolling segment bake: baking is rationed to
+/// [kSegmentBakeBudget] segments per frame, so when work remains a painter
+/// calls [schedule], which ticks [Listenable] listeners after the frame.
+/// Needed for static sources (loaded sessions) whose [GraphDataSource.repaint]
+/// never fires; harmless for live ones. Owned and disposed by the host
+/// widget's State.
+class BakePump implements Listenable {
+  final ValueNotifier<int> _notifier = ValueNotifier<int>(0);
+  bool _scheduled = false;
+  bool _disposed = false;
+
+  /// Schedule a one-shot post-frame tick (coalesced until it fires).
+  void schedule() {
+    if (_scheduled || _disposed) return;
+    _scheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _scheduled = false;
+      if (!_disposed) _notifier.value++;
+    });
+  }
+
+  @override
+  void addListener(VoidCallback listener) => _notifier.addListener(listener);
+
+  @override
+  void removeListener(VoidCallback listener) =>
+      _notifier.removeListener(listener);
+
+  void dispose() {
+    _disposed = true;
+    _notifier.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Minimap
 // ---------------------------------------------------------------------------
 
@@ -919,22 +982,7 @@ class Minimap extends StatefulWidget {
 
 class _MinimapState extends State<Minimap> {
   final SegmentedGraphCache _cache = SegmentedGraphCache();
-
-  /// Extra repaint driver for the rolling bake: baking is rationed to one
-  /// segment per frame, so when work remains the painter requests another
-  /// frame via [_schedulePump]. Needed for static sources (loaded sessions)
-  /// whose [GraphDataSource.repaint] never fires; harmless for live ones.
-  final ValueNotifier<int> _bakePump = ValueNotifier<int>(0);
-  bool _pumpScheduled = false;
-
-  void _schedulePump() {
-    if (_pumpScheduled) return;
-    _pumpScheduled = true;
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      _pumpScheduled = false;
-      if (mounted) _bakePump.value++;
-    });
-  }
+  final BakePump _bakePump = BakePump();
 
   @override
   void dispose() {
@@ -1009,7 +1057,7 @@ class _MinimapState extends State<Minimap> {
                   dpr,
                   _cache,
                   _bakePump,
-                  _schedulePump,
+                  _bakePump.schedule,
                 ),
                 size: Size.infinite,
               ),
@@ -1304,22 +1352,7 @@ class GraphWorkspace extends StatefulWidget {
 class _GraphWorkspaceState extends State<GraphWorkspace> {
   final SegmentedGraphCache _forceCache = SegmentedGraphCache();
   final SegmentedGraphCache _derivCache = SegmentedGraphCache();
-
-  /// Extra repaint driver for the rolling bake: baking is rationed to a few
-  /// segments per frame, so when work remains a painter requests another
-  /// frame via [_schedulePump]. Needed for static sources (loaded sessions)
-  /// whose [GraphDataSource.repaint] never fires; harmless for live ones.
-  final ValueNotifier<int> _bakePump = ValueNotifier<int>(0);
-  bool _pumpScheduled = false;
-
-  void _schedulePump() {
-    if (_pumpScheduled) return;
-    _pumpScheduled = true;
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      _pumpScheduled = false;
-      if (mounted) _bakePump.value++;
-    });
-  }
+  final BakePump _bakePump = BakePump();
 
   @override
   void dispose() {
@@ -1356,7 +1389,7 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                         colorScheme: colorScheme,
                         dpr: dpr,
                         bakePump: _bakePump,
-                        requestRepaint: _schedulePump,
+                        requestRepaint: _bakePump.schedule,
                       ),
                       size: Size.infinite,
                     ),
@@ -1379,7 +1412,7 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                           colorScheme: colorScheme,
                           dpr: dpr,
                           bakePump: _bakePump,
-                          requestRepaint: _schedulePump,
+                          requestRepaint: _bakePump.schedule,
                         ),
                         size: Size.infinite,
                       ),
@@ -1560,9 +1593,9 @@ String _fmtTick(double sec, int decimals) {
   return '$m:${s.padLeft(decimals == 0 ? 2 : decimals + 3, '0')}';
 }
 
-// Label paragraph cache (bounded; fully cleared on overflow -- the per-frame
+// Label paragraph cache, bounded: fully cleared on overflow — the per-frame
 // working set is only a few dozen labels, so a clear just rebuilds the
-// visible ones on the next paint).
+// visible ones on the next paint.
 const int _labelCacheLimit = 512;
 final Map<String, ui.Paragraph> _labelCache = HashMap();
 

--- a/test/adc_packet_decoder_test.dart
+++ b/test/adc_packet_decoder_test.dart
@@ -126,5 +126,17 @@ void main() {
       decoder.onDataPacket(Uint8List(0));
       expect(hub.totalSamples, 0);
     });
+
+    test('a truncated packet is ignored instead of throwing', () {
+      // One byte short of a full packet: a firmware bug must not crash the
+      // app (the in-loop asserts are stripped in release builds).
+      final short = makePacket(0, (s, c) => 1);
+      decoder.onDataPacket(Uint8List.sublistView(short, 0, short.length - 1));
+      expect(hub.totalSamples, 0);
+      // A packet with trailing extra bytes still decodes its 20 samples.
+      final long = Uint8List(short.length + 3)..setAll(0, short);
+      decoder.onDataPacket(long);
+      expect(hub.totalSamples, nwAdcNumSamples);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup from a codebase review with three goals: **reduce
branching, reduce state, reduce bug surface**. 17 files, +518/−529 —
deliberately near-neutral in LOC; the win is fewer states and branches, not
raw line count.

### State reduction
- **GraphController**: four interlocking fields (`_viewStart`/`_viewEnd`/
  `_isLive`/`_liveSpan`) → sealed `GraphViewport` union
  (`GraphLive(span?) | GraphWindow(start, end)`). Illegal states (e.g. a
  stale window surviving in live mode) are now unrepresentable. Public
  getters kept as projections; all 18 controller tests pass unchanged.
- **SessionDetailScreen**: `_data`/`_loading`/`_error` triple → sealed load
  state. Fixes a latent crash: `loadSession` can return null for a
  chunk-less session, which previously hit `_data!`.
- **LiveTab**: new-stream reset is detected from the hub (`totalSamples`
  decrease ⇔ `clear()`) instead of a second `BleLinkManager` edge listener
  duplicating `RecordingController`'s.
- **Wakelock**: toggles only on actual edges of `(wakelockEnabled &&
  isStreaming)` instead of being re-asserted on every link notify (RSSI poll
  every 2 s).

### Branching / duplication
- New `widgets/dialogs.dart` (`showTextPrompt`, `showDeleteConfirm`)
  replaces 5 near-identical dialogs across the live/session screens.
- New `utils/format.dart` replaces 3 formatter copies; `parseJsonColumn`
  unifies the 3 JSON-list-with-fallback parsers; the unreachable legacy
  session-label fallback is deleted.
- `BluetoothIndicator` takes `BtLinkState` + `AvailabilityState` directly
  (8 derived bools deleted); new `BleLinkManager.linkBusy` replaces the
  `DevicesTab` derivation. Mapping verified 1:1 — no indication state lost.
- `ForceUnit.fromRaw` delegates to `multiplierFromRaw`; `subscribeToAdcFeed`
  flattened to guard-continue.

### Bug surface
- Decoder drops short/malformed ADC packets instead of throwing `RangeError`
  in release builds (asserts are stripped); regression test added.
- Graph label-paragraph cache bounded (native-resource leak over long
  sessions).
- Dead code removed: `loadMockDataFile`, `_packSampleList`, `btGattId`;
  stale "AC RMS" doc fixed.

## Verification
- `flutter analyze`: clean.
- `flutter test`: 95/95 pass (94 existing + 1 new decoder regression test).
- BLE indication equivalence audit (old bools ⇔ `BtLinkState` projection)
  posted in the PR discussion.