### PR TITLE
Remove dead code, drop peakForceChannel, add DataHub.generation

### DIFF
--- a/lib/models/bucket_series.dart
+++ b/lib/models/bucket_series.dart
@@ -325,3 +325,48 @@ void foldBucketRange(
   scanExact(start, bFirst * bs);
   scanExact(bLastEx * bs, end);
 }
+
+/// Exact (min, max) of a series over the sample window `[start, end)`, or
+/// null when the window yields no value: buckets fully inside the window
+/// contribute their precomputed aggregates (via [foldBucketRange]); the
+/// partial head/tail portions are scanned per-sample through [sampleAt]
+/// (NaN = skip, e.g. gap-edge samples of a first-difference series).
+///
+/// [sampleAt] must evaluate the SAME series [buckets] aggregates and in the
+/// same (raw) space, so bucket bounds and scanned samples fold together.
+/// Affine display maps (tare offset, unit scale) are applied by the caller to
+/// the two returned bounds only.
+(double, double)? windowedExtremes(
+  BucketSeries buckets,
+  int start,
+  int end,
+  double Function(int sampleIndex) sampleAt,
+) {
+  double mn = double.infinity;
+  double mx = double.negativeInfinity;
+  bool found = false;
+
+  void fold(double v) {
+    if (v < mn) mn = v;
+    if (v > mx) mx = v;
+    found = true;
+  }
+
+  foldBucketRange(
+    buckets,
+    start,
+    end,
+    foldBucket: (bMin, bMax) {
+      fold(bMin.toDouble());
+      fold(bMax.toDouble());
+    },
+    scanExact: (from, to) {
+      for (int i = from; i < to; i++) {
+        final v = sampleAt(i);
+        if (v.isNaN) continue;
+        fold(v);
+      }
+    },
+  );
+  return found ? (mn, mx) : null;
+}

--- a/lib/models/force_unit.dart
+++ b/lib/models/force_unit.dart
@@ -1,16 +1,15 @@
 /// Supported force and electrical display units.
 enum ForceUnit {
-  kN('kN', 'Kilonewtons', true),
-  lbf('lbf', 'Pounds-force', true),
-  kgf('kgf', 'Kilogram-force', true),
-  n('N', 'Newtons', true),
-  mV('mV', 'Raw Voltage', false),
-  raw('Raw', 'ADC Counts', false);
+  kN('kN', 'Kilonewtons'),
+  lbf('lbf', 'Pounds-force'),
+  kgf('kgf', 'Kilogram-force'),
+  n('N', 'Newtons'),
+  mV('mV', 'Raw Voltage'),
+  raw('Raw', 'ADC Counts');
 
-  const ForceUnit(this.symbol, this.label, this.isForce);
+  const ForceUnit(this.symbol, this.label);
   final String symbol;
   final String label;
-  final bool isForce;
 
   /// Hardware constant for raw to mV conversion (1.2V Vref, 101x Gain, 24-bit bipolar ADC)
   static const double rawToMvMultiplier = (1.2 / 8388608.0 / 101.0) * 1000.0;
@@ -23,9 +22,6 @@ enum ForceUnit {
     ForceUnit.mV => 1.0, // Fallback, not typically used
     ForceUnit.raw => 1.0, // Fallback, not typically used
   };
-
-  /// Convert a value in kgf (the device's native calibrated unit) to this unit.
-  double fromKgf(double kgf) => kgf * _kgfMultiplier;
 
   /// Convert a raw ADC value to this unit, given the kgf/raw slope
   double fromRaw(double rawTared, double calibrationSlope) =>
@@ -42,28 +38,26 @@ enum ForceUnit {
     return calibrationSlope * _kgfMultiplier;
   }
 
-  /// Format a [value] (already in this unit) with an explicit sign and a
-  /// trailing [suffix] (e.g. the unit symbol, optionally with "/s").
-  String _formatValue(double value, String suffix) {
+  /// Format a [value] (already in this unit) with an explicit sign, and a
+  /// trailing [suffix] when given (e.g. the unit symbol). When [padded], the
+  /// number is left-padded for column alignment in the stats table.
+  String _formatValue(double value, String suffix, {bool padded = true}) {
     final sign = value < 0 ? '-' : '+';
     final decimals = this == ForceUnit.mV ? 4 : (this == ForceUnit.raw ? 0 : 3);
-    final padding = this == ForceUnit.mV ? 8 : (this == ForceUnit.raw ? 6 : 7);
-    final numStr = value.abs().toStringAsFixed(decimals).padLeft(padding);
-    return '$sign$numStr $suffix';
+    var numStr = value.abs().toStringAsFixed(decimals);
+    if (padded) {
+      final padding = this == ForceUnit.mV
+          ? 8
+          : (this == ForceUnit.raw ? 6 : 7);
+      numStr = numStr.padLeft(padding);
+    }
+    return suffix.isEmpty ? '$sign$numStr' : '$sign$numStr $suffix';
   }
 
   /// Format a [value] (already in this unit) with an explicit sign, without
   /// the unit suffix, and without extra padding. Ideal for constrained layouts.
-  String formatValueOnly(double value) {
-    final sign = value < 0 ? '-' : '+';
-    final decimals = this == ForceUnit.mV ? 4 : (this == ForceUnit.raw ? 0 : 3);
-    final numStr = value.abs().toStringAsFixed(decimals);
-    return '$sign$numStr';
-  }
+  String formatValueOnly(double value) => _formatValue(value, '', padded: false);
 
   /// Format a value (already in this unit) for display.
   String format(double value) => _formatValue(value, symbol);
-
-  /// Format a rate of change (derivative) in this unit for display.
-  String formatRate(double value) => _formatValue(value, '$symbol/s');
 }

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -42,6 +42,24 @@ class _DevicesTabState extends State<DevicesTab> {
     });
   }
 
+  /// Run a connect attempt, surfacing a failure as a snackbar naming
+  /// [deviceName]. Connect buttons are already disabled while a link is
+  /// busy, so this only handles the rejected attempt itself.
+  Future<void> _connectWithFeedback(
+    Future<void> Function() connect,
+    String deviceName,
+  ) async {
+    try {
+      await connect();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to connect to $deviceName.')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final bt = context.watch<BleLinkManager>();
@@ -182,21 +200,10 @@ class _DevicesTabState extends State<DevicesTab> {
                   // second Connect click right after Disconnect.
                   onPressed: bt.linkBusy
                       ? null
-                      : () async {
-                          try {
-                            await bt.connectToDevice(device.deviceId);
-                          } catch (e) {
-                            if (context.mounted) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content: Text(
-                                    'Failed to connect to ${device.name ?? 'device'}.',
-                                  ),
-                                ),
-                              );
-                            }
-                          }
-                        },
+                      : () => _connectWithFeedback(
+                          () => bt.connectToDevice(device.deviceId),
+                          device.name ?? 'device',
+                        ),
                   child: Text(
                     device.deviceId == coolingDownDeviceId
                         ? 'Please wait…'
@@ -220,21 +227,10 @@ class _DevicesTabState extends State<DevicesTab> {
               trailing: FilledButton(
                 onPressed: bt.linkBusy
                     ? null
-                    : () async {
-                        try {
-                          await bt.connectToDemoDevice();
-                        } catch (e) {
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text(
-                                  'Failed to connect to Demo Device.',
-                                ),
-                              ),
-                            );
-                          }
-                        }
-                      },
+                    : () => _connectWithFeedback(
+                        bt.connectToDemoDevice,
+                        'Demo Device',
+                      ),
                 child: const Text('Connect'),
               ),
             ),

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -84,9 +84,9 @@ class _LiveTabState extends State<LiveTab> {
   _LiveDataSource? _dataSource;
   DataHub? _hub;
 
-  /// Last seen hub sample count; a decrease means the hub was cleared for a
-  /// new device stream (see [RecordingController]).
-  int _lastTotalSamples = 0;
+  /// Last seen hub generation; a change means the hub was cleared for a new
+  /// device stream (see [RecordingController]).
+  int _lastGeneration = 0;
 
   @override
   void didChangeDependencies() {
@@ -98,14 +98,14 @@ class _LiveTabState extends State<LiveTab> {
     if (_hub != hub) {
       _hub?.removeListener(_onHubChanged);
       _hub = hub;
-      _lastTotalSamples = hub.totalSamples;
+      _lastGeneration = hub.generation;
       hub.addListener(_onHubChanged);
       _dataSource?.dispose();
       _dataSource = _LiveDataSource(hub);
     }
   }
 
-  /// A hub reset (its sample count only ever increases otherwise) means a new
+  /// A hub reset (its generation bumped by [DataHub.clear]) means a new
   /// device stream just cleared the previous trace: drop any stale pan/zoom
   /// window and follow the fresh live edge. Without this, a user-panned
   /// (non-live) window survives the disconnect and
@@ -113,11 +113,10 @@ class _LiveTabState extends State<LiveTab> {
   /// now-empty buffer (inverted clamp limits -> throw).
   void _onHubChanged() {
     final hub = _hub!;
-    final total = hub.totalSamples;
-    if (total < _lastTotalSamples) {
-      _graphCtrl.goLive(totalSamples: total, oldestSample: 0);
+    if (hub.generation != _lastGeneration) {
+      _lastGeneration = hub.generation;
+      _graphCtrl.goLive(totalSamples: hub.totalSamples, oldestSample: 0);
     }
-    _lastTotalSamples = total;
   }
 
   @override

--- a/lib/screens/settings_tab.dart
+++ b/lib/screens/settings_tab.dart
@@ -16,7 +16,6 @@ class SettingsTab extends StatelessWidget {
   Widget build(BuildContext context) {
     final settings = context.watch<AppSettings>();
     final bt = context.watch<BleLinkManager>();
-    const bool normalDoubleCmp = identical(double.nan, double.nan);
     const bool dart2wasm = bool.fromEnvironment('dart.tool.dart2wasm');
 
     return SafeArea(
@@ -129,16 +128,10 @@ class SettingsTab extends StatelessWidget {
                   targetInfo += ' (${dart2wasm ? "WASM" : "JS"})';
                 }
 
-                String jsCmpWarning = '';
-                if (!normalDoubleCmp && kIsWeb) {
-                  jsCmpWarning = '\nWarning: JS style cmp(double) active';
-                }
-
                 return Text(
                   'Dynamite App v$version\n'
                   'Build Mode: $buildMode\n'
-                  '$targetInfo'
-                  '$jsCmpWarning',
+                  '$targetInfo',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -5,7 +5,6 @@ import 'package:universal_ble/universal_ble.dart';
 
 import 'app_events.dart';
 import 'bt_device_config.dart';
-// ignore: unused_import
 import 'demo_signal_source.dart';
 import 'mockble.dart';
 
@@ -67,7 +66,6 @@ class DeviceLink {
   String deviceId;
   String name = '';
   BtLinkState state = BtLinkState.idle;
-  final List<BleService> services = [];
 
   /// Most recent live RSSI (dBm) for the connected device, polled while
   /// connected. Null until the first successful read (and after reset). This is
@@ -93,7 +91,6 @@ class DeviceLink {
     name = '';
     state = BtLinkState.idle;
     rssi = null;
-    services.clear();
   }
 
   bool get isDemoDevice => deviceId == 'demo_device';
@@ -107,7 +104,6 @@ class DeviceLink {
     this.name = name;
     state = BtLinkState.cooldown;
     rssi = null;
-    services.clear();
   }
 }
 
@@ -167,9 +163,6 @@ class BleLinkManager extends ChangeNotifier {
   final List<BleDevice> _devices = [];
   List<BleDevice> get devices => _devices;
 
-  /// Discovered services for the active link.
-  List<BleService> get services => _link.services;
-
   bool _isScanning = false;
   bool get isScanning => _isScanning;
 
@@ -182,16 +175,6 @@ class BleLinkManager extends ChangeNotifier {
   /// [DeviceLink] directly instead of via these singular getters.
   final DeviceLink _link = DeviceLink();
   DeviceLink get link => _link;
-
-  /// True between a connect request and the connection result (success or
-  /// failure). Used purely for UI status; never assume the device is usable
-  /// while this is true.
-  bool get isConnecting => _link.isConnecting;
-
-  /// True while the GATT link is up but post-connect setup (service discovery +
-  /// ADC subscription) hasn't finished. The device is NOT usable yet — the UI
-  /// shows "Setting up…". Distinct from [isStreaming].
-  bool get isSettingUp => _link.state == BtLinkState.connected;
 
   /// The single "usable / connected" truth: link up AND the ADC feed is
   /// streaming. Every screen keys its connected UI off this.
@@ -348,7 +331,6 @@ class BleLinkManager extends ChangeNotifier {
     }
     await disconnectSelectedDevice();
     _devices.clear();
-    _link.services.clear();
     _isScanning = true;
     await UniversalBle.startScan(
       scanFilter: ScanFilter(withServices: [btServiceId]),
@@ -528,8 +510,7 @@ class BleLinkManager extends ChangeNotifier {
         }
         final discovered = await UniversalBle.discoverServices(deviceId);
         if (_setupSuperseded(gen, deviceId)) return;
-        _link.services.addAll(discovered);
-        for (final srv in _link.services) {
+        for (final srv in discovered) {
           if (srv.uuid == btServiceId) {
             await subscribeToAdcFeed(srv);
             if (_setupSuperseded(gen, deviceId)) return;

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -77,6 +77,12 @@ class DataHub extends ChangeNotifier {
   int totalSamples = 0;
   DeviceCalibration deviceCalibration = DeviceCalibration();
 
+  /// Monotonic counter bumped by [clear]. Lets observers distinguish "same
+  /// stream, more data" from "a new stream reset the hub" explicitly, instead
+  /// of inferring the reset from [totalSamples] decreasing.
+  int _generation = 0;
+  int get generation => _generation;
+
   /// Sample ranges lost to dropped BLE packets (absolute indices). The ring
   /// buffer holds the held previous value across these ranges.
   final GapList gaps = GapList();
@@ -111,6 +117,7 @@ class DataHub extends ChangeNotifier {
   void clear() {
     _tareCount = 0;
     totalSamples = 0;
+    _generation++;
     gaps.clear();
     for (int i = 0; i < numAdcChannels; ++i) {
       rawMax[i] = _noMaxYet;
@@ -209,7 +216,7 @@ class DataHub extends ChangeNotifier {
   /// a gap this returns the held (last real) value; check [liveEdgeIsGap] to
   /// mark it stale in the UI.
   double currentForce(int adcChannel, ForceUnit unit) {
-    if (adcChannel < 0 || adcChannel >= numAdcChannels) return 0;
+    assert(adcChannel >= 0 && adcChannel < numAdcChannels);
     final rawTared = _currentRaw[adcChannel] - tare[adcChannel];
     return unit.fromRaw(rawTared.toDouble(), deviceCalibration.slope);
   }
@@ -217,9 +224,8 @@ class DataHub extends ChangeNotifier {
   /// Get peak force for a given ADC channel in the specified unit. Returns 0
   /// before the first sample arrives ([rawMax] still holds its sentinel).
   double peakForce(int adcChannel, ForceUnit unit) {
-    if (adcChannel < 0 || adcChannel >= numAdcChannels || totalSamples == 0) {
-      return 0;
-    }
+    assert(adcChannel >= 0 && adcChannel < numAdcChannels);
+    if (totalSamples == 0) return 0;
     final rawTared = rawMax[adcChannel] - tare[adcChannel];
     return unit.fromRaw(rawTared.toDouble(), deviceCalibration.slope);
   }
@@ -227,18 +233,16 @@ class DataHub extends ChangeNotifier {
   /// Get minimum (most negative) force for a given ADC channel in the
   /// specified unit. Returns 0 before the first sample arrives.
   double minForce(int adcChannel, ForceUnit unit) {
-    if (adcChannel < 0 || adcChannel >= numAdcChannels || totalSamples == 0) {
-      return 0;
-    }
+    assert(adcChannel >= 0 && adcChannel < numAdcChannels);
+    if (totalSamples == 0) return 0;
     final rawTared = rawMin[adcChannel] - tare[adcChannel];
     return unit.fromRaw(rawTared.toDouble(), deviceCalibration.slope);
   }
 
   /// Get the instantaneous derivative (first-difference) for a channel in unit/s.
   double currentDerivative(int adcChannel, ForceUnit unit) {
-    if (adcChannel < 0 || adcChannel >= numAdcChannels || totalSamples < 2) {
-      return 0;
-    }
+    assert(adcChannel >= 0 && adcChannel < numAdcChannels);
+    if (totalSamples < 2) return 0;
 
     // A held value on either side would fabricate a flat or spiking
     // derivative; report 0 across gap edges instead.

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -4,6 +4,11 @@ import 'package:flutter/foundation.dart';
 
 part 'database.g.dart';
 
+/// JSON-encoded default for the session `visibleChannels` column: every
+/// channel shown. Kept as a literal because drift column defaults must be
+/// const — it must stay in sync with `nwNumAdcChan` (currently 4).
+const String kAllChannelsVisibleJson = '[true,true,true,true]';
+
 /// Table for recorded measurement sessions.
 class Sessions extends Table {
   IntColumn get id => integer().autoIncrement()();
@@ -16,7 +21,6 @@ class Sessions extends Table {
       text().withDefault(const Constant('["Load Cell 1","Load Cell 2"]'))();
   TextColumn get tares => text().withDefault(const Constant('[]'))();
   RealColumn get peakForceRaw => real().withDefault(const Constant(0.0))();
-  IntColumn get peakForceChannel => integer().withDefault(const Constant(0))();
   RealColumn get calibrationSlope =>
       real().withDefault(const Constant(0.0001117587))();
   IntColumn get calibrationOffset => integer().withDefault(const Constant(0))();
@@ -32,7 +36,7 @@ class Sessions extends Table {
   /// list. Initialized from the live view's channel selection at recording
   /// time; afterwards it is per-session and independent of the live view.
   TextColumn get visibleChannels =>
-      text().withDefault(const Constant('[true,true,true,true]'))();
+      text().withDefault(const Constant(kAllChannelsVisibleJson))();
 }
 
 class SessionChunks extends Table {
@@ -75,7 +79,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   /// DEV ONLY: any schema version bump wipes the database and recreates it
   /// from scratch. No user data is migrated. Replace with real per-version
@@ -115,8 +119,7 @@ class AppDatabase extends _$AppDatabase {
     required String tares,
     required double calibrationSlope,
     required int calibrationOffset,
-    required String notes,
-    String visibleChannels = '[true,true,true,true]',
+    String visibleChannels = kAllChannelsVisibleJson,
   }) {
     return into(sessions).insert(
       SessionsCompanion.insert(
@@ -128,7 +131,6 @@ class AppDatabase extends _$AppDatabase {
         tares: Value(tares),
         calibrationSlope: Value(calibrationSlope),
         calibrationOffset: Value(calibrationOffset),
-        notes: Value(notes),
         isCompleted: const Value(false),
         visibleChannels: Value(visibleChannels),
       ),
@@ -143,7 +145,6 @@ class AppDatabase extends _$AppDatabase {
     required int sampleCount,
     required int durationMs,
     required double peakForceRaw,
-    required int peakForceChannel,
     String gaps = '[]',
   }) {
     return _updateSession(
@@ -152,7 +153,6 @@ class AppDatabase extends _$AppDatabase {
         sampleCount: Value(sampleCount),
         durationMs: Value(durationMs),
         peakForceRaw: Value(peakForceRaw),
-        peakForceChannel: Value(peakForceChannel),
         isCompleted: const Value(true),
         gaps: Value(gaps),
       ),

--- a/lib/services/database.g.dart
+++ b/lib/services/database.g.dart
@@ -112,18 +112,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     requiredDuringInsert: false,
     defaultValue: const Constant(0.0),
   );
-  static const VerificationMeta _peakForceChannelMeta = const VerificationMeta(
-    'peakForceChannel',
-  );
-  @override
-  late final GeneratedColumn<int> peakForceChannel = GeneratedColumn<int>(
-    'peak_force_channel',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0),
-  );
   static const VerificationMeta _calibrationSlopeMeta = const VerificationMeta(
     'calibrationSlope',
   );
@@ -205,7 +193,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
-    defaultValue: const Constant('[true,true,true,true]'),
+    defaultValue: const Constant(kAllChannelsVisibleJson),
   );
   @override
   List<GeneratedColumn> get $columns => [
@@ -218,7 +206,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     channelLabels,
     tares,
     peakForceRaw,
-    peakForceChannel,
     calibrationSlope,
     calibrationOffset,
     notes,
@@ -298,15 +285,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
         peakForceRaw.isAcceptableOrUnknown(
           data['peak_force_raw']!,
           _peakForceRawMeta,
-        ),
-      );
-    }
-    if (data.containsKey('peak_force_channel')) {
-      context.handle(
-        _peakForceChannelMeta,
-        peakForceChannel.isAcceptableOrUnknown(
-          data['peak_force_channel']!,
-          _peakForceChannelMeta,
         ),
       );
     }
@@ -412,10 +390,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
         DriftSqlType.double,
         data['${effectivePrefix}peak_force_raw'],
       )!,
-      peakForceChannel: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}peak_force_channel'],
-      )!,
       calibrationSlope: attachedDatabase.typeMapping.read(
         DriftSqlType.double,
         data['${effectivePrefix}calibration_slope'],
@@ -463,7 +437,6 @@ class Session extends DataClass implements Insertable<Session> {
   final String channelLabels;
   final String tares;
   final double peakForceRaw;
-  final int peakForceChannel;
   final double calibrationSlope;
   final int calibrationOffset;
   final String notes;
@@ -488,7 +461,6 @@ class Session extends DataClass implements Insertable<Session> {
     required this.channelLabels,
     required this.tares,
     required this.peakForceRaw,
-    required this.peakForceChannel,
     required this.calibrationSlope,
     required this.calibrationOffset,
     required this.notes,
@@ -509,7 +481,6 @@ class Session extends DataClass implements Insertable<Session> {
     map['channel_labels'] = Variable<String>(channelLabels);
     map['tares'] = Variable<String>(tares);
     map['peak_force_raw'] = Variable<double>(peakForceRaw);
-    map['peak_force_channel'] = Variable<int>(peakForceChannel);
     map['calibration_slope'] = Variable<double>(calibrationSlope);
     map['calibration_offset'] = Variable<int>(calibrationOffset);
     map['notes'] = Variable<String>(notes);
@@ -531,7 +502,6 @@ class Session extends DataClass implements Insertable<Session> {
       channelLabels: Value(channelLabels),
       tares: Value(tares),
       peakForceRaw: Value(peakForceRaw),
-      peakForceChannel: Value(peakForceChannel),
       calibrationSlope: Value(calibrationSlope),
       calibrationOffset: Value(calibrationOffset),
       notes: Value(notes),
@@ -557,7 +527,6 @@ class Session extends DataClass implements Insertable<Session> {
       channelLabels: serializer.fromJson<String>(json['channelLabels']),
       tares: serializer.fromJson<String>(json['tares']),
       peakForceRaw: serializer.fromJson<double>(json['peakForceRaw']),
-      peakForceChannel: serializer.fromJson<int>(json['peakForceChannel']),
       calibrationSlope: serializer.fromJson<double>(json['calibrationSlope']),
       calibrationOffset: serializer.fromJson<int>(json['calibrationOffset']),
       notes: serializer.fromJson<String>(json['notes']),
@@ -580,7 +549,6 @@ class Session extends DataClass implements Insertable<Session> {
       'channelLabels': serializer.toJson<String>(channelLabels),
       'tares': serializer.toJson<String>(tares),
       'peakForceRaw': serializer.toJson<double>(peakForceRaw),
-      'peakForceChannel': serializer.toJson<int>(peakForceChannel),
       'calibrationSlope': serializer.toJson<double>(calibrationSlope),
       'calibrationOffset': serializer.toJson<int>(calibrationOffset),
       'notes': serializer.toJson<String>(notes),
@@ -601,7 +569,6 @@ class Session extends DataClass implements Insertable<Session> {
     String? channelLabels,
     String? tares,
     double? peakForceRaw,
-    int? peakForceChannel,
     double? calibrationSlope,
     int? calibrationOffset,
     String? notes,
@@ -619,7 +586,6 @@ class Session extends DataClass implements Insertable<Session> {
     channelLabels: channelLabels ?? this.channelLabels,
     tares: tares ?? this.tares,
     peakForceRaw: peakForceRaw ?? this.peakForceRaw,
-    peakForceChannel: peakForceChannel ?? this.peakForceChannel,
     calibrationSlope: calibrationSlope ?? this.calibrationSlope,
     calibrationOffset: calibrationOffset ?? this.calibrationOffset,
     notes: notes ?? this.notes,
@@ -649,9 +615,6 @@ class Session extends DataClass implements Insertable<Session> {
       peakForceRaw: data.peakForceRaw.present
           ? data.peakForceRaw.value
           : this.peakForceRaw,
-      peakForceChannel: data.peakForceChannel.present
-          ? data.peakForceChannel.value
-          : this.peakForceChannel,
       calibrationSlope: data.calibrationSlope.present
           ? data.calibrationSlope.value
           : this.calibrationSlope,
@@ -684,7 +647,6 @@ class Session extends DataClass implements Insertable<Session> {
           ..write('channelLabels: $channelLabels, ')
           ..write('tares: $tares, ')
           ..write('peakForceRaw: $peakForceRaw, ')
-          ..write('peakForceChannel: $peakForceChannel, ')
           ..write('calibrationSlope: $calibrationSlope, ')
           ..write('calibrationOffset: $calibrationOffset, ')
           ..write('notes: $notes, ')
@@ -707,7 +669,6 @@ class Session extends DataClass implements Insertable<Session> {
     channelLabels,
     tares,
     peakForceRaw,
-    peakForceChannel,
     calibrationSlope,
     calibrationOffset,
     notes,
@@ -729,7 +690,6 @@ class Session extends DataClass implements Insertable<Session> {
           other.channelLabels == this.channelLabels &&
           other.tares == this.tares &&
           other.peakForceRaw == this.peakForceRaw &&
-          other.peakForceChannel == this.peakForceChannel &&
           other.calibrationSlope == this.calibrationSlope &&
           other.calibrationOffset == this.calibrationOffset &&
           other.notes == this.notes &&
@@ -749,7 +709,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
   final Value<String> channelLabels;
   final Value<String> tares;
   final Value<double> peakForceRaw;
-  final Value<int> peakForceChannel;
   final Value<double> calibrationSlope;
   final Value<int> calibrationOffset;
   final Value<String> notes;
@@ -767,7 +726,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     this.channelLabels = const Value.absent(),
     this.tares = const Value.absent(),
     this.peakForceRaw = const Value.absent(),
-    this.peakForceChannel = const Value.absent(),
     this.calibrationSlope = const Value.absent(),
     this.calibrationOffset = const Value.absent(),
     this.notes = const Value.absent(),
@@ -786,7 +744,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     this.channelLabels = const Value.absent(),
     this.tares = const Value.absent(),
     this.peakForceRaw = const Value.absent(),
-    this.peakForceChannel = const Value.absent(),
     this.calibrationSlope = const Value.absent(),
     this.calibrationOffset = const Value.absent(),
     this.notes = const Value.absent(),
@@ -805,7 +762,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     Expression<String>? channelLabels,
     Expression<String>? tares,
     Expression<double>? peakForceRaw,
-    Expression<int>? peakForceChannel,
     Expression<double>? calibrationSlope,
     Expression<int>? calibrationOffset,
     Expression<String>? notes,
@@ -824,7 +780,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
       if (channelLabels != null) 'channel_labels': channelLabels,
       if (tares != null) 'tares': tares,
       if (peakForceRaw != null) 'peak_force_raw': peakForceRaw,
-      if (peakForceChannel != null) 'peak_force_channel': peakForceChannel,
       if (calibrationSlope != null) 'calibration_slope': calibrationSlope,
       if (calibrationOffset != null) 'calibration_offset': calibrationOffset,
       if (notes != null) 'notes': notes,
@@ -845,7 +800,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     Value<String>? channelLabels,
     Value<String>? tares,
     Value<double>? peakForceRaw,
-    Value<int>? peakForceChannel,
     Value<double>? calibrationSlope,
     Value<int>? calibrationOffset,
     Value<String>? notes,
@@ -864,7 +818,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
       channelLabels: channelLabels ?? this.channelLabels,
       tares: tares ?? this.tares,
       peakForceRaw: peakForceRaw ?? this.peakForceRaw,
-      peakForceChannel: peakForceChannel ?? this.peakForceChannel,
       calibrationSlope: calibrationSlope ?? this.calibrationSlope,
       calibrationOffset: calibrationOffset ?? this.calibrationOffset,
       notes: notes ?? this.notes,
@@ -905,9 +858,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     if (peakForceRaw.present) {
       map['peak_force_raw'] = Variable<double>(peakForceRaw.value);
     }
-    if (peakForceChannel.present) {
-      map['peak_force_channel'] = Variable<int>(peakForceChannel.value);
-    }
     if (calibrationSlope.present) {
       map['calibration_slope'] = Variable<double>(calibrationSlope.value);
     }
@@ -944,7 +894,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
           ..write('channelLabels: $channelLabels, ')
           ..write('tares: $tares, ')
           ..write('peakForceRaw: $peakForceRaw, ')
-          ..write('peakForceChannel: $peakForceChannel, ')
           ..write('calibrationSlope: $calibrationSlope, ')
           ..write('calibrationOffset: $calibrationOffset, ')
           ..write('notes: $notes, ')
@@ -1247,7 +1196,6 @@ typedef $$SessionsTableCreateCompanionBuilder =
       Value<String> channelLabels,
       Value<String> tares,
       Value<double> peakForceRaw,
-      Value<int> peakForceChannel,
       Value<double> calibrationSlope,
       Value<int> calibrationOffset,
       Value<String> notes,
@@ -1267,7 +1215,6 @@ typedef $$SessionsTableUpdateCompanionBuilder =
       Value<String> channelLabels,
       Value<String> tares,
       Value<double> peakForceRaw,
-      Value<int> peakForceChannel,
       Value<double> calibrationSlope,
       Value<int> calibrationOffset,
       Value<String> notes,
@@ -1328,11 +1275,6 @@ class $$SessionsTableFilterComposer
 
   ColumnFilters<double> get peakForceRaw => $composableBuilder(
     column: $table.peakForceRaw,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<int> get peakForceChannel => $composableBuilder(
-    column: $table.peakForceChannel,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -1426,11 +1368,6 @@ class $$SessionsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<int> get peakForceChannel => $composableBuilder(
-    column: $table.peakForceChannel,
-    builder: (column) => ColumnOrderings(column),
-  );
-
   ColumnOrderings<double> get calibrationSlope => $composableBuilder(
     column: $table.calibrationSlope,
     builder: (column) => ColumnOrderings(column),
@@ -1513,11 +1450,6 @@ class $$SessionsTableAnnotationComposer
     builder: (column) => column,
   );
 
-  GeneratedColumn<int> get peakForceChannel => $composableBuilder(
-    column: $table.peakForceChannel,
-    builder: (column) => column,
-  );
-
   GeneratedColumn<double> get calibrationSlope => $composableBuilder(
     column: $table.calibrationSlope,
     builder: (column) => column,
@@ -1587,7 +1519,6 @@ class $$SessionsTableTableManager
                 Value<String> channelLabels = const Value.absent(),
                 Value<String> tares = const Value.absent(),
                 Value<double> peakForceRaw = const Value.absent(),
-                Value<int> peakForceChannel = const Value.absent(),
                 Value<double> calibrationSlope = const Value.absent(),
                 Value<int> calibrationOffset = const Value.absent(),
                 Value<String> notes = const Value.absent(),
@@ -1605,7 +1536,6 @@ class $$SessionsTableTableManager
                 channelLabels: channelLabels,
                 tares: tares,
                 peakForceRaw: peakForceRaw,
-                peakForceChannel: peakForceChannel,
                 calibrationSlope: calibrationSlope,
                 calibrationOffset: calibrationOffset,
                 notes: notes,
@@ -1625,7 +1555,6 @@ class $$SessionsTableTableManager
                 Value<String> channelLabels = const Value.absent(),
                 Value<String> tares = const Value.absent(),
                 Value<double> peakForceRaw = const Value.absent(),
-                Value<int> peakForceChannel = const Value.absent(),
                 Value<double> calibrationSlope = const Value.absent(),
                 Value<int> calibrationOffset = const Value.absent(),
                 Value<String> notes = const Value.absent(),
@@ -1643,7 +1572,6 @@ class $$SessionsTableTableManager
                 channelLabels: channelLabels,
                 tares: tares,
                 peakForceRaw: peakForceRaw,
-                peakForceChannel: peakForceChannel,
                 calibrationSlope: calibrationSlope,
                 calibrationOffset: calibrationOffset,
                 notes: notes,

--- a/lib/services/mockble.dart
+++ b/lib/services/mockble.dart
@@ -14,7 +14,6 @@ class MockBlePlatform extends UniversalBlePlatform {
   static const hwDelay = Duration(milliseconds: 200);
 
   MockBlePlatform._() {
-    _setupListeners();
     // Always have a synthetic feed available synchronously so [connect] never
     // blocks on file I/O (which would stall under a fake-async test clock).
     _mockData
@@ -248,10 +247,6 @@ class MockBlePlatform extends UniversalBlePlatform {
   @override
   Future<List<BleDevice>> getSystemDevices(List<String>? withServices) async {
     return ([]);
-  }
-
-  void _setupListeners() {
-    //onValueChange = (String deviceId, String characteristicId, Uint8List value) {};
   }
 
   /// Pack 4 channel values (24-bit signed) into the 12-byte wire sample.

--- a/lib/services/recording_controller.dart
+++ b/lib/services/recording_controller.dart
@@ -174,7 +174,7 @@ class RecordingController extends ChangeNotifier {
   /// finalization re-detects the latched error and surfaces it).
   void _onSamplesAppended(int startIdx, int count) {
     final writer = _sessionWriter;
-    if (!_sessionInProgress || writer == null || count <= 0) {
+    if (!_sessionInProgress || writer == null) {
       return;
     }
     if (writer.hasError) {

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -27,7 +27,6 @@ class SessionStorage {
     required String name,
     required List<String> channelLabels,
     required List<bool> visibleChannels,
-    String notes = '',
   }) async {
     // Snapshot the tare once; the same values are persisted below and used by
     // the writer's peak scan, so stored peaks, stored tares and playback can
@@ -44,7 +43,6 @@ class SessionStorage {
       tares: jsonEncode(tare.toList()),
       calibrationSlope: dataHub.deviceCalibration.slope,
       calibrationOffset: dataHub.deviceCalibration.offset,
-      notes: notes,
       visibleChannels: jsonEncode(visibleChannels),
     );
 
@@ -68,7 +66,6 @@ class SessionStorage {
       // A session that captured no samples leaves peakRaw at -infinity; that
       // must not reach the DB (or the session list's peak display).
       peakForceRaw: writer.peakRaw.isFinite ? writer.peakRaw : 0.0,
-      peakForceChannel: writer.peakChannel,
       gaps: writer.gaps.toJson(),
     );
 
@@ -105,7 +102,6 @@ class SessionStorage {
         sampleCount: agg.samples,
         durationMs: (agg.samples * 1000) ~/ session.sampleRate,
         peakForceRaw: agg.peakRaw,
-        peakForceChannel: agg.peakChannel,
       );
     }
   }
@@ -207,7 +203,6 @@ class _ChunkAggregate {
   /// Callers persisting this must guard the no-samples case (see
   /// [SessionStorage.finalizeSession]).
   double peakRaw = double.negativeInfinity;
-  int peakChannel = 0;
 
   void scan(Uint8List bytes, Float64List tare) {
     final data = ByteData.sublistView(bytes);
@@ -220,7 +215,6 @@ class _ChunkAggregate {
         final val = raw - (ch < tare.length ? tare[ch] : 0);
         if (val > peakRaw) {
           peakRaw = val.toDouble();
-          peakChannel = ch;
         }
       }
     }
@@ -347,7 +341,6 @@ class LiveSessionWriter {
   int _chunkIndex = 0;
   int totalSamplesRecorded = 0;
   double peakRaw = 0.0;
-  int peakChannel = 0;
 
   /// Dropped-sample ranges accumulated across the recording, relative to the
   /// session's first sample. Persisted by [SessionStorage.finalizeSession].
@@ -437,7 +430,6 @@ class LiveSessionWriter {
       _agg.scan(bytes, tare);
       totalSamplesRecorded = _agg.samples;
       peakRaw = _agg.peakRaw;
-      peakChannel = _agg.peakChannel;
 
       _staging.add(bytes);
 

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -645,26 +645,6 @@ class GraphController extends ChangeNotifier {
   /// Whether we're following the live edge (auto-scroll with new data).
   bool get isLive => _viewport is GraphLive;
 
-  /// When in live mode and zoomed in, the fixed span shown from the right
-  /// edge. Null means "show all data" (auto-expanding up to buffer capacity).
-  int? get liveSpan => switch (_viewport) {
-    GraphLive(:final span) => span,
-    GraphWindow() => null,
-  };
-
-  /// Start of the visible window in samples; 0 in live mode (the live range
-  /// is derived by [effectiveRange], never stored).
-  int get viewStart => switch (_viewport) {
-    GraphWindow(:final start) => start,
-    GraphLive() => 0,
-  };
-
-  /// End of the visible window in samples; null in live mode.
-  int? get viewEnd => switch (_viewport) {
-    GraphWindow(:final end) => end,
-    GraphLive() => null,
-  };
-
   /// Snap to live mode -- follow the right edge.
   /// If [span] is provided, locks to that scrolling window.
   /// If not provided, derives the lock from the current window (or keeps the
@@ -705,12 +685,6 @@ class GraphController extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Set a specific visible window (exits live mode).
-  void setWindow(int start, int end) {
-    _viewport = GraphWindow(start, end);
-    notifyListeners();
-  }
-
   /// Get the effective visible range given total data size.
   (int start, int end) effectiveRange(
     int totalSamples,
@@ -727,17 +701,6 @@ class GraphController extends ChangeNotifier {
       case GraphWindow(:final start, :final end):
         return (start, end.clamp(start + 1, totalSamples));
     }
-  }
-
-  /// Whether the current window covers all available data.
-  ///
-  /// Every plot renders in one of two modes:
-  ///   * squeeze -- the window spans the whole history, so the x-mapping of
-  ///     every sample recompresses as new data arrives;
-  ///   * slide   -- a fixed-span window slides over the data.
-  bool isSqueeze(int totalSamples, int oldestSample) {
-    final (s, e) = effectiveRange(totalSamples, oldestSample);
-    return e - s >= totalSamples - oldestSample;
   }
 
   /// Apply the window [newStart, newStart + span), clamped to the available
@@ -872,12 +835,6 @@ class GraphController extends ChangeNotifier {
       oldestSample: oldestSample,
     );
   }
-
-  /// Reset to show all data in live mode (fully zoomed out).
-  void reset() {
-    _viewport = const GraphLive();
-    notifyListeners();
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -960,6 +917,11 @@ class BakePump implements Listenable {
 // Minimap
 // ---------------------------------------------------------------------------
 
+/// Span of samples the minimap squeezes into its width: all available data,
+/// clamped below by the controller's minimum live span.
+int minimapSpan(int totalSamples, int oldestSample, int minLiveSpan) =>
+    math.max(totalSamples - oldestSample, minLiveSpan);
+
 class Minimap extends StatefulWidget {
   final GraphDataSource dataSource;
   final AppSettings settings;
@@ -991,10 +953,6 @@ class _MinimapState extends State<Minimap> {
     super.dispose();
   }
 
-  /// Span of the samples the minimap squeezes into its width.
-  int _mapSpan(int totalSamples, int oldestSample) =>
-      math.max(totalSamples - oldestSample, widget.graphCtrl.minLiveSpan);
-
   void _onMinimapTap(TapDownDetails d, double graphWidth) {
     final totalSamples = widget.dataSource.totalSamples;
     if (totalSamples == 0 || graphWidth <= 0) return;
@@ -1003,7 +961,11 @@ class _MinimapState extends State<Minimap> {
       0.0,
       1.0,
     );
-    final mapSpan = _mapSpan(totalSamples, oldestSample);
+    final mapSpan = minimapSpan(
+      totalSamples,
+      oldestSample,
+      widget.graphCtrl.minLiveSpan,
+    );
     final mapStart = totalSamples - mapSpan;
     widget.graphCtrl.centerOn(
       mapStart + (frac * mapSpan).round(),
@@ -1017,7 +979,9 @@ class _MinimapState extends State<Minimap> {
     final totalSamples = widget.dataSource.totalSamples;
     if (totalSamples == 0 || graphWidth <= 0) return;
     final oldestSample = widget.dataSource.oldestSample;
-    final samplesPerPixel = _mapSpan(totalSamples, oldestSample) / graphWidth;
+    final samplesPerPixel =
+        minimapSpan(totalSamples, oldestSample, widget.graphCtrl.minLiveSpan) /
+        graphWidth;
     widget.graphCtrl.pan(
       (d.delta.dx * samplesPerPixel).round(),
       totalSamples,
@@ -1113,7 +1077,7 @@ class _MinimapPainter extends CustomPainter {
     if (totalSamples == 0) return;
 
     final oldestSample = _data.oldestSample;
-    final mapSpan = math.max(totalSamples - oldestSample, _ctrl.minLiveSpan);
+    final mapSpan = minimapSpan(totalSamples, oldestSample, _ctrl.minLiveSpan);
     final mapStart = totalSamples - mapSpan;
 
     final activeIndices = _activeChannels;
@@ -2506,11 +2470,12 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
   YAxisRange computeYRange(int viewStart, int viewEnd) {
     // Compute data min/max across active channels in visible window (raw,
     // tare-subtracted) so the noise floor stays a raw-count threshold, then
-    // convert to display units. [foldBucketRange] folds full buckets from
+    // convert to display units. [windowedExtremes] folds full buckets from
     // the precomputed aggregates (exact for min/max) and per-sample scans
     // only the partial head/tail, so the cost is O(window / bucketSize).
     final oldestSample = _data.oldestSample;
     final totalSamples = _data.totalSamples;
+    final bufferCap = _data.bufferCapacity;
     double rawMax = 0;
     double rawMin = 0;
     bool hasData = false;
@@ -2519,34 +2484,24 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
       final s = _data.channel(ch);
       final line = s.data;
       if (line.isEmpty) continue;
-      final tare = s.tare;
-      final bufferCap = _data.bufferCapacity;
       final sScanStart = math.max(viewStart, oldestSample);
       final sScanEnd = math.min(viewEnd, totalSamples);
       if (sScanStart >= sScanEnd) continue;
 
-      void fold(double v) {
-        if (!hasData || v > rawMax) rawMax = v;
-        if (!hasData || v < rawMin) rawMin = v;
-        hasData = true;
-      }
-
       // Gap samples hold a previous real value, so they can never extend
-      // the range: no exclusion needed on either path.
-      foldBucketRange(
+      // the range: no exclusion needed.
+      final ext = windowedExtremes(
         s.buckets,
         sScanStart,
         sScanEnd,
-        foldBucket: (bMin, bMax) {
-          fold((bMin - tare).toDouble());
-          fold((bMax - tare).toDouble());
-        },
-        scanExact: (from, to) {
-          for (int i = from; i < to; i++) {
-            fold((line[i % bufferCap] - tare).toDouble());
-          }
-        },
+        (i) => line[i % bufferCap].toDouble(),
       );
+      if (ext == null) continue;
+      final lo = ext.$1 - s.tare;
+      final hi = ext.$2 - s.tare;
+      if (!hasData || hi > rawMax) rawMax = hi;
+      if (!hasData || lo < rawMin) rawMin = lo;
+      hasData = true;
     }
 
     // Enforce a minimum visible range (noise floor) so the graph isn't degenerate
@@ -2590,18 +2545,24 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
   @override
   int get firstSampleOffset => 1; // first difference needs sample j-1
 
-  /// Per-sample first difference in display units per second. A held value
-  /// on either side of the difference would fabricate a flat or spiking
-  /// derivative; break the polyline across gap edges instead.
-  double Function(int j) _sampleAt(int channel) {
+  /// Per-sample first difference in raw counts. A held value on either side
+  /// of the difference would fabricate a flat or spiking derivative; NaN
+  /// marks gap edges instead, breaking the polyline.
+  double Function(int j) _rawDiffAt(int channel) {
     final line = _data.channel(channel).data;
     final bufferCap = _data.bufferCapacity;
     final gaps = _data.gaps;
-    final scale = _displayScale;
     return (j) {
       if (gaps.contains(j) || gaps.contains(j - 1)) return double.nan;
-      return (line[j % bufferCap] - line[(j - 1) % bufferCap]) * scale;
+      return (line[j % bufferCap] - line[(j - 1) % bufferCap]).toDouble();
     };
+  }
+
+  /// Per-sample first difference in display units per second.
+  double Function(int j) _sampleAt(int channel) {
+    final rawDiff = _rawDiffAt(channel);
+    final scale = _displayScale;
+    return (j) => rawDiff(j) * scale; // NaN propagates
   }
 
   /// Raw-diff -> display-units-per-second multiplier.
@@ -2625,7 +2586,7 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
   @override
   YAxisRange computeYRange(int viewStart, int viewEnd) {
     // Derivative min/max (display units) across the visible window.
-    // [foldBucketRange] folds full buckets from the precomputed diff
+    // [windowedExtremes] folds full buckets from the precomputed diff
     // aggregates (exact for min/max) and per-sample scans only the partial
     // head/tail, so the cost is O(window / bucketSize).
     double dMin = 0;
@@ -2644,33 +2605,23 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
     for (final ch in _activeChannels) {
       if (_data.channel(ch).data.isEmpty) continue;
       if (startI >= endI) continue;
-      final valueAt = _sampleAt(ch);
-
-      void scanExact(int from, int to) {
-        for (int i = from; i < to; i++) {
-          final d = valueAt(i);
-          if (d.isNaN) continue;
-          fold(d);
-        }
-      }
 
       final buckets = _data.diffBuckets(ch);
       if (buckets == null) {
-        scanExact(startI, endI);
-      } else {
-        foldBucketRange(
-          buckets,
-          startI,
-          endI,
-          // Folding both scaled bounds keeps this correct under a negative
-          // scale.
-          foldBucket: (bMin, bMax) {
-            fold(bMin * scale);
-            fold(bMax * scale);
-          },
-          scanExact: scanExact,
-        );
+        // Exact-only fallback for sources without diff aggregates.
+        final valueAt = _sampleAt(ch);
+        for (int i = startI; i < endI; i++) {
+          final d = valueAt(i);
+          if (!d.isNaN) fold(d);
+        }
+        continue;
       }
+
+      final ext = windowedExtremes(buckets, startI, endI, _rawDiffAt(ch));
+      if (ext == null) continue;
+      // Folding both scaled bounds keeps this correct under a negative scale.
+      fold(ext.$1 * scale);
+      fold(ext.$2 * scale);
     }
     return _computeYRange(dMin, dMax);
   }

--- a/test/envelope_reduction_test.dart
+++ b/test/envelope_reduction_test.dart
@@ -178,4 +178,63 @@ void main() {
       bruteAndFold(all, 130, 134);
     });
   });
+
+  group('windowedExtremes', () {
+    BucketAccumulator ingest(List<int> all) {
+      final acc = BucketAccumulator(bucketSize: bs, numBuckets: numBuckets);
+      for (int i = 0; i < all.length; i++) {
+        acc.add(i, all[i]);
+      }
+      return acc;
+    }
+
+    test('matches brute-force min/max over random windows', () {
+      final all = randomData(134, 11);
+      final acc = ingest(all);
+      final rng = math.Random(12);
+      for (int i = 0; i < 200; i++) {
+        final start = 54 + rng.nextInt(70);
+        final end = math.min(start + 1 + rng.nextInt(134 - start), 134);
+        final ext = windowedExtremes(
+          acc.series,
+          start,
+          end,
+          (j) => all[j].toDouble(),
+        );
+        final window = all.sublist(start, end);
+        expect(ext, isNotNull);
+        expect(
+          ext!.$1,
+          window.reduce(math.min).toDouble(),
+          reason: '[$start, $end) min',
+        );
+        expect(
+          ext.$2,
+          window.reduce(math.max).toDouble(),
+          reason: '[$start, $end) max',
+        );
+      }
+    });
+
+    test('NaN samples are skipped on the scanned portions', () {
+      final all = randomData(40, 13);
+      final acc = ingest(all);
+      // Small window (exact-scan fallback) with one NaN injected.
+      final ext = windowedExtremes(
+        acc.series,
+        5,
+        12,
+        (j) => j == 7 ? double.nan : all[j].toDouble(),
+      );
+      final expected = [for (int j = 5; j < 12; j++) if (j != 7) all[j]];
+      expect(ext, isNotNull);
+      expect(ext!.$1, expected.reduce(math.min).toDouble());
+      expect(ext.$2, expected.reduce(math.max).toDouble());
+    });
+
+    test('returns null when no sample in the window yields a value', () {
+      final acc = ingest(randomData(30, 14));
+      expect(windowedExtremes(acc.series, 5, 8, (_) => double.nan), isNull);
+    });
+  });
 }

--- a/test/graph_controller_test.dart
+++ b/test/graph_controller_test.dart
@@ -6,14 +6,15 @@ import 'package:dynamite_app/widgets/graph_components.dart';
 /// Unit tests for the [GraphController] viewport state machine. It is pure
 /// Dart (no painting, no widgets): every mutation method takes the current data
 /// shape as plain ints, so we can drive it directly without a GraphDataSource.
+///
+/// The viewport itself is a sealed union ([GraphLive] / [GraphWindow]); the
+/// tests observe it exclusively through [GraphController.isLive] and
+/// [GraphController.effectiveRange], the same API the app consumes.
 void main() {
   group('GraphController initial state', () {
-    test('starts live with a null window and no locked span', () {
+    test('starts live', () {
       final ctrl = GraphController();
       expect(ctrl.isLive, isTrue);
-      expect(ctrl.viewEnd, isNull);
-      expect(ctrl.liveSpan, isNull);
-      expect(ctrl.viewStart, 0);
     });
 
     test('effectiveRange in live mode with no locked span shows all data', () {
@@ -23,7 +24,8 @@ void main() {
 
     test('a positive minLiveSpan locks the initial scrolling window', () {
       final ctrl = GraphController(minLiveSpan: 2000);
-      expect(ctrl.liveSpan, 2000);
+      // Enough data: the locked span shows from the right edge.
+      expect(ctrl.effectiveRange(5000, 0), (3000, 5000));
       // Less data than the min span: window extends to a negative start.
       expect(ctrl.effectiveRange(1000, 0), (-1000, 1000));
     });
@@ -34,40 +36,21 @@ void main() {
     });
   });
 
-  group('GraphController.setWindow', () {
-    test('exits live mode and reports the exact window', () {
-      final ctrl = GraphController();
-      ctrl.setWindow(100, 300);
-      expect(ctrl.isLive, isFalse);
-      expect(ctrl.viewStart, 100);
-      expect(ctrl.viewEnd, 300);
-      expect(ctrl.liveSpan, isNull);
-      expect(ctrl.effectiveRange(1000, 0), (100, 300));
-    });
-
-    test('clamps a reversed end to start + 1', () {
-      final ctrl = GraphController();
-      ctrl.setWindow(100, 50);
-      expect(ctrl.effectiveRange(1000, 0), (100, 101));
-    });
-  });
-
   group('GraphController.applyWindow', () {
     test('clamps the left edge to the oldest available sample', () {
       final ctrl = GraphController();
       ctrl.applyWindow(-50, 200, 1000, 0);
-      expect(ctrl.viewStart, 0);
-      expect(ctrl.viewEnd, 200);
       expect(ctrl.isLive, isFalse);
+      expect(ctrl.effectiveRange(1000, 0), (0, 200));
     });
 
     test('snaps to live mode and locks the current span at the right edge', () {
       final ctrl = GraphController();
       ctrl.applyWindow(800, 200, 1000, 0);
       expect(ctrl.isLive, isTrue);
-      expect(ctrl.liveSpan, 200);
-      expect(ctrl.viewEnd, isNull);
+      // Locked to the 200-sample span: the window tracks the right edge.
       expect(ctrl.effectiveRange(1000, 0), (800, 1000));
+      expect(ctrl.effectiveRange(1200, 0), (1000, 1200));
     });
   });
 
@@ -83,7 +66,7 @@ void main() {
         totalSamples: 1000,
         oldestSample: 0,
       );
-      final (s, e) = (ctrl.viewStart, ctrl.viewEnd!);
+      final (s, e) = ctrl.effectiveRange(1000, 0);
       expect(e - s, 50);
       expect(ctrl.isLive, isFalse);
     });
@@ -100,11 +83,10 @@ void main() {
         oldestSample: 0,
       );
       expect(ctrl.isLive, isTrue);
-      expect(ctrl.liveSpan, 500);
       expect(ctrl.effectiveRange(1000, 0), (500, 1000));
     });
 
-    test('zooming out to the max span clears liveSpan (auto-expand)', () {
+    test('zooming out to the max span auto-expands with the data', () {
       final ctrl = GraphController();
       ctrl.zoomTo(
         10000,
@@ -116,46 +98,26 @@ void main() {
         oldestSample: 0,
       );
       expect(ctrl.isLive, isTrue);
-      expect(ctrl.liveSpan, isNull);
+      // No locked span: the window grows as new data arrives.
       expect(ctrl.effectiveRange(500, 0), (0, 500));
+      expect(ctrl.effectiveRange(700, 0), (0, 700));
     });
   });
 
   group('GraphController.pan / centerOn', () {
     test('pan shifts the window by the delta', () {
       final ctrl = GraphController();
-      ctrl.setWindow(100, 300);
+      ctrl.applyWindow(100, 200, 1000, 0);
       ctrl.pan(50, 1000, 0, 600000);
-      expect(ctrl.viewStart, 150);
-      expect(ctrl.viewEnd, 350);
       expect(ctrl.isLive, isFalse);
+      expect(ctrl.effectiveRange(1000, 0), (150, 350));
     });
 
     test('centerOn centers the current span on a sample', () {
       final ctrl = GraphController();
-      ctrl.setWindow(100, 300); // span 200
+      ctrl.applyWindow(100, 200, 1000, 0); // span 200
       ctrl.centerOn(500, 1000, 0, 600000);
-      expect(ctrl.viewStart, 400);
-      expect(ctrl.viewEnd, 600);
-    });
-  });
-
-  group('GraphController.isSqueeze / reset', () {
-    test('isSqueeze is true when the window spans all available data', () {
-      final ctrl = GraphController();
-      expect(ctrl.isSqueeze(1000, 0), isTrue);
-      ctrl.goLive(span: 200, totalSamples: 1000, oldestSample: 0);
-      expect(ctrl.isSqueeze(1000, 0), isFalse);
-    });
-
-    test('reset returns to live full-view', () {
-      final ctrl = GraphController();
-      ctrl.setWindow(100, 300);
-      ctrl.reset();
-      expect(ctrl.isLive, isTrue);
-      expect(ctrl.viewEnd, isNull);
-      expect(ctrl.viewStart, 0);
-      expect(ctrl.liveSpan, isNull);
+      expect(ctrl.effectiveRange(1000, 0), (400, 600));
     });
   });
 
@@ -165,11 +127,11 @@ void main() {
       var count = 0;
       ctrl.addListener(() => count++);
 
-      ctrl.setWindow(100, 300);
+      ctrl.applyWindow(100, 200, 1000, 0);
       expect(count, 1);
-      ctrl.reset();
-      expect(count, 2);
       ctrl.goLive(totalSamples: 1000, oldestSample: 0);
+      expect(count, 2);
+      ctrl.applyWindow(300, 200, 1000, 0);
       expect(count, 3);
     });
   });
@@ -180,16 +142,17 @@ void main() {
   /// happen.
   group('GraphController across a stream reset', () {
     test('a stale panned window throws against an empty buffer', () {
-      // The crash the reset prevents: a non-live window from the previous
-      // stream clamped against a cleared hub has inverted clamp limits.
+      // The crash the reset prevents: a window parked deep in history (set
+      // while the old stream had plenty of data) clamped against a cleared
+      // hub has inverted clamp limits.
       final ctrl = GraphController(minLiveSpan: 20000);
-      ctrl.setWindow(100000, 200000); // user panned deep into history
+      ctrl.applyWindow(100000, 100000, 300000, 0); // user panned into history
       expect(() => ctrl.effectiveRange(0, 0), throwsArgumentError);
     });
 
     test('goLive restores a safe live-follow range', () {
       final ctrl = GraphController(minLiveSpan: 20000);
-      ctrl.setWindow(100000, 200000);
+      ctrl.applyWindow(100000, 100000, 300000, 0);
 
       ctrl.goLive(totalSamples: 0, oldestSample: 0);
 


### PR DESCRIPTION
**Dead code & write-only state**
- `GraphController`: removed `setWindow`/`isSqueeze`/`reset` and the
  `liveSpan`/`viewStart`/`viewEnd` getters — tested but never called by the
  app. Tests now observe the viewport only via `isLive`/`effectiveRange`.
- `DeviceLink.services` and the unused `services`/`isConnecting`/`isSettingUp`
  pass-throughs removed; service discovery result is now iterated locally.
- `ForceUnit.isForce`/`fromKgf`/`formatRate`, the unused `notes` param chain,
  `MockBlePlatform._setupListeners`, a dead storage guard, and the settings
  JS-comparison diagnostic removed.
- Dropped write-only `peakForceChannel` column (schema v4 → v5; per-channel
  peaks are already available in session detail).

**State reduction**
- New `DataHub.generation` counter marks stream resets explicitly, replacing
  LiveTab's `totalSamples`-decrease heuristic and its documented crash mode.
- Channel bounds checks became debug `assert`s; one shared
  "all channels visible" default for the DB and settings.

**Dedup**
- New `windowedExtremes()` in `bucket_series.dart` backs both the force and
  derivative Y-range folds (previously two parallel implementations).
- `minimapSpan()` shared between minimap widget and painter; `ForceUnit`
  formatting unified; one connect-with-feedback helper in the Devices tab.

## Test plan

- `flutter analyze`: clean.
- `flutter test`: 94/94 passing — 3 new `windowedExtremes` tests
  (brute-force equivalence, NaN skipping, null case); GraphController tests
  re-plumbed to app-consumed API only; stream-reset crash repro kept.
- ⚠️ Schema v5 wipes existing local session DBs on next app run (current
  dev migration strategy) — recordings on test devices will be cleared.