### PR TITLE
Harden BLE link failures, surface malformed packets, drop stale schema defaults

### DIFF
--- a/lib/screens/app_shell.dart
+++ b/lib/screens/app_shell.dart
@@ -85,6 +85,10 @@ class AppShellState extends State<AppShell> {
             content: Text('Lost connection to $deviceName during setup.'),
           ),
         );
+      case BleConnectionLost(:final deviceName):
+        messenger.showSnackBar(
+          SnackBar(content: Text('Connection to $deviceName lost.')),
+        );
       case RecordingStorageError(:final error):
         messenger.showSnackBar(
           SnackBar(

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -43,8 +43,10 @@ class _DevicesTabState extends State<DevicesTab> {
   }
 
   /// Run a connect attempt, surfacing a failure as a snackbar naming
-  /// [deviceName]. Connect buttons are already disabled while a link is
-  /// busy, so this only handles the rejected attempt itself.
+  /// [deviceName] with the underlying error detail (timeout vs GATT error vs
+  /// user-cancelled web picker are wildly different diagnoses). Connect
+  /// buttons are already disabled while a link is busy, so this only handles
+  /// the rejected attempt itself.
   Future<void> _connectWithFeedback(
     Future<void> Function() connect,
     String deviceName,
@@ -52,9 +54,10 @@ class _DevicesTabState extends State<DevicesTab> {
     try {
       await connect();
     } catch (e) {
+      debugPrint('Connect to $deviceName failed: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to connect to $deviceName.')),
+          SnackBar(content: Text('Failed to connect to $deviceName: $e')),
         );
       }
     }
@@ -97,6 +100,9 @@ class _DevicesTabState extends State<DevicesTab> {
                       ),
                     ),
                     const SizedBox(width: 8),
+                    // TODO(ux): see BleLinkManager._startScan — starting a
+                    // scan while streaming kills the active link (and any
+                    // in-progress recording). Decide disable-vs-confirm.
                     FilledButton.tonal(
                       onPressed: () async {
                         await bt.toggleScan();

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -217,9 +217,16 @@ class _LiveTabState extends State<LiveTab> {
     return SafeArea(
       child: Column(
         children: [
-          LiveStatusBar(
-            isConnected: isConnected,
-            connectedDeviceName: link.connectedDeviceName,
+          // The bar shows the hub's protocol-error count, which changes with
+          // packet traffic — listen to the hub (per-packet notify) here
+          // rather than rebuilding the whole tab.
+          ListenableBuilder(
+            listenable: hub,
+            builder: (context, _) => LiveStatusBar(
+              isConnected: isConnected,
+              connectedDeviceName: link.connectedDeviceName,
+              protocolErrorCount: hub.protocolErrorCount,
+            ),
           ),
           if (isConnected)
             LiveStats(
@@ -268,10 +275,16 @@ class LiveStatusBar extends StatelessWidget {
   final bool isConnected;
   final String connectedDeviceName;
 
+  /// Malformed ADC packets seen on this stream ([DataHub.protocolErrorCount]).
+  /// Non-zero shows a persistent warning marker: bad packets are dropped but
+  /// never hidden from the user.
+  final int protocolErrorCount;
+
   const LiveStatusBar({
     super.key,
     required this.isConnected,
     required this.connectedDeviceName,
+    this.protocolErrorCount = 0,
   });
 
   @override
@@ -315,6 +328,20 @@ class LiveStatusBar extends StatelessWidget {
                 ),
               ),
             ),
+            if (isConnected && protocolErrorCount > 0)
+              Tooltip(
+                message:
+                    '$protocolErrorCount malformed ADC packet(s) received — '
+                    'firmware/protocol mismatch',
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: Icon(
+                    Icons.warning_amber,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                ),
+              ),
             if (isConnected)
               Text(
                 '${DataHub.samplesPerSec} Hz',

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -217,7 +217,7 @@ class _LiveTabState extends State<LiveTab> {
     return SafeArea(
       child: Column(
         children: [
-          // The bar shows the hub's protocol-error count, which changes with
+          // The bar shows the hub's protocol-error latch, which changes with
           // packet traffic — listen to the hub (per-packet notify) here
           // rather than rebuilding the whole tab.
           ListenableBuilder(
@@ -225,7 +225,7 @@ class _LiveTabState extends State<LiveTab> {
             builder: (context, _) => LiveStatusBar(
               isConnected: isConnected,
               connectedDeviceName: link.connectedDeviceName,
-              protocolErrorCount: hub.protocolErrorCount,
+              protocolErrorSeen: hub.protocolErrorSeen,
             ),
           ),
           if (isConnected)
@@ -275,16 +275,16 @@ class LiveStatusBar extends StatelessWidget {
   final bool isConnected;
   final String connectedDeviceName;
 
-  /// Malformed ADC packets seen on this stream ([DataHub.protocolErrorCount]).
-  /// Non-zero shows a persistent warning marker: bad packets are dropped but
-  /// never hidden from the user.
-  final int protocolErrorCount;
+  /// Whether a malformed ADC packet was seen on this stream
+  /// ([DataHub.protocolErrorSeen]). Shows a persistent warning marker: bad
+  /// packets are dropped but never hidden from the user.
+  final bool protocolErrorSeen;
 
   const LiveStatusBar({
     super.key,
     required this.isConnected,
     required this.connectedDeviceName,
-    this.protocolErrorCount = 0,
+    this.protocolErrorSeen = false,
   });
 
   @override
@@ -328,10 +328,9 @@ class LiveStatusBar extends StatelessWidget {
                 ),
               ),
             ),
-            if (isConnected && protocolErrorCount > 0)
+            if (isConnected && protocolErrorSeen)
               Tooltip(
-                message:
-                    '$protocolErrorCount malformed ADC packet(s) received — '
+                message: 'Malformed ADC packets received — '
                     'firmware/protocol mismatch',
                 child: Padding(
                   padding: const EdgeInsets.only(right: 8),

--- a/lib/services/adc_packet_decoder.dart
+++ b/lib/services/adc_packet_decoder.dart
@@ -53,10 +53,10 @@ class AdcPacketDecoder {
     // the fixed-size loop below). Anything shorter — e.g. a truncated
     // notification from a firmware bug — can't be parsed (indexing past the
     // end would throw in release builds). Drop it, but NOT silently: the
-    // hub's [DataHub.protocolErrorCount] surfaces it in the live UI.
+    // hub's [DataHub.reportProtocolError] latch surfaces it in the live UI.
     const int minLength = nwHeaderSize + nwAdcNumSamples * nwAdcSampleLength;
     if (data.length < minLength) {
-      hub.protocolErrorCount++;
+      hub.reportProtocolError();
       debugPrint(
         'Dropping short ADC packet: ${data.length} B (need $minLength B)',
       );

--- a/lib/services/adc_packet_decoder.dart
+++ b/lib/services/adc_packet_decoder.dart
@@ -51,10 +51,12 @@ class AdcPacketDecoder {
     // A decodable packet holds the 2-byte counter plus at least
     // nwAdcNumSamples full frames (extra trailing bytes are ignored, matching
     // the fixed-size loop below). Anything shorter — e.g. a truncated
-    // notification from a firmware bug — is dropped rather than parsed:
-    // indexing past the end would throw in release builds.
+    // notification from a firmware bug — can't be parsed (indexing past the
+    // end would throw in release builds). Drop it, but NOT silently: the
+    // hub's [DataHub.protocolErrorCount] surfaces it in the live UI.
     const int minLength = nwHeaderSize + nwAdcNumSamples * nwAdcSampleLength;
     if (data.length < minLength) {
+      hub.protocolErrorCount++;
       debugPrint(
         'Dropping short ADC packet: ${data.length} B (need $minLength B)',
       );

--- a/lib/services/app_events.dart
+++ b/lib/services/app_events.dart
@@ -26,6 +26,17 @@ class BleConnectionFailed extends AppEvent {
   final String deviceName;
 }
 
+/// The link dropped unexpectedly while it was up (setting up or streaming) —
+/// i.e. NOT a user-requested disconnect and not a post-connect setup failure
+/// (those surface as [BleConnectionFailed]). A recording in progress is
+/// finalized by `RecordingController` when this happens.
+class BleConnectionLost extends AppEvent {
+  const BleConnectionLost(this.deviceName);
+
+  /// The affected device's display name (or id).
+  final String deviceName;
+}
+
 /// A recording's storage writer latched a failure (e.g. disk full / web
 /// quota); the saved session may be truncated. Emitted from
 /// `RecordingController.stopSession` for both user-initiated and auto stops.

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -329,6 +329,10 @@ class BleLinkManager extends ChangeNotifier {
         _link.state == BtLinkState.connected) {
       return;
     }
+    // TODO(ux): starting a scan while streaming disconnects the active link
+    // — and silently stops any in-progress recording. Decide the policy:
+    // disable Scan while streaming, or confirm first when a recording is in
+    // progress. (The Devices tab Scan button mirrors this TODO.)
     await disconnectSelectedDevice();
     _devices.clear();
     _isScanning = true;
@@ -510,12 +514,19 @@ class BleLinkManager extends ChangeNotifier {
         }
         final discovered = await UniversalBle.discoverServices(deviceId);
         if (_setupSuperseded(gen, deviceId)) return;
+        bool subscribed = false;
         for (final srv in discovered) {
           if (srv.uuid == btServiceId) {
-            await subscribeToAdcFeed(srv);
+            subscribed = await subscribeToAdcFeed(srv);
             if (_setupSuperseded(gen, deviceId)) return;
             break;
           }
+        }
+        // A link without the ADC feed is unusable: fail the connection here
+        // (the catch below tears down and toasts) rather than advancing to
+        // "streaming" with no data flowing.
+        if (!subscribed) {
+          throw StateError('ADC feed characteristic not found on $deviceId');
         }
         // Setup complete: advance to the usable "streaming" state and begin live
         // RSSI polling for the signal display.
@@ -541,7 +552,17 @@ class BleLinkManager extends ChangeNotifier {
       // common teardown, which (on web) parks the link in cooldown for the
       // reconnect settle window before returning it to the idle sentinel.
       final String name = _link.name.isEmpty ? deviceId : _link.name;
+      // An unexpected drop while the link was up (setting up or streaming)
+      // gets a user notice. User-requested disconnects arrive here in
+      // `disconnecting`, and post-connect setup failures already emitted
+      // BleConnectionFailed before tearing down — so neither double-reports.
+      final bool wasActive =
+          _link.state == BtLinkState.connected ||
+          _link.state == BtLinkState.streaming;
       _endLink(deviceId, name);
+      if (wasActive) {
+        _events.emit(BleConnectionLost(name));
+      }
       notifyListeners();
     }
   }
@@ -668,19 +689,33 @@ class BleLinkManager extends ChangeNotifier {
     }
   }
 
-  Future<void> subscribeToAdcFeed(BleService service) async {
+  /// Subscribe to the ADC feed characteristic of [service] (reading the
+  /// calibration characteristic first). Returns true when the subscription
+  /// was made; false when no usable ADC feed characteristic exists — the
+  /// caller fails the connection in that case, since a link without the
+  /// feed is unusable.
+  Future<bool> subscribeToAdcFeed(BleService service) async {
     final String deviceId = _link.deviceId;
     if (deviceId.isEmpty) {
-      return;
+      return false;
     }
     for (final characteristic in service.characteristics) {
       if (characteristic.uuid != btChrAdcFeedId ||
           !characteristic.properties.contains(CharacteristicProperty.notify)) {
         continue;
       }
-      onCalibrationData?.call(
-        await UniversalBle.read(deviceId, service.uuid, btChrCalibration),
-      );
+      // Calibration is best-effort: parsing is a TODO and defaults are in
+      // use, so a failed read must not fail the whole connection.
+      // TODO(cal): once real calibration parsing lands, surface a
+      // "calibration unreadable — using defaults" warning event instead of
+      // only logging.
+      try {
+        onCalibrationData?.call(
+          await UniversalBle.read(deviceId, service.uuid, btChrCalibration),
+        );
+      } catch (e) {
+        debugPrint('Calibration read failed for $deviceId: $e');
+      }
       await UniversalBle.subscribeNotifications(
         deviceId,
         service.uuid,
@@ -689,8 +724,9 @@ class BleLinkManager extends ChangeNotifier {
       // The link's transition to the usable [BtLinkState.streaming] state is
       // driven by the caller ([_onConnectionChange]) once this returns and the
       // generation guard confirms the pass wasn't superseded.
-      return;
+      return true;
     }
+    return false;
   }
 
   void _onValueChange(

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -77,10 +77,11 @@ class DataHub extends ChangeNotifier {
   int totalSamples = 0;
   DeviceCalibration deviceCalibration = DeviceCalibration();
 
-  /// Malformed/undecodable ADC packets seen on this stream (e.g. truncated
-  /// notifications). The decoder increments this instead of silently
-  /// dropping; the live UI surfaces a non-zero count. Reset by [clear].
-  int protocolErrorCount = 0;
+  /// Whether a malformed/undecodable ADC packet (e.g. a truncated
+  /// notification) was seen on this stream. Latched by [reportProtocolError]
+  /// instead of silently dropping; the live UI surfaces the latch. Reset by
+  /// [clear].
+  bool protocolErrorSeen = false;
 
   /// Monotonic counter bumped by [clear]. Lets observers distinguish "same
   /// stream, more data" from "a new stream reset the hub" explicitly, instead
@@ -123,7 +124,7 @@ class DataHub extends ChangeNotifier {
     _tareCount = 0;
     totalSamples = 0;
     _generation++;
-    protocolErrorCount = 0;
+    protocolErrorSeen = false;
     gaps.clear();
     for (int i = 0; i < numAdcChannels; ++i) {
       rawMax[i] = _noMaxYet;
@@ -134,6 +135,17 @@ class DataHub extends ChangeNotifier {
       valueBuckets[i].reset();
       diffBuckets[i].reset();
     }
+    notifyListeners();
+  }
+
+  /// Latch [protocolErrorSeen] and notify observers — but only on the first
+  /// malformed packet of a stream. The malformed-packet path never reaches
+  /// [commitBatch], so without this notify a stream where EVERY packet is
+  /// undecodable (firmware/protocol mismatch) would show no warning at all;
+  /// latching keeps a flood of bad packets from becoming a notify storm.
+  void reportProtocolError() {
+    if (protocolErrorSeen) return;
+    protocolErrorSeen = true;
     notifyListeners();
   }
 

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -77,6 +77,11 @@ class DataHub extends ChangeNotifier {
   int totalSamples = 0;
   DeviceCalibration deviceCalibration = DeviceCalibration();
 
+  /// Malformed/undecodable ADC packets seen on this stream (e.g. truncated
+  /// notifications). The decoder increments this instead of silently
+  /// dropping; the live UI surfaces a non-zero count. Reset by [clear].
+  int protocolErrorCount = 0;
+
   /// Monotonic counter bumped by [clear]. Lets observers distinguish "same
   /// stream, more data" from "a new stream reset the hub" explicitly, instead
   /// of inferring the reset from [totalSamples] decreasing.
@@ -118,6 +123,7 @@ class DataHub extends ChangeNotifier {
     _tareCount = 0;
     totalSamples = 0;
     _generation++;
+    protocolErrorCount = 0;
     gaps.clear();
     for (int i = 0; i < numAdcChannels; ++i) {
       rawMax[i] = _noMaxYet;
@@ -295,7 +301,7 @@ class DeviceCalibration {
     this.offset = 0,
     this.capacityKg = 200.0,
     this.sensitivityMvV = 2.0,
-    this.excitationV = 4.5,
+    this.excitationV = 4.53,
   });
 
   final int offset;

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -4,26 +4,25 @@ import 'package:flutter/foundation.dart';
 
 part 'database.g.dart';
 
-/// JSON-encoded default for the session `visibleChannels` column: every
-/// channel shown. Kept as a literal because drift column defaults must be
-/// const — it must stay in sync with `nwNumAdcChan` (currently 4).
-const String kAllChannelsVisibleJson = '[true,true,true,true]';
-
 /// Table for recorded measurement sessions.
+///
+/// Columns whose value must be chosen deliberately at insert time (sample
+/// rate, channel layout, tares, calibration, visibility) carry NO default, so
+/// drift makes them compile-time required on insert — a stale fallback can
+/// never silently land in a row. Harmless display/aggregate defaults (`name`,
+/// `notes`, counters, flags) are kept.
 class Sessions extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get name => text().withDefault(const Constant(''))();
   DateTimeColumn get createdAt => dateTime()();
   IntColumn get durationMs => integer().withDefault(const Constant(0))();
-  IntColumn get sampleRate => integer().withDefault(const Constant(1000))();
-  IntColumn get channelCount => integer().withDefault(const Constant(2))();
-  TextColumn get channelLabels =>
-      text().withDefault(const Constant('["Load Cell 1","Load Cell 2"]'))();
-  TextColumn get tares => text().withDefault(const Constant('[]'))();
+  IntColumn get sampleRate => integer()();
+  IntColumn get channelCount => integer()();
+  TextColumn get channelLabels => text()();
+  TextColumn get tares => text()();
   RealColumn get peakForceRaw => real().withDefault(const Constant(0.0))();
-  RealColumn get calibrationSlope =>
-      real().withDefault(const Constant(0.0001117587))();
-  IntColumn get calibrationOffset => integer().withDefault(const Constant(0))();
+  RealColumn get calibrationSlope => real()();
+  IntColumn get calibrationOffset => integer()();
   TextColumn get notes => text().withDefault(const Constant(''))();
   IntColumn get sampleCount => integer().withDefault(const Constant(0))();
   BoolColumn get isCompleted => boolean().withDefault(const Constant(true))();
@@ -35,8 +34,7 @@ class Sessions extends Table {
   /// Which channels are shown in the session detail view, as a JSON bool
   /// list. Initialized from the live view's channel selection at recording
   /// time; afterwards it is per-session and independent of the live view.
-  TextColumn get visibleChannels =>
-      text().withDefault(const Constant(kAllChannelsVisibleJson))();
+  TextColumn get visibleChannels => text()();
 }
 
 class SessionChunks extends Table {
@@ -79,7 +77,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   /// DEV ONLY: any schema version bump wipes the database and recreates it
   /// from scratch. No user data is migrated. Replace with real per-version
@@ -119,20 +117,20 @@ class AppDatabase extends _$AppDatabase {
     required String tares,
     required double calibrationSlope,
     required int calibrationOffset,
-    String visibleChannels = kAllChannelsVisibleJson,
+    required String visibleChannels,
   }) {
     return into(sessions).insert(
       SessionsCompanion.insert(
         name: Value(name),
         createdAt: DateTime.now(),
-        sampleRate: Value(sampleRate),
-        channelCount: Value(channelCount),
-        channelLabels: Value(channelLabels),
-        tares: Value(tares),
-        calibrationSlope: Value(calibrationSlope),
-        calibrationOffset: Value(calibrationOffset),
+        sampleRate: sampleRate,
+        channelCount: channelCount,
+        channelLabels: channelLabels,
+        tares: tares,
+        calibrationSlope: calibrationSlope,
+        calibrationOffset: calibrationOffset,
         isCompleted: const Value(false),
-        visibleChannels: Value(visibleChannels),
+        visibleChannels: visibleChannels,
       ),
     );
   }

--- a/lib/services/database.g.dart
+++ b/lib/services/database.g.dart
@@ -63,8 +63,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     aliasedName,
     false,
     type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(1000),
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _channelCountMeta = const VerificationMeta(
     'channelCount',
@@ -75,8 +74,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     aliasedName,
     false,
     type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(2),
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _channelLabelsMeta = const VerificationMeta(
     'channelLabels',
@@ -87,8 +85,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     aliasedName,
     false,
     type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('["Load Cell 1","Load Cell 2"]'),
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _taresMeta = const VerificationMeta('tares');
   @override
@@ -97,8 +94,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     aliasedName,
     false,
     type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('[]'),
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _peakForceRawMeta = const VerificationMeta(
     'peakForceRaw',
@@ -121,8 +117,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     aliasedName,
     false,
     type: DriftSqlType.double,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0.0001117587),
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _calibrationOffsetMeta = const VerificationMeta(
     'calibrationOffset',
@@ -133,8 +128,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     aliasedName,
     false,
     type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0),
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _notesMeta = const VerificationMeta('notes');
   @override
@@ -192,8 +186,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     aliasedName,
     false,
     type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(kAllChannelsVisibleJson),
+    requiredDuringInsert: true,
   );
   @override
   List<GeneratedColumn> get $columns => [
@@ -254,6 +247,8 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
         _sampleRateMeta,
         sampleRate.isAcceptableOrUnknown(data['sample_rate']!, _sampleRateMeta),
       );
+    } else if (isInserting) {
+      context.missing(_sampleRateMeta);
     }
     if (data.containsKey('channel_count')) {
       context.handle(
@@ -263,6 +258,8 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
           _channelCountMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_channelCountMeta);
     }
     if (data.containsKey('channel_labels')) {
       context.handle(
@@ -272,12 +269,16 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
           _channelLabelsMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_channelLabelsMeta);
     }
     if (data.containsKey('tares')) {
       context.handle(
         _taresMeta,
         tares.isAcceptableOrUnknown(data['tares']!, _taresMeta),
       );
+    } else if (isInserting) {
+      context.missing(_taresMeta);
     }
     if (data.containsKey('peak_force_raw')) {
       context.handle(
@@ -296,6 +297,8 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
           _calibrationSlopeMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_calibrationSlopeMeta);
     }
     if (data.containsKey('calibration_offset')) {
       context.handle(
@@ -305,6 +308,8 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
           _calibrationOffsetMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_calibrationOffsetMeta);
     }
     if (data.containsKey('notes')) {
       context.handle(
@@ -344,6 +349,8 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
           _visibleChannelsMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_visibleChannelsMeta);
     }
     return context;
   }
@@ -739,19 +746,26 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     this.name = const Value.absent(),
     required DateTime createdAt,
     this.durationMs = const Value.absent(),
-    this.sampleRate = const Value.absent(),
-    this.channelCount = const Value.absent(),
-    this.channelLabels = const Value.absent(),
-    this.tares = const Value.absent(),
+    required int sampleRate,
+    required int channelCount,
+    required String channelLabels,
+    required String tares,
     this.peakForceRaw = const Value.absent(),
-    this.calibrationSlope = const Value.absent(),
-    this.calibrationOffset = const Value.absent(),
+    required double calibrationSlope,
+    required int calibrationOffset,
     this.notes = const Value.absent(),
     this.sampleCount = const Value.absent(),
     this.isCompleted = const Value.absent(),
     this.gaps = const Value.absent(),
-    this.visibleChannels = const Value.absent(),
-  }) : createdAt = Value(createdAt);
+    required String visibleChannels,
+  }) : createdAt = Value(createdAt),
+       sampleRate = Value(sampleRate),
+       channelCount = Value(channelCount),
+       channelLabels = Value(channelLabels),
+       tares = Value(tares),
+       calibrationSlope = Value(calibrationSlope),
+       calibrationOffset = Value(calibrationOffset),
+       visibleChannels = Value(visibleChannels);
   static Insertable<Session> custom({
     Expression<int>? id,
     Expression<String>? name,
@@ -1191,18 +1205,18 @@ typedef $$SessionsTableCreateCompanionBuilder =
       Value<String> name,
       required DateTime createdAt,
       Value<int> durationMs,
-      Value<int> sampleRate,
-      Value<int> channelCount,
-      Value<String> channelLabels,
-      Value<String> tares,
+      required int sampleRate,
+      required int channelCount,
+      required String channelLabels,
+      required String tares,
       Value<double> peakForceRaw,
-      Value<double> calibrationSlope,
-      Value<int> calibrationOffset,
+      required double calibrationSlope,
+      required int calibrationOffset,
       Value<String> notes,
       Value<int> sampleCount,
       Value<bool> isCompleted,
       Value<String> gaps,
-      Value<String> visibleChannels,
+      required String visibleChannels,
     });
 typedef $$SessionsTableUpdateCompanionBuilder =
     SessionsCompanion Function({
@@ -1550,18 +1564,18 @@ class $$SessionsTableTableManager
                 Value<String> name = const Value.absent(),
                 required DateTime createdAt,
                 Value<int> durationMs = const Value.absent(),
-                Value<int> sampleRate = const Value.absent(),
-                Value<int> channelCount = const Value.absent(),
-                Value<String> channelLabels = const Value.absent(),
-                Value<String> tares = const Value.absent(),
+                required int sampleRate,
+                required int channelCount,
+                required String channelLabels,
+                required String tares,
                 Value<double> peakForceRaw = const Value.absent(),
-                Value<double> calibrationSlope = const Value.absent(),
-                Value<int> calibrationOffset = const Value.absent(),
+                required double calibrationSlope,
+                required int calibrationOffset,
                 Value<String> notes = const Value.absent(),
                 Value<int> sampleCount = const Value.absent(),
                 Value<bool> isCompleted = const Value.absent(),
                 Value<String> gaps = const Value.absent(),
-                Value<String> visibleChannels = const Value.absent(),
+                required String visibleChannels,
               }) => SessionsCompanion.insert(
                 id: id,
                 name: name,

--- a/lib/services/mockble.dart
+++ b/lib/services/mockble.dart
@@ -40,6 +40,33 @@ class MockBlePlatform extends UniversalBlePlatform {
   /// packet is always delivered so the decoder can establish continuity.
   int dropEveryNPackets = 0;
 
+  /// Test knobs ---------------------------------------------------------------
+
+  /// When false, [discoverServices] reports a GATT table WITHOUT the ADC feed
+  /// service, so post-connect setup cannot subscribe to the feed.
+  bool includeAdcService = true;
+
+  /// When true, reads of the calibration characteristic throw.
+  bool failCalibrationRead = false;
+
+  /// When true, [disconnect] never fires the connection-change callback, so
+  /// the client's disconnect-timeout reconciliation path is what tears the
+  /// link down.
+  bool hangDisconnect = false;
+
+  /// Reset every knob to its default and silently sever any leftover link
+  /// (no callbacks), so the singleton is clean for the next test.
+  void resetKnobs() {
+    dropEveryNPackets = 0;
+    includeAdcService = true;
+    failCalibrationRead = false;
+    hangDisconnect = false;
+    _connectedDeviceId = null;
+    _connectionState = BleConnectionState.disconnected;
+    _notificationTimer?.cancel();
+    _notificationTimer = null;
+  }
+
   @override
   Future<AvailabilityState> getBluetoothAvailabilityState() async {
     await Future<void>.delayed(hwDelay);
@@ -130,6 +157,11 @@ class MockBlePlatform extends UniversalBlePlatform {
 
   @override
   Future<void> disconnect(String deviceId) async {
+    if (hangDisconnect) {
+      // Never fire the connection-change callback: the link stays "connected"
+      // here and the client's disconnect-timeout reconciliation tears it down.
+      return;
+    }
     _connectionState = BleConnectionState.disconnected;
     await setNotifiable(deviceId, '', '', BleInputProperty.disabled);
     _connectedDeviceId = null;
@@ -139,7 +171,12 @@ class MockBlePlatform extends UniversalBlePlatform {
   @override
   Future<List<BleService>> discoverServices(String deviceId, bool _) async {
     await Future<void>.delayed(netDelay);
-    return _generateServices(deviceId);
+    final services = _generateServices(deviceId);
+    if (!includeAdcService) {
+      // A device whose GATT table lacks the ADC feed service.
+      return [for (final s in services) if (s.uuid != btServiceId) s];
+    }
+    return services;
   }
 
   @override
@@ -200,6 +237,9 @@ class MockBlePlatform extends UniversalBlePlatform {
     final Duration? timeout,
   }) async {
     await Future<void>.delayed(netDelay);
+    if (failCalibrationRead && characteristic == btChrCalibration) {
+      throw StateError('Mock calibration read failure');
+    }
     return Uint8List(255);
   }
 

--- a/lib/services/recording_controller.dart
+++ b/lib/services/recording_controller.dart
@@ -134,9 +134,12 @@ class RecordingController extends ChangeNotifier {
     return const StartSessionOk();
   }
 
-  /// Default session name from the wall clock, e.g. `7/20 14:05`.
+  /// Default session name from the wall clock, e.g. `7/20 14:05:32`. Seconds
+  /// included so two sessions started within the same minute don't collide.
   static String _autoSessionName(DateTime now) =>
-      '${now.month}/${now.day} ${now.hour}:${now.minute.toString().padLeft(2, '0')}';
+      '${now.month}/${now.day} '
+      '${now.hour}:${now.minute.toString().padLeft(2, '0')}:'
+      '${now.second.toString().padLeft(2, '0')}';
 
   /// Stop the current recording and finalize it. Returns the saved session id
   /// and name (or nulls if nothing was recording) and any write error the

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -699,7 +699,12 @@ class GraphController extends ChangeNotifier {
         }
         return (totalSamples - s, totalSamples);
       case GraphWindow(:final start, :final end):
-        return (start, end.clamp(start + 1, totalSamples));
+        // Defensive: a parked window can outlive the data (e.g. the hub is
+        // cleared for a new stream while parked). Clamp the start first so
+        // the end clamp can never receive inverted limits and throw.
+        final s = math.min(math.max(start, 0), math.max(0, totalSamples - 1));
+        final e = math.min(math.max(end, s + 1), math.max(totalSamples, s + 1));
+        return (s, e);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,7 +154,7 @@ packages:
     source: hosted
     version: "1.19.1"
   convert:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,6 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  convert: ^3.1.2
   cross_file: ^0.3.4+2
   package_info_plus: ^10.1.0
   google_fonts: ^8.0.2

--- a/test/adc_packet_decoder_test.dart
+++ b/test/adc_packet_decoder_test.dart
@@ -122,21 +122,31 @@ void main() {
       expect(hub.gaps.contains(nwAdcNumSamples), isFalse);
     });
 
-    test('an empty packet is ignored', () {
+    test('an empty packet is ignored and counted as a protocol error', () {
       decoder.onDataPacket(Uint8List(0));
       expect(hub.totalSamples, 0);
+      expect(hub.protocolErrorCount, 1);
     });
 
-    test('a truncated packet is ignored instead of throwing', () {
-      // One byte short of a full packet: a firmware bug must not crash the
-      // app (the in-loop asserts are stripped in release builds).
-      final short = makePacket(0, (s, c) => 1);
-      decoder.onDataPacket(Uint8List.sublistView(short, 0, short.length - 1));
-      expect(hub.totalSamples, 0);
-      // A packet with trailing extra bytes still decodes its 20 samples.
-      final long = Uint8List(short.length + 3)..setAll(0, short);
-      decoder.onDataPacket(long);
-      expect(hub.totalSamples, nwAdcNumSamples);
-    });
+    test(
+      'a truncated packet is ignored, counted, and never throws; extra '
+      'trailing bytes still decode',
+      () {
+        // One byte short of a full packet: a firmware bug must not crash the
+        // app (the in-loop asserts are stripped in release builds).
+        final short = makePacket(0, (s, c) => 1);
+        decoder.onDataPacket(Uint8List.sublistView(short, 0, short.length - 1));
+        expect(hub.totalSamples, 0);
+        expect(hub.protocolErrorCount, 1);
+        // A second malformed packet keeps counting (the UI surfaces this).
+        decoder.onDataPacket(Uint8List(1));
+        expect(hub.protocolErrorCount, 2);
+        // A packet with trailing extra bytes still decodes its 20 samples.
+        final long = Uint8List(short.length + 3)..setAll(0, short);
+        decoder.onDataPacket(long);
+        expect(hub.totalSamples, nwAdcNumSamples);
+        expect(hub.protocolErrorCount, 2);
+      },
+    );
   });
 }

--- a/test/adc_packet_decoder_test.dart
+++ b/test/adc_packet_decoder_test.dart
@@ -122,14 +122,14 @@ void main() {
       expect(hub.gaps.contains(nwAdcNumSamples), isFalse);
     });
 
-    test('an empty packet is ignored and counted as a protocol error', () {
+    test('an empty packet is ignored and flags a protocol error', () {
       decoder.onDataPacket(Uint8List(0));
       expect(hub.totalSamples, 0);
-      expect(hub.protocolErrorCount, 1);
+      expect(hub.protocolErrorSeen, isTrue);
     });
 
     test(
-      'a truncated packet is ignored, counted, and never throws; extra '
+      'a truncated packet is ignored, flagged, and never throws; extra '
       'trailing bytes still decode',
       () {
         // One byte short of a full packet: a firmware bug must not crash the
@@ -137,16 +137,29 @@ void main() {
         final short = makePacket(0, (s, c) => 1);
         decoder.onDataPacket(Uint8List.sublistView(short, 0, short.length - 1));
         expect(hub.totalSamples, 0);
-        expect(hub.protocolErrorCount, 1);
-        // A second malformed packet keeps counting (the UI surfaces this).
+        expect(hub.protocolErrorSeen, isTrue);
+        // A second malformed packet keeps the latch set (the UI surfaces it).
         decoder.onDataPacket(Uint8List(1));
-        expect(hub.protocolErrorCount, 2);
+        expect(hub.protocolErrorSeen, isTrue);
         // A packet with trailing extra bytes still decodes its 20 samples.
         final long = Uint8List(short.length + 3)..setAll(0, short);
         decoder.onDataPacket(long);
         expect(hub.totalSamples, nwAdcNumSamples);
-        expect(hub.protocolErrorCount, 2);
+        expect(hub.protocolErrorSeen, isTrue);
       },
     );
+
+    test('the first malformed packet notifies once; later ones do not', () {
+      // The malformed path never reaches commitBatch, so without its own
+      // notify a stream where EVERY packet is bad would never surface the
+      // warning. The latch must notify exactly once per stream (no storm).
+      var notifyCount = 0;
+      hub.addListener(() => notifyCount++);
+
+      decoder.onDataPacket(Uint8List(0));
+      expect(notifyCount, 1);
+      decoder.onDataPacket(Uint8List(1));
+      expect(notifyCount, 1);
+    });
   });
 }

--- a/test/ble_link_manager_test.dart
+++ b/test/ble_link_manager_test.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import 'package:dynamite_app/services/app_events.dart';
+import 'package:dynamite_app/services/ble_link_manager.dart';
+import 'package:dynamite_app/services/bt_device_config.dart';
+import 'package:dynamite_app/services/mockble.dart';
+
+/// Tests for the [BleLinkManager] state machine against [MockBlePlatform],
+/// driven deterministically with [fakeAsync] (same harness as
+/// mockble_test.dart — no real time passes).
+///
+/// Mock timing: hwDelay 200 ms (availability), netDelay 1 s (connect /
+/// discoverServices / calibration read). A full connect therefore takes ~3 s:
+/// connect(1s) -> MTU(immediate) -> discoverServices(1s) -> calibration(1s)
+/// -> subscribe. [BleLinkManager.disconnectTimeout] is 2500 ms.
+///
+/// IMPORTANT: every test tears its link down INSIDE the [fakeAsync] scope
+/// (see [teardownLink]). A disconnect left running when the scope exits keeps
+/// executing against the shared static universal_ble command queue in real
+/// time, where a queued command's closure (created in a dead fake zone) never
+/// completes — wedging the queue for every later test.
+void main() {
+  // The mock device that advertises the ADC service (see _generateServices).
+  const deviceId = '2';
+
+  setUp(() {
+    UniversalBle.setInstance(MockBlePlatform.instance);
+    MockBlePlatform.instance.resetKnobs();
+  });
+
+  /// Builds a link manager with an [AppEvents] collector and the calibration
+  /// callback wired (the app always wires it; an unwired
+  /// [BleLinkManager.onCalibrationData] short-circuits the calibration read,
+  /// changing setup timing). Tests that observe the feed set
+  /// [BleLinkManager.onAdcData] directly.
+  (BleLinkManager, List<AppEvent>) wire() {
+    final events = AppEvents();
+    final seen = <AppEvent>[];
+    final sub = events.stream.listen(seen.add);
+    addTearDown(() => unawaited(sub.cancel()));
+    final link = BleLinkManager(events: events)..onCalibrationData = (_) {};
+    return (link, seen);
+  }
+
+  /// In-scope link teardown: disconnect (cancelling the mock's timers) and
+  /// let everything settle on the fake clock.
+  void teardownLink(FakeAsync async, BleLinkManager link) {
+    MockBlePlatform.instance.hangDisconnect = false;
+    unawaited(link.disconnectSelectedDevice());
+    async.elapse(const Duration(seconds: 4));
+  }
+
+  test('connect reaches streaming and notifications flow to onAdcData', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+      var received = 0;
+      link.onAdcData = (_) => received++;
+
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+
+      expect(link.isStreaming, isTrue);
+      expect(received, greaterThan(0));
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('a device without the ADC feed fails setup instead of "connecting"', () {
+    fakeAsync((async) {
+      MockBlePlatform.instance.includeAdcService = false;
+      final (link, seen) = wire();
+
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+
+      expect(link.isStreaming, isFalse);
+      expect(link.link.state, BtLinkState.idle);
+      expect(seen.whereType<BleConnectionFailed>(), hasLength(1));
+      expect(seen.whereType<BleConnectionLost>(), isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('an unexpected disconnect while streaming emits BleConnectionLost', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isTrue);
+
+      // Simulate a remote drop: the platform reports the link down without a
+      // user-requested disconnect.
+      unawaited(MockBlePlatform.instance.disconnect(deviceId));
+      async.elapse(const Duration(milliseconds: 100));
+
+      expect(link.link.state, BtLinkState.idle);
+      expect(seen.whereType<BleConnectionLost>(), hasLength(1));
+      expect(seen.whereType<BleConnectionFailed>(), isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test(
+    'a disconnect that never confirms forces idle and emits a timeout notice',
+    () {
+      fakeAsync((async) {
+        final (link, seen) = wire();
+        unawaited(link.connectToDevice(deviceId));
+        async.elapse(const Duration(seconds: 4));
+        expect(link.isStreaming, isTrue);
+
+        MockBlePlatform.instance.hangDisconnect = true;
+        unawaited(link.disconnectSelectedDevice());
+        // disconnectTimeout (2500 ms) + the availability-state query (200 ms).
+        async.elapse(const Duration(seconds: 4));
+
+        expect(link.link.state, BtLinkState.idle);
+        expect(seen.whereType<BleDisconnectTimeout>(), hasLength(1));
+        // A user-requested disconnect is not an unexpected drop.
+        expect(seen.whereType<BleConnectionLost>(), isEmpty);
+
+        teardownLink(async, link);
+      });
+    },
+  );
+
+  test('disconnecting mid post-connect setup tears down silently', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+
+      unawaited(link.connectToDevice(deviceId));
+      // After 1 s the GATT link is up and post-connect setup (discovery) is
+      // still running: the "Setting up…" window.
+      async.elapse(const Duration(seconds: 1));
+      expect(link.link.state, BtLinkState.connected);
+
+      unawaited(link.disconnectSelectedDevice());
+      async.elapse(const Duration(seconds: 4));
+
+      expect(link.link.state, BtLinkState.idle);
+      expect(link.isStreaming, isFalse);
+      // The superseded setup pass bails silently: no failure or drop notices.
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('a second connect while connecting is a no-op', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+
+      unawaited(link.connectToDevice(deviceId));
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+
+      expect(link.isStreaming, isTrue);
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('notifications from foreign sources are dropped', () {
+    fakeAsync((async) {
+      final (link, _) = wire();
+      var received = 0;
+      link.onAdcData = (_) => received++;
+
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isTrue);
+      final fromFeed = received;
+      expect(fromFeed, greaterThan(0));
+
+      // Wrong characteristic on the active device, and the ADC characteristic
+      // on a foreign device: both must be dropped by _onValueChange.
+      MockBlePlatform.instance.updateCharacteristicValue(
+        deviceId,
+        'c1234567',
+        Uint8List(242),
+        null,
+      );
+      MockBlePlatform.instance.updateCharacteristicValue(
+        'zzz',
+        btChrAdcFeedId,
+        Uint8List(242),
+        null,
+      );
+      async.flushMicrotasks();
+      expect(received, fromFeed);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('starting a scan mid-connect does not clear the device list', () {
+    fakeAsync((async) {
+      final (link, _) = wire();
+      // Let the startup availability query resolve (hwDelay 200 ms).
+      async.elapse(const Duration(milliseconds: 300));
+
+      unawaited(link.toggleScan());
+      async.elapse(const Duration(seconds: 3));
+      expect(link.devices, isNotEmpty);
+      unawaited(link.toggleScan()); // stop scanning
+      async.elapse(const Duration(milliseconds: 100));
+
+      unawaited(link.connectToDevice(deviceId));
+      // Mid-transition: _startScan must bail BEFORE clearing the list.
+      unawaited(link.toggleScan());
+      async.elapse(const Duration(milliseconds: 100));
+      expect(link.devices, isNotEmpty);
+      expect(link.isScanning, isFalse);
+
+      async.elapse(const Duration(seconds: 4)); // let the connect settle
+      teardownLink(async, link);
+    });
+  });
+
+  test('a failing calibration read does not prevent streaming', () {
+    fakeAsync((async) {
+      MockBlePlatform.instance.failCalibrationRead = true;
+      final (link, seen) = wire();
+
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+
+      expect(link.isStreaming, isTrue);
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('demo device streams and disconnects cleanly', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+      var received = 0;
+      link.onAdcData = (_) => received++;
+
+      unawaited(link.connectToDemoDevice());
+      expect(link.isStreaming, isTrue);
+      async.elapse(const Duration(milliseconds: 100));
+      expect(received, greaterThan(0));
+
+      unawaited(link.disconnectSelectedDevice());
+      async.elapse(const Duration(milliseconds: 100));
+      expect(link.link.state, BtLinkState.idle);
+      expect(seen, isEmpty);
+    });
+  });
+}
+
+
+
+

--- a/test/graph_controller_test.dart
+++ b/test/graph_controller_test.dart
@@ -138,16 +138,18 @@ void main() {
 
   /// The viewport-side half of the per-stream reset: when a new device stream
   /// clears the hub, the live tab snaps the controller back to live follow
-  /// via [GraphController.goLive]. These tests document why that call must
-  /// happen.
+  /// via [GraphController.goLive]. [effectiveRange] is additionally
+  /// self-defensive against stale parked windows (it clamps rather than
+  /// throwing), so the goLive call is a UX nicety, not a crash guard.
   group('GraphController across a stream reset', () {
-    test('a stale panned window throws against an empty buffer', () {
-      // The crash the reset prevents: a window parked deep in history (set
-      // while the old stream had plenty of data) clamped against a cleared
-      // hub has inverted clamp limits.
+    test('a stale panned window clamps instead of throwing', () {
+      // A window parked deep in history (set while the old stream had plenty
+      // of data) evaluated against a cleared hub: the start clamp runs first,
+      // so the end clamp can never receive inverted limits.
       final ctrl = GraphController(minLiveSpan: 20000);
       ctrl.applyWindow(100000, 100000, 300000, 0); // user panned into history
-      expect(() => ctrl.effectiveRange(0, 0), throwsArgumentError);
+      expect(ctrl.effectiveRange(0, 0), (0, 1));
+      expect(ctrl.effectiveRange(50, 0), (49, 50));
     });
 
     test('goLive restores a safe live-follow range', () {

--- a/test/recording_controller_test.dart
+++ b/test/recording_controller_test.dart
@@ -94,7 +94,7 @@ void main() {
       expect(saved, isNotNull);
       expect(saved!.isCompleted, isTrue);
       expect(saved.sampleCount, n);
-      expect(saved.name, matches(RegExp(r'^\d+/\d+ \d+:\d{2}$')));
+      expect(saved.name, matches(RegExp(r'^\d+/\d+ \d+:\d{2}:\d{2}$')));
       expect(stop.name, saved.name);
       expect(saved.channelLabels, '["Load Cell 1","Load Cell 2","Ch 3","Ch 4"]');
     },


### PR DESCRIPTION
### Silent failures -> loud failures
- **False "Connected"**: if the GATT service/ADC characteristic is missing,
  post-connect setup now throws (`StateError`) into the existing
  teardown + `BleConnectionFailed` path instead of advancing to
  `streaming` with no data flowing (`subscribeToAdcFeed` returns bool).
- **Calibration read no longer fatal**: a failed read of the (still-TODO)
  calibration characteristic is logged and skipped; defaults are used, and
  the connection proceeds. `TODO(cal)` left to escalate to a warning
  event once real parsing lands.
- **Unexpected drops surface**: new `BleConnectionLost` app event, emitted
  only when the link was up and the drop wasn't user-requested (no
  double-report with `BleConnectionFailed`/`BleDisconnectTimeout`).
  Shell toast: "Connection to X lost."

### Data integrity visibility
- `DataHub.protocolErrorSeen` latches on the first malformed/short ADC
  packet of a stream (dropped but never hidden); the live status bar
  shows a warning icon + tooltip. `reportProtocolError()` notifies once
  per stream

### Robustness
- `GraphController.effectiveRange` clamps the window start before the
  end, so a stale parked window can no longer produce an inverted-clamp
  throw (the old "throws" test now documents the clamp behavior).
- `TODO(ux)` markers for scan-while-streaming (currently kills an active
  recording); policy decision deferred.

### Schema / config
- `Sessions`: defaults removed from `sampleRate`, `channelCount`,
  `channelLabels`, `tares`, `calibrationSlope`, `calibrationOffset`,
  `visibleChannels` — drift now enforces them at compile time on insert.
  Schema v6 (dev-wipe migration applies). `database.g.dart` regenerated.
- `DeviceCalibration.excitationV` 4.5 → 4.53 to match hardware.
- Removed unused `convert` dependency.
- Session auto-names include seconds (same-minute collision);
  connect-failure snackbars now include the underlying error.

### Tests
- New `test/ble_link_manager_test.dart`: 10 tests covering happy path,
  missing ADC service, unexpected disconnect, hung disconnect,
  mid-setup disconnect race, double-connect, foreign-notification drop,
  scan guard, calibration failure, demo lifecycle.
- New `MockBlePlatform` knobs: `includeAdcService`,
  `failCalibrationRead`, `hangDisconnect`, `resetKnobs()`.
- Test file documents the fakeAsync hazard: link teardowns must settle
  inside the fake clock or the static universal_ble command queue wedges.

## Verification
- `flutter analyze`: clean.
- `flutter test`: 105/105 pass (94 prior + 10 new BLE-link tests + 1 new
  decoder notify-once regression test).