### PR TITLE
Simplify BLE link states, collapse graph adapters, drop dead state

### DIFF
--- a/lib/models/force_unit.dart
+++ b/lib/models/force_unit.dart
@@ -1,62 +1,69 @@
-/// Supported force and electrical display units.
-enum ForceUnit {
-  kN('kN', 'Kilonewtons'),
-  lbf('lbf', 'Pounds-force'),
-  kgf('kgf', 'Kilogram-force'),
-  n('N', 'Newtons'),
-  mV('mV', 'Raw Voltage'),
-  raw('Raw', 'ADC Counts');
+/// Analog front-end constants (fixed by hardware): the load cell signal
+/// passes a 101x gain stage into a 24-bit bipolar ADC with a 1.2V full-scale
+/// reference. The load-cell side of the chain (excitation, sensitivity,
+/// capacity) lives in DeviceCalibration (services/data_hub.dart).
+const double adcFullScaleV = 1.2;
+const double frontEndGain = 101.0;
+const int adcCountsPerPolarity = 1 << 23; // 24-bit bipolar: 2^23 per side
 
-  const ForceUnit(this.symbol, this.label);
+/// mV at the load cell output per ADC count.
+const double rawToMvMultiplier =
+    adcFullScaleV / adcCountsPerPolarity / frontEndGain * 1000.0;
+
+/// Supported force and electrical display units.
+///
+/// Each value declares its conversion out of raw ADC counts as constructor
+/// data: force units carry [kgfFactor] (1 kgf expressed in the unit) and
+/// convert via the device calibration slope; electrical/raw units carry a
+/// [fixedRawFactor] and ignore calibration. Exactly one of the two must be
+/// set per value (enforced by the constructor assert).
+enum ForceUnit {
+  kN('kN', 'Kilonewtons', kgfFactor: 9.80665 / 1000),
+  lbf('lbf', 'Pounds-force', kgfFactor: 2.20462),
+  kgf('kgf', 'Kilogram-force', kgfFactor: 1.0),
+  n('N', 'Newtons', kgfFactor: 9.80665),
+  mV('mV', 'Raw Voltage', fixedRawFactor: rawToMvMultiplier),
+  raw('Raw', 'ADC Counts', fixedRawFactor: 1.0);
+
+  const ForceUnit(
+    this.symbol,
+    this.label, {
+    this.kgfFactor,
+    this.fixedRawFactor,
+  }) : assert(
+         (kgfFactor == null) != (fixedRawFactor == null),
+         'declare exactly one conversion factor',
+       );
+
   final String symbol;
   final String label;
 
-  /// Hardware constant for raw to mV conversion (1.2V Vref, 101x Gain, 24-bit bipolar ADC)
-  static const double rawToMvMultiplier = (1.2 / 8388608.0 / 101.0) * 1000.0;
+  /// 1 kgf expressed in this unit (force units only).
+  final double? kgfFactor;
 
-  double get _kgfMultiplier => switch (this) {
-    ForceUnit.kgf => 1.0,
-    ForceUnit.n => 9.80665,
-    ForceUnit.kN => 9.80665 / 1000.0,
-    ForceUnit.lbf => 2.20462,
-    ForceUnit.mV => 1.0, // Fallback, not typically used
-    ForceUnit.raw => 1.0, // Fallback, not typically used
-  };
+  /// Fixed raw-counts -> unit multiplier (electrical/raw units only).
+  final double? fixedRawFactor;
 
   /// Convert a raw ADC value to this unit, given the kgf/raw slope
   double fromRaw(double rawTared, double calibrationSlope) =>
       rawTared * multiplierFromRaw(calibrationSlope);
 
   /// Get the multiplier from raw ADC counts to this unit
-  double multiplierFromRaw(double calibrationSlope) {
-    if (this == ForceUnit.mV) {
-      return rawToMvMultiplier;
-    }
-    if (this == ForceUnit.raw) {
-      return 1.0;
-    }
-    return calibrationSlope * _kgfMultiplier;
-  }
+  double multiplierFromRaw(double calibrationSlope) =>
+      fixedRawFactor ?? calibrationSlope * kgfFactor!;
 
   /// Format a [value] (already in this unit) with an explicit sign, and a
-  /// trailing [suffix] when given (e.g. the unit symbol). When [padded], the
-  /// number is left-padded for column alignment in the stats table.
-  String _formatValue(double value, String suffix, {bool padded = true}) {
+  /// trailing [suffix] when given (e.g. the unit symbol).
+  String _formatValue(double value, String suffix) {
     final sign = value < 0 ? '-' : '+';
     final decimals = this == ForceUnit.mV ? 4 : (this == ForceUnit.raw ? 0 : 3);
-    var numStr = value.abs().toStringAsFixed(decimals);
-    if (padded) {
-      final padding = this == ForceUnit.mV
-          ? 8
-          : (this == ForceUnit.raw ? 6 : 7);
-      numStr = numStr.padLeft(padding);
-    }
+    final numStr = value.abs().toStringAsFixed(decimals);
     return suffix.isEmpty ? '$sign$numStr' : '$sign$numStr $suffix';
   }
 
   /// Format a [value] (already in this unit) with an explicit sign, without
-  /// the unit suffix, and without extra padding. Ideal for constrained layouts.
-  String formatValueOnly(double value) => _formatValue(value, '', padded: false);
+  /// the unit suffix. Ideal for constrained layouts.
+  String formatValueOnly(double value) => _formatValue(value, '');
 
   /// Format a value (already in this unit) for display.
   String format(double value) => _formatValue(value, symbol);

--- a/lib/models/graph_data_source.dart
+++ b/lib/models/graph_data_source.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+
+import 'bucket_series.dart';
+import 'gap_list.dart';
+
+/// A single channel's raw circular-buffer data plus its precomputed extremes,
+/// tare offset, and raw-value [BucketSeries]. Returned by
+/// [GraphDataSource.channel].
+typedef ChannelSeries = ({
+  List<int> data,
+  double min,
+  double max,
+  double tare,
+  BucketSeries buckets,
+});
+
+/// Data interface required by the shared graph components (main graph,
+/// minimap, etc.). Implemented directly by the two sources — [DataHub]
+/// (live stream) and [SessionData] (static recording) — so the components
+/// render either without an adapter layer.
+///
+/// Sources are not required to be [ChangeNotifier]s; instead they expose a
+/// [repaint] [Listenable] that fires when their data changes (a never-firing
+/// listenable is fine for static data). This keeps the interface usable by
+/// both live and static sources, and leaves room for composed/derived
+/// sources later.
+abstract interface class GraphDataSource {
+  /// Total number of logical samples generated so far (can exceed
+  /// bufferCapacity).
+  int get totalSamples;
+
+  /// The size of the circular buffer. Used to modulus array indices.
+  int get bufferCapacity;
+
+  /// The oldest available sample index (absolute time).
+  int get oldestSample;
+
+  /// The sample rate of the data (Hz).
+  int get sampleRate;
+
+  /// The calibration slope used to convert raw counts to kgf.
+  double get calibrationSlope;
+
+  /// Notifies listeners when the underlying data changes.
+  Listenable get repaint;
+
+  /// Returns the series (data + extremes + tare + buckets) for a given
+  /// channel index.
+  ChannelSeries channel(int channelIndex);
+
+  /// Bucket aggregates of the first-difference series for a channel,
+  /// enabling the derivative graph's bucket fast path; null when the source
+  /// does not track them (the derivative then renders on the exact path).
+  /// Named `diffBucketsFor` so implementations may keep their
+  /// `diffBuckets` accumulator field without a member collision.
+  BucketSeries? diffBucketsFor(int channelIndex);
+
+  /// Sample ranges where data was lost (dropped packets). The buffer holds
+  /// held values there; renderers break the polyline and hatch these ranges.
+  /// Sources that cannot have gaps return an empty (never-mutated) [GapList].
+  GapList get gaps;
+}
+
+/// A [Listenable] that never fires; use as [GraphDataSource.repaint] for
+/// static data sources (e.g. a loaded session).
+final Listenable kNeverRepaints = _NeverListenable();
+
+class _NeverListenable extends Listenable {
+  @override
+  void addListener(VoidCallback listener) {}
+  @override
+  void removeListener(VoidCallback listener) {}
+}

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -71,10 +71,7 @@ class _DevicesTabState extends State<DevicesTab> {
     final isStreaming = bt.isStreaming;
     // The link is up (setting up OR streaming) — the connected card is shown for
     // both so the user can see progress and cancel a stuck setup.
-    final isLinkUp = bt.selectedDeviceId.isNotEmpty;
-    // The specific device currently in its post-disconnect cooldown window (web
-    // only); its row shows "Please wait…" instead of "Connect".
-    final coolingDownDeviceId = bt.isCoolingDown ? bt.link.deviceId : '';
+    final isLinkUp = bt.isLinkUp;
 
     return SafeArea(
       child: ListView(
@@ -210,11 +207,7 @@ class _DevicesTabState extends State<DevicesTab> {
                           () => bt.connectToDevice(device.deviceId),
                           device.name ?? 'device',
                         ),
-                  child: Text(
-                    device.deviceId == coolingDownDeviceId
-                        ? 'Please wait…'
-                        : 'Connect',
-                  ),
+                  child: const Text('Connect'),
                 ),
               ),
             ),

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/app_settings.dart';
-import '../models/bucket_series.dart';
-import '../models/gap_list.dart';
 
 import '../services/ble_link_manager.dart';
 import '../services/data_hub.dart';
@@ -25,63 +23,11 @@ class LiveTab extends StatefulWidget {
   State<LiveTab> createState() => _LiveTabState();
 }
 
-/// Adapts a live [DataHub] to the [GraphDataSource] interface consumed by the
-/// shared graph widgets. Forwards the hub's change notifications.
-class _LiveDataSource extends ChangeNotifier implements GraphDataSource {
-  final DataHub _hub;
-  _LiveDataSource(this._hub) {
-    _hub.addListener(notifyListeners);
-  }
-
-  @override
-  void dispose() {
-    _hub.removeListener(notifyListeners);
-    super.dispose();
-  }
-
-  @override
-  int get totalSamples => _hub.totalSamples;
-
-  @override
-  int get bufferCapacity => DataHub.maxDataSz;
-
-  @override
-  int get oldestSample => _hub.totalSamples > DataHub.maxDataSz
-      ? _hub.totalSamples - DataHub.maxDataSz
-      : 0;
-
-  @override
-  int get sampleRate => DataHub.samplesPerSec;
-
-  @override
-  double get calibrationSlope => _hub.deviceCalibration.slope;
-
-  @override
-  Listenable get repaint => this;
-
-  @override
-  ChannelSeries channel(int channelIndex) => (
-    data: _hub.rawData[channelIndex],
-    min: _hub.rawMin[channelIndex].toDouble(),
-    max: _hub.rawMax[channelIndex].toDouble(),
-    tare: _hub.tare[channelIndex],
-    buckets: _hub.valueBuckets[channelIndex].series,
-  );
-
-  @override
-  BucketSeries? diffBuckets(int channelIndex) =>
-      _hub.diffBuckets[channelIndex].series;
-
-  @override
-  GapList get gaps => _hub.gaps;
-}
-
 class _LiveTabState extends State<LiveTab> {
   final GraphController _graphCtrl = GraphController(
     minLiveSpan: 20 * DataHub.samplesPerSec,
   );
   bool _showDerivative = false;
-  _LiveDataSource? _dataSource;
   DataHub? _hub;
 
   /// Last seen hub generation; a change means the hub was cleared for a new
@@ -100,8 +46,6 @@ class _LiveTabState extends State<LiveTab> {
       _hub = hub;
       _lastGeneration = hub.generation;
       hub.addListener(_onHubChanged);
-      _dataSource?.dispose();
-      _dataSource = _LiveDataSource(hub);
     }
   }
 
@@ -122,7 +66,6 @@ class _LiveTabState extends State<LiveTab> {
   @override
   void dispose() {
     _hub?.removeListener(_onHubChanged);
-    _dataSource?.dispose();
     _graphCtrl.dispose();
     super.dispose();
   }
@@ -235,7 +178,7 @@ class _LiveTabState extends State<LiveTab> {
               showDerivative: _showDerivative,
             ),
           if (isConnected)
-            Expanded(child: _buildGraphArea(settings))
+            Expanded(child: _buildGraphArea(settings, hub))
           else
             const Expanded(child: DisconnectedPrompt()),
           if (isConnected)
@@ -255,10 +198,9 @@ class _LiveTabState extends State<LiveTab> {
     );
   }
 
-  Widget _buildGraphArea(AppSettings settings) {
-    if (_dataSource == null) return const SizedBox.shrink();
+  Widget _buildGraphArea(AppSettings settings, DataHub hub) {
     return GraphWorkspace(
-      data: _dataSource!,
+      data: hub,
       ctrl: _graphCtrl,
       settings: settings,
       activeChannels: settings.activeChannelIndices,

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -8,8 +8,6 @@ import 'package:provider/provider.dart';
 import 'package:file_selector/file_selector.dart';
 
 import '../models/app_settings.dart';
-import '../models/bucket_series.dart';
-import '../models/gap_list.dart';
 import '../services/database.dart';
 import '../services/session_storage.dart';
 import '../utils/format.dart';
@@ -24,47 +22,6 @@ class SessionDetailScreen extends StatefulWidget {
 
   @override
   State<SessionDetailScreen> createState() => _SessionDetailScreenState();
-}
-
-/// Adapts static [SessionData] to the [GraphDataSource] interface. Session data
-/// never changes, so [repaint] is a never-firing listenable.
-class _SessionDataSource implements GraphDataSource {
-  final SessionData _data;
-  const _SessionDataSource(this._data);
-
-  @override
-  int get totalSamples => _data.sampleCount;
-
-  @override
-  int get bufferCapacity => _data.sampleCount;
-
-  @override
-  int get oldestSample => 0;
-
-  @override
-  int get sampleRate => _data.sampleRate;
-
-  @override
-  double get calibrationSlope => _data.calibrationSlope;
-
-  @override
-  Listenable get repaint => kNeverRepaints;
-
-  @override
-  ChannelSeries channel(int channelIndex) => (
-    data: _data.channels[channelIndex],
-    min: _data.mins[channelIndex],
-    max: _data.maxs[channelIndex],
-    tare: _data.tares[channelIndex],
-    buckets: _data.valueBuckets[channelIndex].series,
-  );
-
-  @override
-  BucketSeries? diffBuckets(int channelIndex) =>
-      _data.diffBuckets[channelIndex].series;
-
-  @override
-  GapList get gaps => _data.gaps;
 }
 
 class _SessionDetailScreenState extends State<SessionDetailScreen> {
@@ -205,7 +162,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
             child: Padding(
               padding: const EdgeInsets.all(8.0),
               child: GraphWorkspace(
-                data: _SessionDataSource(data),
+                data: data,
                 ctrl: _graphCtrl,
                 settings: settings,
                 activeChannels: [
@@ -242,25 +199,6 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                   value: '${_session.sampleRate} Hz',
                 ),
                 _StatRow(label: 'Samples', value: '${data.sampleCount}'),
-                for (int ch = 0; ch < data.channels.length; ch++) ...[
-                  const Divider(height: 16),
-                  Text(
-                    channelLabels[ch],
-                    style: TextStyle(
-                      fontWeight: FontWeight.w500,
-                      color: getChannelColor(ch),
-                    ),
-                  ),
-                  _StatRow(
-                    label: 'Peak',
-                    value: settings.displayUnit.format(
-                      settings.displayUnit.fromRaw(
-                        data.maxs[ch] - data.tares[ch],
-                        data.calibrationSlope,
-                      ),
-                    ),
-                  ),
-                ],
               ],
             ),
           ),

--- a/lib/services/adc_packet_decoder.dart
+++ b/lib/services/adc_packet_decoder.dart
@@ -36,9 +36,7 @@ class AdcPacketDecoder {
   void onCalibrationPacket(Uint8List data) {
     // TODO: implement calibration parsing
     final calibration = DeviceCalibration();
-    debugPrint(
-      'Calibration ${calibration.slope}, offset ${calibration.offset}',
-    );
+    debugPrint('Calibration ${calibration.slope}');
     hub.updateCalibration(calibration);
   }
 

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -42,14 +42,6 @@ enum BtLinkState {
   /// disconnect() timeout). Connect must stay blocked while in this state so we
   /// never issue a connect against a half-torn-down link.
   disconnecting,
-
-  /// The link has fully disconnected, but the platform stack (Web Bluetooth on
-  /// Chrome in particular) may not yet be ready to accept a fresh connection to
-  /// the SAME device. We hold the link here for [BleLinkManager.reconnectSettleDelay]
-  /// after teardown so the UI keeps Connect disabled (with a "please wait" hint)
-  /// instead of silently sleeping inside the connect call. Web-only; native
-  /// stacks go straight back to [idle] on disconnect.
-  cooldown,
 }
 
 /// All per-device link state for a single BLE device.
@@ -83,7 +75,6 @@ class DeviceLink {
   /// The single "usable / connected" truth: link up AND the ADC feed is flowing.
   bool get isStreaming => state == BtLinkState.streaming;
   bool get isDisconnecting => state == BtLinkState.disconnecting;
-  bool get isCoolingDown => state == BtLinkState.cooldown;
 
   /// Reset back to the idle sentinel (used on disconnect).
   void reset() {
@@ -94,21 +85,10 @@ class DeviceLink {
   }
 
   bool get isDemoDevice => deviceId == 'demo_device';
-
-  /// Like [reset], but parks the link in [BtLinkState.cooldown] for the given
-  /// [deviceId] (the device just torn down). Keeps [deviceId]/[name] so the UI
-  /// can label that specific device's row while the reconnect settle window
-  /// elapses; everything else is cleared as in [reset].
-  void enterCooldown(String deviceId, String name) {
-    this.deviceId = deviceId;
-    this.name = name;
-    state = BtLinkState.cooldown;
-    rssi = null;
-  }
 }
 
 /// The BLE link state machine: adapter availability, scanning, connect /
-/// post-connect setup / disconnect / cooldown, and live RSSI polling.
+/// post-connect setup / disconnect, and live RSSI polling.
 ///
 /// This class owns *only* the link. It knows nothing about the wire protocol
 /// or recording: raw notification bytes and calibration reads are handed off
@@ -130,24 +110,19 @@ class BleLinkManager extends ChangeNotifier {
   /// Chrome) need a moment to finish tearing down GATT before they will accept
   /// a fresh connection to the SAME device. Reconnecting sooner makes Chrome
   /// briefly accept then drop the link (and throws "Cannot discover services if
-  /// the device is not connected"). On web we hold the link in
-  /// [BtLinkState.cooldown] for this window after teardown — Connect stays
-  /// disabled (with a hint) until it elapses, instead of silently sleeping
-  /// inside [connectToDevice].
+  /// the device is not connected"). [connectToDevice] waits out the remainder
+  /// of this window (computed from [_lastDisconnectAt]) in the visible
+  /// [BtLinkState.connecting] state. Web-only; native stacks don't exhibit the
+  /// too-soon-reconnect race and skip the wait.
   static const Duration reconnectSettleDelay = Duration(milliseconds: 1000);
 
-  /// Timestamp of the last observed disconnect, keyed by deviceId. Kept on the
-  /// manager (not on [DeviceLink], which gets reset on disconnect) so the
-  /// settle window survives the reset.
+  /// Timestamp of the last observed disconnect, keyed by deviceId; read by
+  /// [connectToDevice] to compute the remaining settle wait on web. Kept on
+  /// the manager (not on [DeviceLink], which gets reset on disconnect) so the
+  /// window survives the reset.
   ///
   /// MULTI-DEVICE (Path A): already per-device via this map.
   final Map<String, DateTime> _lastDisconnectAt = {};
-
-  /// One-shot timer that returns the active link from [BtLinkState.cooldown]
-  /// back to [BtLinkState.idle] once [reconnectSettleDelay] has elapsed since
-  /// the last teardown. Web-only (see [_endLink]). Cancelled if the
-  /// link is superseded before it fires.
-  Timer? _cooldownTimer;
 
   /// Monotonic counter bumped on every connect request, disconnect request, and
   /// teardown. The async post-connect setup in [_onConnectionChange] captures
@@ -183,16 +158,12 @@ class BleLinkManager extends ChangeNotifier {
   /// True while a disconnect has been requested but not yet confirmed.
   bool get isDisconnecting => _link.isDisconnecting;
 
-  /// True during the post-disconnect settle window (web only) — the link has
-  /// fully torn down but the stack isn't yet ready to reconnect to the same
-  /// device. Connect stays blocked while this is true.
-  bool get isCoolingDown => _link.isCoolingDown;
+  /// True while the GATT link is up (during post-connect setup or streaming).
+  bool get isLinkUp => _link.isLinkUp;
 
-  /// A link is "busy" whenever it is mid-transition, active, or cooling down
-  /// after a disconnect; device-row Connect buttons stay disabled until the
-  /// link returns to idle. This is what prevents the disconnect→reconnect
-  /// double-click race — including the web post-disconnect settle window where
-  /// the stack isn't yet ready to accept a fresh connection.
+  /// A link is "busy" whenever it is mid-transition or active; device-row
+  /// Connect buttons stay disabled until the link returns to idle. This is
+  /// what prevents the disconnect→reconnect double-click race.
   bool get linkBusy => _link.state != BtLinkState.idle;
 
   /// Device id of the active link whenever the GATT link is up (during setup or
@@ -322,11 +293,8 @@ class BleLinkManager extends ChangeNotifier {
     // empty list with no picker having opened).
     //
     // MULTI-DEVICE (Path A): this becomes "if any link is mid-transition"
-    // (connecting/disconnecting/cooldown) rather than a single flag.
-    if (_link.isConnecting ||
-        _link.isDisconnecting ||
-        _link.isCoolingDown ||
-        _link.state == BtLinkState.connected) {
+    // (connecting/disconnecting) rather than a single flag.
+    if (_link.state != BtLinkState.idle && !_link.isStreaming) {
       return;
     }
     // TODO(ux): starting a scan while streaming disconnects the active link
@@ -413,40 +381,17 @@ class BleLinkManager extends ChangeNotifier {
 
   /// Common teardown for every path that ends a link (clean disconnect, failed
   /// post-connect setup, disconnect timeout): stop RSSI polling, stamp the
-  /// disconnect time, and clear the link. Recording is NOT handled here —
+  /// disconnect time (the web reconnect-settle wait in [connectToDevice] reads
+  /// it), and clear the link. Recording is NOT handled here —
   /// [RecordingController] observes this notifier and stops its session when
-  /// streaming ends.
-  ///
-  /// On web we don't go straight to [BtLinkState.idle]: we park the link in
-  /// [BtLinkState.cooldown] for the remainder of [reconnectSettleDelay] so the
-  /// UI keeps Connect disabled (with a hint) until Chrome has finished GATT
-  /// teardown. Native stacks don't exhibit the too-soon-reconnect race, so they
-  /// reset directly to idle. Does NOT call [notifyListeners] — callers do.
-  void _endLink(String deviceId, String name) {
+  /// streaming ends. Does NOT call [notifyListeners] — callers do.
+  void _endLink(String deviceId) {
     // Supersede any in-flight post-connect setup pass so it bails out instead of
     // writing state for a link we're tearing down.
     _setupGeneration++;
     _stopRssiPolling();
     _lastDisconnectAt[deviceId] = DateTime.now();
-    _cooldownTimer?.cancel();
-    _cooldownTimer = null;
-
-    if (!kIsWeb) {
-      _link.reset();
-      return;
-    }
-
-    // Web: hold the link in cooldown for the settle window, then release it.
-    _link.enterCooldown(deviceId, name);
-    _cooldownTimer = Timer(reconnectSettleDelay, () {
-      _cooldownTimer = null;
-      // Only release if we're still cooling down THIS device (a new connect
-      // attempt to a different device, or a fresh teardown, may have moved on).
-      if (_link.isCoolingDown && _link.deviceId == deviceId) {
-        _link.reset();
-        notifyListeners();
-      }
-    });
+    _link.reset();
   }
 
   /// True if the post-connect setup pass that captured [gen] for [deviceId] has
@@ -543,14 +488,19 @@ class BleLinkManager extends ChangeNotifier {
         }
         debugPrint('Post-connect setup failed for $deviceId: $e');
         final String name = _link.name.isEmpty ? deviceId : _link.name;
-        _endLink(deviceId, name);
+        _endLink(deviceId);
         _events.emit(BleConnectionFailed(name));
         notifyListeners();
       }
     } else {
+      // A disconnect callback for an already-idle link (e.g. a late event
+      // from a previously torn-down connection): nothing to tear down, and
+      // running teardown would re-stamp the settle window the next connect
+      // waits on.
+      if (_link.deviceId.isEmpty) return;
+
       // Disconnect resolved (whether user-requested or unexpected): run the
-      // common teardown, which (on web) parks the link in cooldown for the
-      // reconnect settle window before returning it to the idle sentinel.
+      // common teardown back to the idle sentinel.
       final String name = _link.name.isEmpty ? deviceId : _link.name;
       // An unexpected drop while the link was up (setting up or streaming)
       // gets a user notice. User-requested disconnects arrive here in
@@ -559,7 +509,7 @@ class BleLinkManager extends ChangeNotifier {
       final bool wasActive =
           _link.state == BtLinkState.connected ||
           _link.state == BtLinkState.streaming;
-      _endLink(deviceId, name);
+      _endLink(deviceId);
       if (wasActive) {
         _events.emit(BleConnectionLost(name));
       }
@@ -592,12 +542,10 @@ class BleLinkManager extends ChangeNotifier {
       await _stopScan();
     }
     // Block connecting while a link is busy (connecting/connected/disconnecting)
-    // or cooling down. The disconnecting/cooldown cases are what stop the
-    // "double-click after Disconnect" race: the device row's Connect button is
-    // disabled until the link returns to idle — first via the disconnect
-    // callback (or the disconnect() timeout reconciliation), then through the
-    // post-disconnect cooldown window on web — so we never reach here against a
-    // link that the stack isn't yet ready to reconnect.
+    // so we never issue a connect against a link that is still tearing down:
+    // the device row's Connect button is disabled until the link returns to
+    // idle (via the disconnect callback or the disconnect() timeout
+    // reconciliation).
     //
     // NOTE: we deliberately track link state from the event callbacks
     // (_onConnectionChange) rather than from UniversalBle.getConnectionState().
@@ -611,21 +559,29 @@ class BleLinkManager extends ChangeNotifier {
     if (_link.state != BtLinkState.idle) {
       return;
     }
-    // A pending cooldown timer (from a prior teardown) is now moot: its guard
-    // would no-op once we move to `connecting`, but cancel it eagerly so it
-    // can't fire against this new attempt.
-    _cooldownTimer?.cancel();
-    _cooldownTimer = null;
     // Supersede any lingering setup pass from a prior attempt.
-    _setupGeneration++;
+    final int gen = ++_setupGeneration;
     _link.deviceId = deviceId;
     _link.state = BtLinkState.connecting;
     notifyListeners();
 
-    // The post-disconnect settle window is now enforced as the visible
-    // [BtLinkState.cooldown] state (see [_endLink]) BEFORE Connect is re-enabled,
-    // so by the time we get here the stack has already had time to finish GATT
-    // teardown. No inline sleep is needed.
+    // Web Bluetooth needs a moment after GATT teardown before it will accept
+    // a fresh connection to the SAME device (reconnecting sooner makes Chrome
+    // briefly accept then drop the link). Wait out the remainder of the
+    // settle window here, in the visible "Connecting…" state. Native stacks
+    // don't exhibit the race and skip the wait entirely.
+    if (kIsWeb) {
+      final last = _lastDisconnectAt[deviceId];
+      if (last != null) {
+        final remaining =
+            reconnectSettleDelay - DateTime.now().difference(last);
+        if (remaining > Duration.zero) {
+          await Future<void>.delayed(remaining);
+        }
+        // A teardown superseded this attempt while we waited.
+        if (gen != _setupGeneration) return;
+      }
+    }
 
     try {
       await UniversalBle.connect(deviceId);
@@ -653,7 +609,7 @@ class BleLinkManager extends ChangeNotifier {
 
     if (_link.isDemoDevice) {
       _demoSource?.stop();
-      _endLink(_link.deviceId, _link.name);
+      _endLink(_link.deviceId);
       notifyListeners();
       return;
     }
@@ -683,7 +639,7 @@ class BleLinkManager extends ChangeNotifier {
     if (_link.deviceId == deviceId &&
         _link.state == BtLinkState.disconnecting) {
       debugPrint('Disconnect did not settle for $deviceId; forcing idle');
-      _endLink(deviceId, deviceName);
+      _endLink(deviceId);
       _events.emit(BleDisconnectTimeout(deviceName));
       notifyListeners();
     }
@@ -772,8 +728,6 @@ class BleLinkManager extends ChangeNotifier {
     onCalibrationData = null;
     _demoSource?.stop();
     _stopRssiPolling();
-    _cooldownTimer?.cancel();
-    _cooldownTimer = null;
     // Supersede any in-flight post-connect setup pass so it bails out.
     _setupGeneration++;
 

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -6,6 +6,7 @@ import 'adc_protocol.dart';
 import '../models/bucket_series.dart';
 import '../models/force_unit.dart';
 import '../models/gap_list.dart';
+import '../models/graph_data_source.dart';
 
 /// Invoked by [DataHub.commitBatch] with the exact slice of samples appended
 /// by the decoder for one packet ([startIdx] is the logical index of the
@@ -23,7 +24,13 @@ typedef SamplesAppendedListener = void Function(int startIdx, int count);
 /// Dropped samples are tracked out-of-band in [gaps]; the ring buffer holds
 /// the previous sample's value across a gap, so every stored value is a real
 /// ADC reading and downstream consumers need no magic-value checks.
-class DataHub extends ChangeNotifier {
+///
+/// Implements [GraphDataSource] directly (no adapter): the graph components
+/// read the ring buffer, buckets and gaps through the interface, and repaint
+/// off this notifier. The [totalSamples] and [gaps] fields already satisfy
+/// their interface counterparts; the rest are thin getters over existing
+/// state.
+class DataHub extends ChangeNotifier implements GraphDataSource {
   /// Number of ADC channels the device streams. This is also the number of
   /// lines stored and displayed: channel index == storage index == display index.
   static const int numAdcChannels = nwNumAdcChan;
@@ -74,6 +81,7 @@ class DataHub extends ChangeNotifier {
     growable: false,
   );
   int _tareCount = 0;
+  @override
   int totalSamples = 0;
   DeviceCalibration deviceCalibration = DeviceCalibration();
 
@@ -91,6 +99,7 @@ class DataHub extends ChangeNotifier {
 
   /// Sample ranges lost to dropped BLE packets (absolute indices). The ring
   /// buffer holds the held previous value across these ranges.
+  @override
   final GapList gaps = GapList();
 
   /// Observers notified by [commitBatch] with the exact slice of samples
@@ -226,6 +235,37 @@ class DataHub extends ChangeNotifier {
     deviceCalibration = calibration;
   }
 
+  // -- GraphDataSource --------------------------------------------------------
+
+  @override
+  int get bufferCapacity => maxDataSz;
+
+  @override
+  int get oldestSample =>
+      totalSamples > maxDataSz ? totalSamples - maxDataSz : 0;
+
+  @override
+  int get sampleRate => samplesPerSec;
+
+  @override
+  double get calibrationSlope => deviceCalibration.slope;
+
+  @override
+  Listenable get repaint => this;
+
+  @override
+  ChannelSeries channel(int channelIndex) => (
+    data: rawData[channelIndex],
+    min: rawMin[channelIndex].toDouble(),
+    max: rawMax[channelIndex].toDouble(),
+    tare: tare[channelIndex],
+    buckets: valueBuckets[channelIndex].series,
+  );
+
+  @override
+  BucketSeries? diffBucketsFor(int channelIndex) =>
+      diffBuckets[channelIndex].series;
+
   /// Whether the newest sample is a dropped one — i.e. the live readings the
   /// stats display are held values, not fresh data.
   bool get liveEdgeIsGap => gaps.contains(totalSamples - 1);
@@ -308,22 +348,35 @@ class DataHub extends ChangeNotifier {
   }
 }
 
+/// Calibration parameters of a load cell channel and the resulting
+/// raw-count -> kgf slope.
+///
+/// Signal chain (per-channel device parameters — becoming configurable via
+/// the device's calibration characteristic):
+///   [excitationV] excitation
+///   -> load cell ([sensitivityMvV] mV/V at [capacityKg] full scale, i.e.
+///      sensitivity x excitation mV output at full-scale load)
+///   -> 101x front-end gain
+///   -> 1.2V FSR 24-bit bipolar ADC (constants in force_unit.dart)
+///
+/// Today every field is a compile-time default; the decoder reads the
+/// calibration characteristic but parsing is a TODO.
 class DeviceCalibration {
   DeviceCalibration({
-    this.offset = 0,
     this.capacityKg = 200.0,
     this.sensitivityMvV = 2.0,
     this.excitationV = 4.53,
   });
 
-  final int offset;
   final double capacityKg;
   final double sensitivityMvV;
   final double excitationV;
 
-  /// Calculates kgf per raw count dynamically based on the parameters
+  /// kgf per raw count: the full-scale output ([sensitivityMvV] x
+  /// [excitationV] mV at [capacityKg]) mapped through the front-end's
+  /// mV-per-count.
   double get slope {
     final maxMv = sensitivityMvV * excitationV;
-    return (capacityKg * ForceUnit.rawToMvMultiplier) / maxMv;
+    return capacityKg * rawToMvMultiplier / maxMv;
   }
 }

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -22,7 +22,6 @@ class Sessions extends Table {
   TextColumn get tares => text()();
   RealColumn get peakForceRaw => real().withDefault(const Constant(0.0))();
   RealColumn get calibrationSlope => real()();
-  IntColumn get calibrationOffset => integer()();
   TextColumn get notes => text().withDefault(const Constant(''))();
   IntColumn get sampleCount => integer().withDefault(const Constant(0))();
   BoolColumn get isCompleted => boolean().withDefault(const Constant(true))();
@@ -77,7 +76,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   /// DEV ONLY: any schema version bump wipes the database and recreates it
   /// from scratch. No user data is migrated. Replace with real per-version
@@ -116,7 +115,6 @@ class AppDatabase extends _$AppDatabase {
     required String channelLabels,
     required String tares,
     required double calibrationSlope,
-    required int calibrationOffset,
     required String visibleChannels,
   }) {
     return into(sessions).insert(
@@ -128,7 +126,6 @@ class AppDatabase extends _$AppDatabase {
         channelLabels: channelLabels,
         tares: tares,
         calibrationSlope: calibrationSlope,
-        calibrationOffset: calibrationOffset,
         isCompleted: const Value(false),
         visibleChannels: visibleChannels,
       ),

--- a/lib/services/database.g.dart
+++ b/lib/services/database.g.dart
@@ -119,17 +119,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     type: DriftSqlType.double,
     requiredDuringInsert: true,
   );
-  static const VerificationMeta _calibrationOffsetMeta = const VerificationMeta(
-    'calibrationOffset',
-  );
-  @override
-  late final GeneratedColumn<int> calibrationOffset = GeneratedColumn<int>(
-    'calibration_offset',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
   static const VerificationMeta _notesMeta = const VerificationMeta('notes');
   @override
   late final GeneratedColumn<String> notes = GeneratedColumn<String>(
@@ -200,7 +189,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     tares,
     peakForceRaw,
     calibrationSlope,
-    calibrationOffset,
     notes,
     sampleCount,
     isCompleted,
@@ -300,17 +288,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     } else if (isInserting) {
       context.missing(_calibrationSlopeMeta);
     }
-    if (data.containsKey('calibration_offset')) {
-      context.handle(
-        _calibrationOffsetMeta,
-        calibrationOffset.isAcceptableOrUnknown(
-          data['calibration_offset']!,
-          _calibrationOffsetMeta,
-        ),
-      );
-    } else if (isInserting) {
-      context.missing(_calibrationOffsetMeta);
-    }
     if (data.containsKey('notes')) {
       context.handle(
         _notesMeta,
@@ -401,10 +378,6 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
         DriftSqlType.double,
         data['${effectivePrefix}calibration_slope'],
       )!,
-      calibrationOffset: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}calibration_offset'],
-      )!,
       notes: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}notes'],
@@ -445,7 +418,6 @@ class Session extends DataClass implements Insertable<Session> {
   final String tares;
   final double peakForceRaw;
   final double calibrationSlope;
-  final int calibrationOffset;
   final String notes;
   final int sampleCount;
   final bool isCompleted;
@@ -469,7 +441,6 @@ class Session extends DataClass implements Insertable<Session> {
     required this.tares,
     required this.peakForceRaw,
     required this.calibrationSlope,
-    required this.calibrationOffset,
     required this.notes,
     required this.sampleCount,
     required this.isCompleted,
@@ -489,7 +460,6 @@ class Session extends DataClass implements Insertable<Session> {
     map['tares'] = Variable<String>(tares);
     map['peak_force_raw'] = Variable<double>(peakForceRaw);
     map['calibration_slope'] = Variable<double>(calibrationSlope);
-    map['calibration_offset'] = Variable<int>(calibrationOffset);
     map['notes'] = Variable<String>(notes);
     map['sample_count'] = Variable<int>(sampleCount);
     map['is_completed'] = Variable<bool>(isCompleted);
@@ -510,7 +480,6 @@ class Session extends DataClass implements Insertable<Session> {
       tares: Value(tares),
       peakForceRaw: Value(peakForceRaw),
       calibrationSlope: Value(calibrationSlope),
-      calibrationOffset: Value(calibrationOffset),
       notes: Value(notes),
       sampleCount: Value(sampleCount),
       isCompleted: Value(isCompleted),
@@ -535,7 +504,6 @@ class Session extends DataClass implements Insertable<Session> {
       tares: serializer.fromJson<String>(json['tares']),
       peakForceRaw: serializer.fromJson<double>(json['peakForceRaw']),
       calibrationSlope: serializer.fromJson<double>(json['calibrationSlope']),
-      calibrationOffset: serializer.fromJson<int>(json['calibrationOffset']),
       notes: serializer.fromJson<String>(json['notes']),
       sampleCount: serializer.fromJson<int>(json['sampleCount']),
       isCompleted: serializer.fromJson<bool>(json['isCompleted']),
@@ -557,7 +525,6 @@ class Session extends DataClass implements Insertable<Session> {
       'tares': serializer.toJson<String>(tares),
       'peakForceRaw': serializer.toJson<double>(peakForceRaw),
       'calibrationSlope': serializer.toJson<double>(calibrationSlope),
-      'calibrationOffset': serializer.toJson<int>(calibrationOffset),
       'notes': serializer.toJson<String>(notes),
       'sampleCount': serializer.toJson<int>(sampleCount),
       'isCompleted': serializer.toJson<bool>(isCompleted),
@@ -577,7 +544,6 @@ class Session extends DataClass implements Insertable<Session> {
     String? tares,
     double? peakForceRaw,
     double? calibrationSlope,
-    int? calibrationOffset,
     String? notes,
     int? sampleCount,
     bool? isCompleted,
@@ -594,7 +560,6 @@ class Session extends DataClass implements Insertable<Session> {
     tares: tares ?? this.tares,
     peakForceRaw: peakForceRaw ?? this.peakForceRaw,
     calibrationSlope: calibrationSlope ?? this.calibrationSlope,
-    calibrationOffset: calibrationOffset ?? this.calibrationOffset,
     notes: notes ?? this.notes,
     sampleCount: sampleCount ?? this.sampleCount,
     isCompleted: isCompleted ?? this.isCompleted,
@@ -625,9 +590,6 @@ class Session extends DataClass implements Insertable<Session> {
       calibrationSlope: data.calibrationSlope.present
           ? data.calibrationSlope.value
           : this.calibrationSlope,
-      calibrationOffset: data.calibrationOffset.present
-          ? data.calibrationOffset.value
-          : this.calibrationOffset,
       notes: data.notes.present ? data.notes.value : this.notes,
       sampleCount: data.sampleCount.present
           ? data.sampleCount.value
@@ -655,7 +617,6 @@ class Session extends DataClass implements Insertable<Session> {
           ..write('tares: $tares, ')
           ..write('peakForceRaw: $peakForceRaw, ')
           ..write('calibrationSlope: $calibrationSlope, ')
-          ..write('calibrationOffset: $calibrationOffset, ')
           ..write('notes: $notes, ')
           ..write('sampleCount: $sampleCount, ')
           ..write('isCompleted: $isCompleted, ')
@@ -677,7 +638,6 @@ class Session extends DataClass implements Insertable<Session> {
     tares,
     peakForceRaw,
     calibrationSlope,
-    calibrationOffset,
     notes,
     sampleCount,
     isCompleted,
@@ -698,7 +658,6 @@ class Session extends DataClass implements Insertable<Session> {
           other.tares == this.tares &&
           other.peakForceRaw == this.peakForceRaw &&
           other.calibrationSlope == this.calibrationSlope &&
-          other.calibrationOffset == this.calibrationOffset &&
           other.notes == this.notes &&
           other.sampleCount == this.sampleCount &&
           other.isCompleted == this.isCompleted &&
@@ -717,7 +676,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
   final Value<String> tares;
   final Value<double> peakForceRaw;
   final Value<double> calibrationSlope;
-  final Value<int> calibrationOffset;
   final Value<String> notes;
   final Value<int> sampleCount;
   final Value<bool> isCompleted;
@@ -734,7 +692,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     this.tares = const Value.absent(),
     this.peakForceRaw = const Value.absent(),
     this.calibrationSlope = const Value.absent(),
-    this.calibrationOffset = const Value.absent(),
     this.notes = const Value.absent(),
     this.sampleCount = const Value.absent(),
     this.isCompleted = const Value.absent(),
@@ -752,7 +709,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     required String tares,
     this.peakForceRaw = const Value.absent(),
     required double calibrationSlope,
-    required int calibrationOffset,
     this.notes = const Value.absent(),
     this.sampleCount = const Value.absent(),
     this.isCompleted = const Value.absent(),
@@ -764,7 +720,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
        channelLabels = Value(channelLabels),
        tares = Value(tares),
        calibrationSlope = Value(calibrationSlope),
-       calibrationOffset = Value(calibrationOffset),
        visibleChannels = Value(visibleChannels);
   static Insertable<Session> custom({
     Expression<int>? id,
@@ -777,7 +732,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     Expression<String>? tares,
     Expression<double>? peakForceRaw,
     Expression<double>? calibrationSlope,
-    Expression<int>? calibrationOffset,
     Expression<String>? notes,
     Expression<int>? sampleCount,
     Expression<bool>? isCompleted,
@@ -795,7 +749,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
       if (tares != null) 'tares': tares,
       if (peakForceRaw != null) 'peak_force_raw': peakForceRaw,
       if (calibrationSlope != null) 'calibration_slope': calibrationSlope,
-      if (calibrationOffset != null) 'calibration_offset': calibrationOffset,
       if (notes != null) 'notes': notes,
       if (sampleCount != null) 'sample_count': sampleCount,
       if (isCompleted != null) 'is_completed': isCompleted,
@@ -815,7 +768,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     Value<String>? tares,
     Value<double>? peakForceRaw,
     Value<double>? calibrationSlope,
-    Value<int>? calibrationOffset,
     Value<String>? notes,
     Value<int>? sampleCount,
     Value<bool>? isCompleted,
@@ -833,7 +785,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
       tares: tares ?? this.tares,
       peakForceRaw: peakForceRaw ?? this.peakForceRaw,
       calibrationSlope: calibrationSlope ?? this.calibrationSlope,
-      calibrationOffset: calibrationOffset ?? this.calibrationOffset,
       notes: notes ?? this.notes,
       sampleCount: sampleCount ?? this.sampleCount,
       isCompleted: isCompleted ?? this.isCompleted,
@@ -875,9 +826,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     if (calibrationSlope.present) {
       map['calibration_slope'] = Variable<double>(calibrationSlope.value);
     }
-    if (calibrationOffset.present) {
-      map['calibration_offset'] = Variable<int>(calibrationOffset.value);
-    }
     if (notes.present) {
       map['notes'] = Variable<String>(notes.value);
     }
@@ -909,7 +857,6 @@ class SessionsCompanion extends UpdateCompanion<Session> {
           ..write('tares: $tares, ')
           ..write('peakForceRaw: $peakForceRaw, ')
           ..write('calibrationSlope: $calibrationSlope, ')
-          ..write('calibrationOffset: $calibrationOffset, ')
           ..write('notes: $notes, ')
           ..write('sampleCount: $sampleCount, ')
           ..write('isCompleted: $isCompleted, ')
@@ -1211,7 +1158,6 @@ typedef $$SessionsTableCreateCompanionBuilder =
       required String tares,
       Value<double> peakForceRaw,
       required double calibrationSlope,
-      required int calibrationOffset,
       Value<String> notes,
       Value<int> sampleCount,
       Value<bool> isCompleted,
@@ -1230,7 +1176,6 @@ typedef $$SessionsTableUpdateCompanionBuilder =
       Value<String> tares,
       Value<double> peakForceRaw,
       Value<double> calibrationSlope,
-      Value<int> calibrationOffset,
       Value<String> notes,
       Value<int> sampleCount,
       Value<bool> isCompleted,
@@ -1294,11 +1239,6 @@ class $$SessionsTableFilterComposer
 
   ColumnFilters<double> get calibrationSlope => $composableBuilder(
     column: $table.calibrationSlope,
-    builder: (column) => ColumnFilters(column),
-  );
-
-  ColumnFilters<int> get calibrationOffset => $composableBuilder(
-    column: $table.calibrationOffset,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -1387,11 +1327,6 @@ class $$SessionsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<int> get calibrationOffset => $composableBuilder(
-    column: $table.calibrationOffset,
-    builder: (column) => ColumnOrderings(column),
-  );
-
   ColumnOrderings<String> get notes => $composableBuilder(
     column: $table.notes,
     builder: (column) => ColumnOrderings(column),
@@ -1469,11 +1404,6 @@ class $$SessionsTableAnnotationComposer
     builder: (column) => column,
   );
 
-  GeneratedColumn<int> get calibrationOffset => $composableBuilder(
-    column: $table.calibrationOffset,
-    builder: (column) => column,
-  );
-
   GeneratedColumn<String> get notes =>
       $composableBuilder(column: $table.notes, builder: (column) => column);
 
@@ -1534,7 +1464,6 @@ class $$SessionsTableTableManager
                 Value<String> tares = const Value.absent(),
                 Value<double> peakForceRaw = const Value.absent(),
                 Value<double> calibrationSlope = const Value.absent(),
-                Value<int> calibrationOffset = const Value.absent(),
                 Value<String> notes = const Value.absent(),
                 Value<int> sampleCount = const Value.absent(),
                 Value<bool> isCompleted = const Value.absent(),
@@ -1551,7 +1480,6 @@ class $$SessionsTableTableManager
                 tares: tares,
                 peakForceRaw: peakForceRaw,
                 calibrationSlope: calibrationSlope,
-                calibrationOffset: calibrationOffset,
                 notes: notes,
                 sampleCount: sampleCount,
                 isCompleted: isCompleted,
@@ -1570,7 +1498,6 @@ class $$SessionsTableTableManager
                 required String tares,
                 Value<double> peakForceRaw = const Value.absent(),
                 required double calibrationSlope,
-                required int calibrationOffset,
                 Value<String> notes = const Value.absent(),
                 Value<int> sampleCount = const Value.absent(),
                 Value<bool> isCompleted = const Value.absent(),
@@ -1587,7 +1514,6 @@ class $$SessionsTableTableManager
                 tares: tares,
                 peakForceRaw: peakForceRaw,
                 calibrationSlope: calibrationSlope,
-                calibrationOffset: calibrationOffset,
                 notes: notes,
                 sampleCount: sampleCount,
                 isCompleted: isCompleted,

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -7,6 +7,7 @@ import 'database.dart';
 import 'data_hub.dart';
 import '../models/bucket_series.dart';
 import '../models/gap_list.dart';
+import '../models/graph_data_source.dart';
 
 /// Chunk format: packed int32 LE values, interleaved
 /// `[ch0_s0, ch1_s0, ..., ch0_s1, ch1_s1, ...]`, with one value per ADC channel
@@ -42,7 +43,6 @@ class SessionStorage {
       channelLabels: jsonEncode(channelLabels),
       tares: jsonEncode(tare.toList()),
       calibrationSlope: dataHub.deviceCalibration.slope,
-      calibrationOffset: dataHub.deviceCalibration.offset,
       visibleChannels: jsonEncode(visibleChannels),
     );
 
@@ -139,7 +139,6 @@ class SessionStorage {
       sampleRate: session.sampleRate,
       sampleCount: globalS,
       calibrationSlope: session.calibrationSlope,
-      calibrationOffset: session.calibrationOffset,
       tares: _parseTares(session.tares, channelCount),
       gaps: GapList.fromJson(session.gaps),
     );
@@ -222,20 +221,24 @@ class _ChunkAggregate {
   }
 }
 
-/// Loaded session data for playback/review. A plain immutable data holder;
-/// the UI wraps it in a GraphDataSource adapter for rendering.
-class SessionData {
+/// Loaded session data for playback/review. An immutable data holder that
+/// implements [GraphDataSource] directly, so the graph components render it
+/// without an adapter; [sampleRate], [calibrationSlope] and [gaps] already
+/// satisfy their interface counterparts.
+class SessionData implements GraphDataSource {
   final List<Int32List> channels;
+  @override
   final int sampleRate;
   final int sampleCount;
+  @override
   final double calibrationSlope;
-  final int calibrationOffset;
   final List<double> tares;
 
   /// Dropped-sample ranges (session-relative). The channel data holds held
   /// values across these ranges, so stats/buckets need no exclusion logic;
   /// renderers use this to hatch and break the polyline, and CSV export
   /// blanks these rows. Empty for crash-recovered sessions (gap info lost).
+  @override
   final GapList gaps;
 
   /// Per-channel extremes, computed once on construction.
@@ -261,7 +264,6 @@ class SessionData {
     required this.sampleRate,
     required this.sampleCount,
     required this.calibrationSlope,
-    required this.calibrationOffset,
     required this.tares,
     GapList? gaps,
   }) : gaps = gaps ?? GapList(),
@@ -306,6 +308,33 @@ class SessionData {
 
   /// Duration in seconds.
   double get durationSeconds => sampleCount / sampleRate;
+
+  // -- GraphDataSource --------------------------------------------------------
+
+  @override
+  int get totalSamples => sampleCount;
+
+  @override
+  int get bufferCapacity => sampleCount;
+
+  @override
+  int get oldestSample => 0;
+
+  @override
+  Listenable get repaint => kNeverRepaints;
+
+  @override
+  ChannelSeries channel(int channelIndex) => (
+    data: channels[channelIndex],
+    min: mins[channelIndex],
+    max: maxs[channelIndex],
+    tare: tares[channelIndex],
+    buckets: valueBuckets[channelIndex].series,
+  );
+
+  @override
+  BucketSeries? diffBucketsFor(int channelIndex) =>
+      diffBuckets[channelIndex].series;
 }
 
 /// Streams recorded samples to the DB as they arrive, flushing in chunks so a

--- a/lib/widgets/bt_icon.dart
+++ b/lib/widgets/bt_icon.dart
@@ -41,14 +41,6 @@ class BluetoothIndicator extends StatelessWidget {
             Colors.lightBlue,
             'Disconnecting…',
           );
-        case BtLinkState.cooldown:
-          // Web: the link has torn down but the stack isn't ready to reconnect
-          // yet. Connect stays disabled through this settle window.
-          return const (
-            Icons.bluetooth_searching,
-            Colors.lightBlue,
-            'Almost ready…',
-          );
         case BtLinkState.streaming:
           return const (
             Icons.bluetooth_connected,

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -11,6 +11,7 @@ import '../models/app_settings.dart';
 import '../models/bucket_series.dart';
 import '../models/force_unit.dart';
 import '../models/gap_list.dart';
+import '../models/graph_data_source.dart';
 
 // ---------------------------------------------------------------------------
 // Shared graph layout constants
@@ -542,69 +543,6 @@ int blockSizeFor(int viewSamples, double graphW) {
   // floor => >= 1 sample/block, so the polyline never has more vertices than
   // pixels. The remainder (viewSamples % blockSize) lands in the short final block.
   return math.max(1, (viewSamples / graphW).floor());
-}
-
-/// A single channel's raw circular-buffer data plus its precomputed extremes,
-/// tare offset, and raw-value [BucketSeries]. Returned by
-/// [GraphDataSource.channel].
-typedef ChannelSeries = ({
-  List<int> data,
-  double min,
-  double max,
-  double tare,
-  BucketSeries buckets,
-});
-
-/// Data interface required by the shared graph components (main graph, minimap, etc).
-/// This allows the components to render either live DataHub data or static SessionData.
-///
-/// Sources are not required to be [ChangeNotifier]s; instead they expose a
-/// [repaint] [Listenable] that fires when their data changes (a never-firing
-/// listenable is fine for static data). This keeps the interface usable by both
-/// live and static sources, and leaves room for composed/derived sources later.
-abstract interface class GraphDataSource {
-  /// Total number of logical samples generated so far (can exceed bufferCapacity).
-  int get totalSamples;
-
-  /// The size of the circular buffer. Used to modulus array indices.
-  int get bufferCapacity;
-
-  /// The oldest available sample index (absolute time).
-  int get oldestSample;
-
-  /// The sample rate of the data (Hz).
-  int get sampleRate;
-
-  /// The calibration slope used to convert raw counts to kgf.
-  double get calibrationSlope;
-
-  /// Notifies listeners when the underlying data changes.
-  Listenable get repaint;
-
-  /// Returns the series (data + extremes + tare + buckets) for a given
-  /// channel index.
-  ChannelSeries channel(int channelIndex);
-
-  /// Bucket aggregates of the first-difference series for a channel,
-  /// enabling the derivative graph's bucket fast path; null when the source
-  /// does not track them (the derivative then renders on the exact path).
-  BucketSeries? diffBuckets(int channelIndex);
-
-  /// Sample ranges where data was lost (dropped packets). The buffer holds
-  /// held values there; renderers break the polyline and hatch these ranges.
-  /// Sources that cannot have gaps return an empty (never-mutated) [GapList].
-  GapList get gaps;
-}
-
-/// A [Listenable] that never fires; use as [GraphDataSource.repaint] for static
-/// data sources (e.g. a loaded session).
-final Listenable kNeverRepaints = _NeverListenable();
-
-class _NeverListenable extends Listenable {
-  @override
-  void addListener(VoidCallback listener) {}
-  @override
-  void removeListener(VoidCallback listener) {}
 }
 
 // ---------------------------------------------------------------------------
@@ -1299,7 +1237,6 @@ class GraphWorkspace extends StatefulWidget {
   final List<int> activeChannels;
   final bool showDerivative;
   final bool isLiveGraph;
-  final bool showMinimap;
   final bool showZoomSpan;
 
   const GraphWorkspace({
@@ -1310,7 +1247,6 @@ class GraphWorkspace extends StatefulWidget {
     required this.activeChannels,
     this.showDerivative = false,
     this.isLiveGraph = true,
-    this.showMinimap = true,
     this.showZoomSpan = true,
   });
 
@@ -1329,6 +1265,19 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
     _forceCache.dispose();
     _derivCache.dispose();
     super.dispose();
+  }
+
+  /// Zoom by [factor] (>1 in, <1 out), anchored at the live edge when
+  /// following it and at the window center otherwise.
+  void _zoomBy(double factor) {
+    if (widget.data.totalSamples <= 0) return;
+    widget.ctrl.zoom(
+      factor,
+      widget.ctrl.isLive ? 1.0 : 0.5,
+      widget.data.totalSamples,
+      widget.data.oldestSample,
+      widget.data.bufferCapacity,
+    );
   }
 
   @override
@@ -1388,13 +1337,12 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                     ),
                   ),
                 // Minimap
-                if (widget.showMinimap)
-                  Minimap(
-                    dataSource: widget.data,
-                    settings: widget.settings,
-                    graphCtrl: widget.ctrl,
-                    activeChannels: widget.activeChannels,
-                  ),
+                Minimap(
+                  dataSource: widget.data,
+                  settings: widget.settings,
+                  graphCtrl: widget.ctrl,
+                  activeChannels: widget.activeChannels,
+                ),
               ],
             ),
             // LIVE button (appears when not following live edge)
@@ -1444,18 +1392,7 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                         Icons.zoom_out,
                         color: Theme.of(context).colorScheme.onPrimary,
                       ),
-                      onPressed: () {
-                        if (widget.data.totalSamples > 0) {
-                          final focal = widget.ctrl.isLive ? 1.0 : 0.5;
-                          widget.ctrl.zoom(
-                            1 / 1.2,
-                            focal,
-                            widget.data.totalSamples,
-                            widget.data.oldestSample,
-                            widget.data.bufferCapacity,
-                          );
-                        }
-                      },
+                      onPressed: () => _zoomBy(1 / 1.2),
                     ),
                     if (widget.showZoomSpan)
                       ListenableBuilder(
@@ -1507,18 +1444,7 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                         Icons.zoom_in,
                         color: Theme.of(context).colorScheme.onPrimary,
                       ),
-                      onPressed: () {
-                        if (widget.data.totalSamples > 0) {
-                          final focal = widget.ctrl.isLive ? 1.0 : 0.5;
-                          widget.ctrl.zoom(
-                            1.2,
-                            focal,
-                            widget.data.totalSamples,
-                            widget.data.oldestSample,
-                            widget.data.bufferCapacity,
-                          );
-                        }
-                      },
+                      onPressed: () => _zoomBy(1.2),
                     ),
                   ],
                 ),
@@ -2578,7 +2504,7 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
   @override
   EnvelopeSeries series(int channel) {
     final sampleAt = _sampleAt(channel);
-    final buckets = _data.diffBuckets(channel);
+    final buckets = _data.diffBucketsFor(channel);
     if (buckets == null) return EnvelopeSeries.exact(sampleAt);
     final scale = _displayScale;
     return EnvelopeSeries.bucketed(
@@ -2611,7 +2537,7 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
       if (_data.channel(ch).data.isEmpty) continue;
       if (startI >= endI) continue;
 
-      final buckets = _data.diffBuckets(ch);
+      final buckets = _data.diffBucketsFor(ch);
       if (buckets == null) {
         // Exact-only fallback for sources without diff aggregates.
         final valueAt = _sampleAt(ch);

--- a/test/ble_link_manager_test.dart
+++ b/test/ble_link_manager_test.dart
@@ -259,6 +259,56 @@ void main() {
       expect(seen, isEmpty);
     });
   });
+
+  test('reconnecting after a clean disconnect reaches streaming again', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isTrue);
+
+      unawaited(link.disconnectSelectedDevice());
+      async.elapse(const Duration(seconds: 4));
+      expect(link.link.state, BtLinkState.idle);
+
+      // The web reconnect-settle wait does not apply on native: an immediate
+      // reconnect proceeds without delay.
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+
+      expect(link.isStreaming, isTrue);
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('a stale disconnect callback on an idle link is a no-op', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isTrue);
+
+      unawaited(link.disconnectSelectedDevice());
+      async.elapse(const Duration(seconds: 4));
+      expect(link.link.state, BtLinkState.idle);
+      expect(seen, isEmpty);
+
+      // A late duplicate disconnect event arrives after the link is idle.
+      // It must not touch state, notify, or re-stamp the settle window.
+      var notifies = 0;
+      link.addListener(() => notifies++);
+      MockBlePlatform.instance.updateConnection(deviceId, false);
+      async.flushMicrotasks();
+
+      expect(link.link.state, BtLinkState.idle);
+      expect(notifies, 0);
+      expect(seen, isEmpty);
+    });
+  });
 }
 
 

--- a/test/bucket_ingest_test.dart
+++ b/test/bucket_ingest_test.dart
@@ -132,7 +132,6 @@ void main() {
         sampleRate: DataHub.samplesPerSec,
         sampleCount: n,
         calibrationSlope: 1.0,
-        calibrationOffset: 0,
         tares: List.filled(channels, 0.0),
         gaps: GapList.fromJson(hub.gaps.toJson()),
       );
@@ -200,7 +199,6 @@ void main() {
         sampleRate: DataHub.samplesPerSec,
         sampleCount: n,
         calibrationSlope: 1.0,
-        calibrationOffset: 0,
         tares: List.filled(channels, 0.0),
         gaps: GapList.fromJson(hub.gaps.toJson()),
       );

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -21,7 +21,6 @@ void main() {
       sampleRate: DataHub.samplesPerSec,
       sampleCount: values.length,
       calibrationSlope: 1.0,
-      calibrationOffset: 0,
       tares: List.filled(channels, 0.0),
     );
 


### PR DESCRIPTION
Deletes one link state, one timer, two adapter classes, one DB column, and several dead/unreachable branches. No user-visible behavior change except the one noted below.

### BLE link state machine (6 → 5 states)
- `BtLinkState.cooldown` is gone (plus its timer, `enterCooldown`, and the "Please wait…"/"Almost ready…" UI branches). `connectToDevice` now waits out the web reconnect-settle window in the visible `connecting` state, computed from `_lastDisconnectAt` — a map that was previously write-only dead state — and generation-guarded after the sleep.
- **UX change (web only):** reconnecting after a disconnect shows "Connecting…" for up to ~1 s instead of a disabled "Please wait…" button.
- Stale late disconnect callbacks on an idle link are now ignored; they previously re-ran teardown and re-stamped the settle window the next connect waits on.
- `_startScan`'s four-condition guard collapsed to one state check; `_endLink` signature simplified; added `BleLinkManager.isLinkUp`.

### Graph data sources
- `GraphDataSource`/`ChannelSeries`/`kNeverRepaints` moved to `models/graph_data_source.dart` (fixes the services→widgets import direction); interface method renamed `diffBucketsFor` to avoid colliding with the `diffBuckets` accumulator fields.
- `DataHub` and `SessionData` implement the interface directly — the `_LiveDataSource`/`_SessionDataSource` adapters and their disposal/identity-check plumbing (~110 lines) are deleted.

### Unit conversion restructure (prep for calibration configurability)
- `ForceUnit` conversions are now constructor data — one line per unit with its factor visible (`kgfFactor` for force units, `fixedRawFactor` for mV/raw), with a const-constructor assert guaranteeing exactly one factor per unit at compile time. Replaces both the old `_kgfMultiplier` table (which had unreachable fallback arms) and an intermediate switch formulation.
- ADC front-end constants decomposed and named (`adcFullScaleV`, `frontEndGain`, `adcCountsPerPolarity` → `rawToMvMultiplier`) instead of hiding in a comment + magic formula.
- `DeviceCalibration` documents the full signal chain (4.53 V excitation → LC 2 mV/V @ 200 kg FS → 101× gain → 1.2 V FSR ADC), making it the single touch-point for the upcoming calibration-configurability work. Numerically identical conversions.

### Dead state
- `DeviceCalibration.offset` and the `calibrationOffset` DB column removed end-to-end (schema 6→7; the existing dev-wipe migration recreates the DB on first launch).
- `GraphWorkspace.showMinimap` flag (never disabled at any call site) removed; `format()`'s padding branch removed (its only callers were prose contexts where the leading spaces showed).

### Smaller wins
- Duplicate per-channel Peak rows removed from session detail Statistics (the tappable header table already shows them).
- Graph zoom buttons deduped into a `_zoomBy` helper.

### Verification
- `flutter analyze` clean.
- 107/107 tests pass, including 2 new regression tests: reconnect-after-disconnect reaches streaming, and a stale disconnect callback on an idle link is a no-op.