### PR TITLE
Fix zoom crash and stale-UI bugs, persist recording gaps across crashes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'services/hot_restart_cleanup_stub.dart'
 import 'services/recording_controller.dart';
 import 'services/session_storage.dart';
 import 'screens/app_shell.dart';
+import 'widgets/status_colors.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -95,6 +96,7 @@ class DynoApp extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         scaffoldBackgroundColor: const Color(0xFFF8F9FA),
+        extensions: const [StatusColors.light],
         colorScheme: const ColorScheme.light(
           // top "connected" bar, rec, tare buttons, button fonts
           primary: Color(0xFF455A64),
@@ -113,6 +115,7 @@ class DynoApp extends StatelessWidget {
       darkTheme: ThemeData(
         useMaterial3: true,
         scaffoldBackgroundColor: const Color(0xFF121212),
+        extensions: const [StatusColors.dark],
         colorScheme: const ColorScheme.dark(
           primary: Color.fromARGB(255, 103, 155, 179),
           onPrimary: Colors.white,

--- a/lib/models/graph_data_source.dart
+++ b/lib/models/graph_data_source.dart
@@ -44,6 +44,14 @@ abstract interface class GraphDataSource {
   /// Notifies listeners when the underlying data changes.
   Listenable get repaint;
 
+  /// Monotonic identity of the data stream backing this source: bumped when
+  /// the source is reset for a NEW stream (e.g. [DataHub.clear] on
+  /// reconnect), unchanged while the same stream merely grows. Renderers mix
+  /// it into their segment-cache keys, so baked content from a previous
+  /// stream is dropped instead of being blitted over the new stream's data
+  /// (both restart at absolute sample 0). Static sources return a constant.
+  int get dataGeneration;
+
   /// Returns the series (data + extremes + tare + buckets) for a given
   /// channel index.
   ChannelSeries channel(int channelIndex);

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/ble_link_manager.dart';
 import '../widgets/bt_icon.dart';
 import '../widgets/section_header.dart';
+import '../widgets/status_colors.dart';
 
 class DevicesTab extends StatefulWidget {
   final bool isActive;
@@ -133,7 +134,11 @@ class _DevicesTabState extends State<DevicesTab> {
                   isStreaming
                       ? Icons.bluetooth_connected
                       : Icons.bluetooth_searching,
-                  color: Colors.blueAccent,
+                  color: isStreaming
+                      ? Theme.of(
+                          context,
+                        ).extension<StatusColors>()!.linkConnected
+                      : Theme.of(context).extension<StatusColors>()!.linkActive,
                 ),
                 title: Text(bt.connectedDeviceName),
                 subtitle: Text(
@@ -194,7 +199,10 @@ class _DevicesTabState extends State<DevicesTab> {
           for (final device in bt.devices)
             Card(
               child: ListTile(
-                leading: const Icon(Icons.bluetooth, color: Colors.blueGrey),
+                leading: Icon(
+                  Icons.bluetooth,
+                  color: Theme.of(context).colorScheme.outline,
+                ),
                 title: Text(device.name ?? 'Unknown device'),
                 subtitle: Text(
                   device.rssi != null ? 'RSSI: ${device.rssi} dBm' : 'RSSI: --',

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -34,6 +36,39 @@ class _LiveTabState extends State<LiveTab> {
   /// device stream (see [RecordingController]).
   int _lastGeneration = 0;
 
+  /// How long the stream may be silent (while the link reports streaming)
+  /// before the live stats read as stalled. Packets normally arrive at 50 Hz.
+  static const Duration _stallThreshold = Duration(seconds: 2);
+
+  /// 1 Hz ticker driving the stall check: during a stall no packets arrive,
+  /// so the hub never notifies and nothing else would flip the flag.
+  Timer? _stallTimer;
+  bool _stalled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _stallTimer = Timer.periodic(
+      const Duration(seconds: 1),
+      (_) => _checkStall(),
+    );
+  }
+
+  /// Recompute the stalled flag; rebuilds ONLY on an edge (per-tick setState
+  /// would be a pointless 1 Hz rebuild of the whole tab).
+  void _checkStall() {
+    final hub = _hub;
+    if (hub == null) return;
+    final last = hub.lastDataAt;
+    final stalled =
+        context.read<BleLinkManager>().isStreaming &&
+        last != null &&
+        DateTime.now().difference(last) > _stallThreshold;
+    if (stalled != _stalled) {
+      setState(() => _stalled = stalled);
+    }
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -65,6 +100,7 @@ class _LiveTabState extends State<LiveTab> {
 
   @override
   void dispose() {
+    _stallTimer?.cancel();
     _hub?.removeListener(_onHubChanged);
     _graphCtrl.dispose();
     super.dispose();
@@ -176,6 +212,7 @@ class _LiveTabState extends State<LiveTab> {
               settings: settings,
               hub: hub,
               showDerivative: _showDerivative,
+              stalled: _stalled,
             ),
           if (isConnected)
             Expanded(child: _buildGraphArea(settings, hub))
@@ -272,7 +309,8 @@ class LiveStatusBar extends StatelessWidget {
             ),
             if (isConnected && protocolErrorSeen)
               Tooltip(
-                message: 'Malformed ADC packets received — '
+                message:
+                    'Malformed ADC packets received — '
                     'firmware/protocol mismatch',
                 child: Padding(
                   padding: const EdgeInsets.only(right: 8),
@@ -307,11 +345,16 @@ class LiveStats extends StatelessWidget {
   final DataHub hub;
   final bool showDerivative;
 
+  /// The stream has gone silent while the link reports streaming (no packets
+  /// for [_LiveTabState._stallThreshold]). Values are grayed out like a gap.
+  final bool stalled;
+
   const LiveStats({
     super.key,
     required this.settings,
     required this.hub,
     this.showDerivative = false,
+    this.stalled = false,
   });
 
   @override
@@ -323,7 +366,8 @@ class LiveStats extends StatelessWidget {
       builder: (context, _) {
         // During a live gap (dropped packets) the hub reports held values;
         // gray them out so they read as stale rather than fresh readings.
-        final stale = hub.liveEdgeIsGap;
+        // Same for a stall: the newest "reading" is just the last one.
+        final stale = hub.liveEdgeIsGap || stalled;
 
         return ChannelStatsTable(
           labels: settings.channelLabels,

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -331,7 +331,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     // Save via a native "Save As" dialog. On web there is no save-location
     // picker, so hand the bytes to the browser, which downloads the file.
     final bytes = Uint8List.fromList(utf8.encode(buf.toString()));
-    final csvName = '${_session.name.isEmpty ? 'session' : _session.name}.csv';
+    final csvName = _csvFileName(_session.name);
     final xFile = XFile.fromData(bytes, mimeType: 'text/csv', name: csvName);
 
     String savedTo;
@@ -366,6 +366,17 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
 }
 
 // -- Load state --
+
+/// The CSV filename for a session: the session name with characters that are
+/// illegal in Windows/macOS/Android filenames replaced (auto session names
+/// contain `/` and `:` — e.g. `7/20 14:05:32`), and trailing dots/spaces
+/// (illegal on Windows) trimmed.
+String _csvFileName(String sessionName) {
+  final base = sessionName.isEmpty ? 'session' : sessionName;
+  final safe = base.replaceAll(RegExp(r'[\\/:*?"<>|]'), '-');
+  final trimmed = safe.replaceAll(RegExp(r'[. ]+$'), '');
+  return '${trimmed.isEmpty ? 'session' : trimmed}.csv';
+}
 
 /// Load state for the session's sample data: still loading, failed, or ready
 /// (data null means the session has no chunks).

--- a/lib/screens/settings_tab.dart
+++ b/lib/screens/settings_tab.dart
@@ -146,7 +146,7 @@ class SettingsTab extends StatelessWidget {
   }
 }
 
-class _ChannelConfigTile extends StatelessWidget {
+class _ChannelConfigTile extends StatefulWidget {
   const _ChannelConfigTile({
     required this.index,
     required this.label,
@@ -158,6 +158,38 @@ class _ChannelConfigTile extends StatelessWidget {
   final ValueChanged<String> onLabelChanged;
 
   @override
+  State<_ChannelConfigTile> createState() => _ChannelConfigTileState();
+}
+
+class _ChannelConfigTileState extends State<_ChannelConfigTile> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.label);
+  }
+
+  @override
+  void didUpdateWidget(covariant _ChannelConfigTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // The label changed from OUTSIDE this field (e.g. the async SharedPrefs
+    // load completing after the first build): adopt it. A bare
+    // TextFormField(initialValue:) would keep showing the stale default.
+    // Changes caused by this field's own submit are excluded so the caret
+    // isn't disturbed.
+    if (widget.label != oldWidget.label && widget.label != _controller.text) {
+      _controller.text = widget.label;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
@@ -166,19 +198,19 @@ class _ChannelConfigTile extends StatelessWidget {
           children: [
             const SizedBox(width: 8),
             Text(
-              'Ch ${index + 1}',
+              'Ch ${widget.index + 1}',
               style: const TextStyle(fontWeight: FontWeight.w500),
             ),
             const SizedBox(width: 12),
             Expanded(
-              child: TextFormField(
-                initialValue: label,
+              child: TextField(
+                controller: _controller,
                 decoration: const InputDecoration(
                   isDense: true,
                   border: UnderlineInputBorder(),
                   hintText: 'Label',
                 ),
-                onFieldSubmitted: onLabelChanged,
+                onSubmitted: widget.onLabelChanged,
               ),
             ),
           ],

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -155,7 +155,7 @@ class BleLinkManager extends ChangeNotifier {
   AvailabilityState get bluetoothState => _bluetoothState;
 
   final List<BleDevice> _devices = [];
-  List<BleDevice> get devices => _devices;
+  List<BleDevice> get devices => List.unmodifiable(_devices);
 
   bool _isScanning = false;
   bool get isScanning => _isScanning;
@@ -631,9 +631,13 @@ class BleLinkManager extends ChangeNotifier {
       await UniversalBle.connect(deviceId);
     } catch (e) {
       // Connection result (success) arrives via _onConnectionChange; on a
-      // failed connect attempt that callback may never fire, so reset the
-      // link here and let the caller surface the error.
-      _link.reset();
+      // failed connect attempt that callback may never fire, so tear the link
+      // down here and let the caller surface the error. Go through the common
+      // [_endLink] teardown (not a bare reset): it supersedes any lingering
+      // setup pass and, on web, parks the link in cooldown so an immediate
+      // retry doesn't hit the too-soon-reconnect race.
+      final device = _devices.where((d) => d.deviceId == deviceId).firstOrNull;
+      _endLink(deviceId, device?.name ?? deviceId);
       notifyListeners();
       rethrow;
     }

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -91,6 +91,13 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   /// [clear].
   bool protocolErrorSeen = false;
 
+  /// Wall-clock time of the last completed packet batch ([commitBatch]), or
+  /// null before the first packet of the stream. The live UI derives a
+  /// data-stall indication from this: while the link reports streaming, a
+  /// timestamp older than a couple of seconds means the device has gone
+  /// silent (firmware hang / marginal link). Reset by [clear].
+  DateTime? lastDataAt;
+
   /// Monotonic counter bumped by [clear]. Lets observers distinguish "same
   /// stream, more data" from "a new stream reset the hub" explicitly, instead
   /// of inferring the reset from [totalSamples] decreasing.
@@ -134,6 +141,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
     totalSamples = 0;
     _generation++;
     protocolErrorSeen = false;
+    lastDataAt = null;
     gaps.clear();
     for (int i = 0; i < numAdcChannels; ++i) {
       rawMax[i] = _noMaxYet;
@@ -227,6 +235,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
         listener(startIdx, count);
       }
     }
+    lastDataAt = DateTime.now();
     gaps.pruneBefore(totalSamples - maxDataSz); // ring-wrap hygiene
     notifyListeners();
   }
@@ -252,6 +261,11 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
 
   @override
   Listenable get repaint => this;
+
+  /// Stream identity for the graph segment caches: [generation] is bumped by
+  /// [clear], i.e. exactly when a new device stream takes over the hub.
+  @override
+  int get dataGeneration => _generation;
 
   @override
   ChannelSeries channel(int channelIndex) => (

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -134,7 +134,8 @@ class AppDatabase extends _$AppDatabase {
 
   /// Record a session's final aggregates and mark it completed. [gaps] is the
   /// JSON-encoded dropped-sample range list (session-relative); crash recovery
-  /// omits it (gap info is lost for recovered sessions).
+  /// passes the row's existing value so the ranges the live writer persisted
+  /// incrementally (see [setSessionGaps]) survive the crash.
   Future<void> completeSession(
     int id, {
     required int sampleCount,
@@ -154,6 +155,15 @@ class AppDatabase extends _$AppDatabase {
     );
   }
 
+  /// Replace a session's dropped-sample ranges ([gaps] is the JSON-encoded
+  /// range list, session-relative). Called by the live writer on every chunk
+  /// flush, so a crash mid-recording keeps the gap info up to the last
+  /// flushed chunk instead of losing it all (crash recovery only rebuilds
+  /// aggregates; it cannot reconstruct gaps from chunk bytes).
+  Future<void> setSessionGaps(int id, String gaps) {
+    return _updateSession(id, SessionsCompanion(gaps: Value(gaps)));
+  }
+
   /// Rename a session.
   Future<void> renameSession(int id, String name) {
     return _updateSession(id, SessionsCompanion(name: Value(name)));
@@ -166,10 +176,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// Replace a session's visible-channel set ([json] is a JSON bool list).
   Future<void> setSessionVisibleChannels(int id, String json) {
-    return _updateSession(
-      id,
-      SessionsCompanion(visibleChannels: Value(json)),
-    );
+    return _updateSession(id, SessionsCompanion(visibleChannels: Value(json)));
   }
 
   /// Stream all completed sessions, newest first (reactive).

--- a/lib/services/mockble.dart
+++ b/lib/services/mockble.dart
@@ -49,6 +49,10 @@ class MockBlePlatform extends UniversalBlePlatform {
   /// When true, reads of the calibration characteristic throw.
   bool failCalibrationRead = false;
 
+  /// When true, [connect] throws (a refused/failed attempt: no link is
+  /// established and no connection-change callback fires).
+  bool failConnect = false;
+
   /// When true, [disconnect] never fires the connection-change callback, so
   /// the client's disconnect-timeout reconciliation path is what tears the
   /// link down.
@@ -60,6 +64,7 @@ class MockBlePlatform extends UniversalBlePlatform {
     dropEveryNPackets = 0;
     includeAdcService = true;
     failCalibrationRead = false;
+    failConnect = false;
     hangDisconnect = false;
     _connectedDeviceId = null;
     _connectionState = BleConnectionState.disconnected;
@@ -151,6 +156,13 @@ class MockBlePlatform extends UniversalBlePlatform {
     _connectedDeviceId = deviceId;
     _connectionState = BleConnectionState.connecting;
     await Future<void>.delayed(netDelay);
+    if (failConnect) {
+      // A refused/failed attempt: no link, and no connection-change callback
+      // — the client's connect() catch path is what tears its state down.
+      _connectedDeviceId = null;
+      _connectionState = BleConnectionState.disconnected;
+      throw StateError('Mock connect failure');
+    }
     _connectionState = BleConnectionState.connected;
     updateConnection(deviceId, true);
   }
@@ -174,7 +186,10 @@ class MockBlePlatform extends UniversalBlePlatform {
     final services = _generateServices(deviceId);
     if (!includeAdcService) {
       // A device whose GATT table lacks the ADC feed service.
-      return [for (final s in services) if (s.uuid != btServiceId) s];
+      return [
+        for (final s in services)
+          if (s.uuid != btServiceId) s,
+      ];
     }
     return services;
   }

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -97,11 +97,14 @@ class SessionStorage {
         agg.scan(chunk, tare);
       }
 
+      // Preserve the gaps persisted incrementally by the live writer (chunk
+      // bytes alone can't reconstruct them).
       await AppDatabase.instance.completeSession(
         session.id,
         sampleCount: agg.samples,
         durationMs: (agg.samples * 1000) ~/ session.sampleRate,
         peakForceRaw: agg.peakRaw,
+        gaps: session.gaps,
       );
     }
   }
@@ -323,6 +326,10 @@ class SessionData implements GraphDataSource {
   @override
   Listenable get repaint => kNeverRepaints;
 
+  /// Session data is immutable after load; there is no "new stream".
+  @override
+  int get dataGeneration => 0;
+
   @override
   ChannelSeries channel(int channelIndex) => (
     data: channels[channelIndex],
@@ -356,7 +363,12 @@ class LiveSessionWriter {
     this.sessionId,
     this.tare, {
     @visibleForTesting
-    Future<void> Function(int sessionId, int chunkIndex, Uint8List data)?
+    Future<void> Function(
+      int sessionId,
+      int chunkIndex,
+      Uint8List data,
+      String gapsJson,
+    )?
     chunkSink,
   }) : _chunkSink = chunkSink;
 
@@ -372,7 +384,9 @@ class LiveSessionWriter {
   double peakRaw = 0.0;
 
   /// Dropped-sample ranges accumulated across the recording, relative to the
-  /// session's first sample. Persisted by [SessionStorage.finalizeSession].
+  /// session's first sample. Persisted to the session row on every chunk
+  /// flush (so a crash keeps the info up to the last flush) and once more in
+  /// full by [SessionStorage.finalizeSession].
   final GapList gaps = GapList();
 
   /// Hub-absolute index of the session's first sample; latched on the first
@@ -391,11 +405,16 @@ class LiveSessionWriter {
   /// Serializes all DB writes. Each enqueued op awaits the previous one.
   Future<void> _writeQueue = Future.value();
 
-  /// Test seam: when set, chunk payloads go here instead of
-  /// [AppDatabase.insertChunk], so tests can stall and observe writes without
-  /// opening a real database. Resolved lazily so constructing a writer never
-  /// touches the database singleton.
-  final Future<void> Function(int sessionId, int chunkIndex, Uint8List data)?
+  /// Test seam: when set, a flush's DB side effects (chunk insert + gap-range
+  /// update) go here instead of the real database, so tests can stall and
+  /// observe writes without opening one. Resolved lazily so constructing a
+  /// writer never touches the database singleton.
+  final Future<void> Function(
+    int sessionId,
+    int chunkIndex,
+    Uint8List data,
+    String gapsJson,
+  )?
   _chunkSink;
 
   /// Flush whenever the staging buffer reaches ~this many bytes
@@ -477,11 +496,13 @@ class LiveSessionWriter {
     // takeBytes() clears the builder, so a concurrent append can't see it.
     final dataToSave = _staging.takeBytes();
     final chunkIdx = _chunkIndex++;
+    final gapsJson = gaps.toJson();
     try {
-      await (_chunkSink ?? AppDatabase.instance.insertChunk)(
+      await (_chunkSink ?? _defaultChunkSink)(
         sessionId,
         chunkIdx,
         dataToSave,
+        gapsJson,
       );
     } catch (e) {
       // Latch the first failure; stop accumulating so we don't grow unbounded
@@ -489,6 +510,20 @@ class LiveSessionWriter {
       writeError ??= e;
       debugPrint('Session chunk write failed (session $sessionId): $e');
     }
+  }
+
+  /// The production sink: writes the chunk, then updates the session row's
+  /// gap ranges so a crash mid-recording keeps the info up to this flush
+  /// (crash recovery rebuilds aggregates from chunks but cannot reconstruct
+  /// gaps from them). The gaps update is one small row write per flush.
+  static Future<void> _defaultChunkSink(
+    int sessionId,
+    int chunkIndex,
+    Uint8List data,
+    String gapsJson,
+  ) async {
+    await AppDatabase.instance.insertChunk(sessionId, chunkIndex, data);
+    await AppDatabase.instance.setSessionGaps(sessionId, gapsJson);
   }
 
   /// Chain [op] after all previously enqueued writes and return its completion.

--- a/lib/utils/format.dart
+++ b/lib/utils/format.dart
@@ -1,8 +1,12 @@
 /// Shared display formatters for the session screens.
 library;
 
-/// "45s" below a minute, "3m 12s" above.
+/// "45s" below a minute, "3m 12s" below an hour, "1h 15m" above.
 String formatDuration(Duration d) {
+  if (d.inHours >= 1) {
+    final min = d.inMinutes % 60;
+    return '${d.inHours}h ${min}m';
+  }
   if (d.inMinutes >= 1) {
     final sec = d.inSeconds % 60;
     return '${d.inMinutes}m ${sec}s';

--- a/lib/widgets/bt_icon.dart
+++ b/lib/widgets/bt_icon.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:universal_ble/universal_ble.dart' show AvailabilityState;
 
 import '../services/ble_link_manager.dart' show BtLinkState;
+import 'status_colors.dart';
 
 /// Compact Bluetooth status readout (icon + hint text, with a spinner while
 /// anything is in flight). Driven directly by the per-device link state plus
@@ -31,44 +32,29 @@ class BluetoothIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final status = Theme.of(context).extension<StatusColors>()!;
+    final active = status.linkActive;
+    final connected = status.linkConnected;
+
     (IconData, Color, String) indicator() {
       // Link states first: any active link or transition outranks scan and
       // adapter status.
       switch (linkState) {
         case BtLinkState.disconnecting:
-          return const (
-            Icons.bluetooth_searching,
-            Colors.lightBlue,
-            'Disconnecting…',
-          );
+          return (Icons.bluetooth_searching, active, 'Disconnecting…');
         case BtLinkState.cooldown:
           // Web: the link has torn down but the stack isn't ready to reconnect
           // yet. Connect stays disabled through this settle window.
-          return const (
-            Icons.bluetooth_searching,
-            Colors.lightBlue,
-            'Almost ready…',
-          );
+          return (Icons.bluetooth_searching, active, 'Almost ready…');
         case BtLinkState.streaming:
-          return const (
-            Icons.bluetooth_connected,
-            Colors.blueAccent,
-            'Connected',
-          );
+          return (Icons.bluetooth_connected, connected, 'Connected');
         case BtLinkState.connected:
           // GATT link is up but service discovery / ADC subscription is still
           // in progress. Not usable yet.
-          return const (
-            Icons.bluetooth_searching,
-            Colors.lightBlue,
-            'Setting up…',
-          );
+          return (Icons.bluetooth_searching, active, 'Setting up…');
         case BtLinkState.connecting:
-          return const (
-            Icons.bluetooth_searching,
-            Colors.lightBlue,
-            'Connecting…',
-          );
+          return (Icons.bluetooth_searching, active, 'Connecting…');
         case BtLinkState.idle:
           break; // Fall through to scan / adapter status.
       }
@@ -77,7 +63,7 @@ class BluetoothIndicator extends StatelessWidget {
         // in our list, so we tell the user to choose there.
         return (
           Icons.bluetooth_searching,
-          Colors.lightBlue,
+          active,
           kIsWeb ? 'Choose a device…' : 'Scanning for devices…',
         );
       }
@@ -86,53 +72,25 @@ class BluetoothIndicator extends StatelessWidget {
           // A previously-discovered device can remain connectable after a scan
           // stops, so surface that rather than implying a scan is required.
           if (hasDevices) {
-            return const (
-              Icons.bluetooth,
-              Colors.blueAccent,
-              'Tap a device to connect',
-            );
+            return (Icons.bluetooth, connected, 'Tap a device to connect');
           }
           // NOTE: availability is not reliably signalled on all platforms
           // (e.g. web, or Bluetooth already off at launch), so we avoid
           // claiming "ready" and just state the action the user can take.
-          return const (
-            Icons.bluetooth,
-            Colors.blueAccent,
-            'Tap Scan to find devices',
-          );
+          return (Icons.bluetooth, connected, 'Tap Scan to find devices');
         case AvailabilityState.poweredOff:
-          return const (
-            Icons.bluetooth_disabled,
-            Colors.blueGrey,
-            'Bluetooth is off',
-          );
+          return (Icons.bluetooth_disabled, cs.outline, 'Bluetooth is off');
         case AvailabilityState.unknown:
-          return const (
-            Icons.question_mark,
-            Colors.yellow,
-            'Starting up Bluetooth…',
-          );
+          return (Icons.question_mark, cs.outline, 'Starting up Bluetooth…');
         case AvailabilityState.resetting:
-          return const (
-            Icons.question_mark,
-            Colors.green,
-            'Bluetooth resetting…',
-          );
+          return (Icons.question_mark, active, 'Bluetooth resetting…');
         case AvailabilityState.unsupported:
-          return const (Icons.stop, Colors.red, 'Bluetooth not supported');
+          return (Icons.stop, cs.error, 'Bluetooth not supported');
         case AvailabilityState.unauthorized:
-          return const (
-            Icons.stop,
-            Colors.orange,
-            'Bluetooth permission needed',
-          );
+          return (Icons.stop, cs.tertiary, 'Bluetooth permission needed');
         // ignore: unreachable_switch_default
         default:
-          return const (
-            Icons.question_mark,
-            Colors.grey,
-            'Bluetooth unavailable',
-          );
+          return (Icons.question_mark, cs.outline, 'Bluetooth unavailable');
       }
     }
 

--- a/lib/widgets/channel_stats_table.dart
+++ b/lib/widgets/channel_stats_table.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 import '../models/force_unit.dart';
 import 'graph_components.dart' show getChannelColor;
@@ -64,13 +63,15 @@ class ChannelStatsTable extends StatelessWidget {
     final headerStyle = Theme.of(
       context,
     ).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.bold);
-    final monoStyle = GoogleFonts.robotoMono(
-      textStyle: Theme.of(context).textTheme.bodySmall,
-    );
-    final emphasizedStyle = GoogleFonts.robotoMono(
-      textStyle: Theme.of(
-        context,
-      ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+    // Tabular figures keep the numeric columns aligned using the platform's
+    // default font — no bundled font assets and no runtime font fetch.
+    const tabularFigures = [FontFeature.tabularFigures()];
+    final monoStyle = Theme.of(
+      context,
+    ).textTheme.bodySmall?.copyWith(fontFeatures: tabularFigures);
+    final emphasizedStyle = Theme.of(context).textTheme.titleMedium?.copyWith(
+      fontWeight: FontWeight.bold,
+      fontFeatures: tabularFigures,
     );
 
     return Padding(

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -688,8 +688,11 @@ class GraphController extends ChangeNotifier {
     required int oldestSample,
   }) {
     final maxSpan = math.max(totalSamples - oldestSample, minLiveSpan);
-    // Minimum ~50 samples visible (50ms at 1kHz)
-    final span = newSpan.clamp(50, maxSpan);
+    // Minimum ~50 samples visible (50ms at 1kHz) -- or the whole dataset when
+    // less than that exists (a parked session of <50 samples): clamp(50, ...)
+    // would invert the limits and throw there.
+    final minSpan = math.min(50, maxSpan);
+    final span = newSpan.clamp(minSpan, maxSpan);
 
     double effectiveFocal = focalFraction;
     if (anchorLiveEdge && focalFraction > 0.8) {
@@ -1070,7 +1073,7 @@ class _MinimapPainter extends CustomPainter {
       cache: _cache,
       data: _data,
       activeChannels: activeIndices,
-      keyExtras: [...tares, unit, _data.calibrationSlope],
+      keyExtras: [_data.dataGeneration, ...tares, unit, _data.calibrationSlope],
       gw: gw,
       gh: gh,
       dpr: _dpr,
@@ -1258,12 +1261,14 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
   final SegmentedGraphCache _forceCache = SegmentedGraphCache();
   final SegmentedGraphCache _derivCache = SegmentedGraphCache();
   final BakePump _bakePump = BakePump();
+  final LabelCache _labelCache = LabelCache();
 
   @override
   void dispose() {
     _bakePump.dispose();
     _forceCache.dispose();
     _derivCache.dispose();
+    _labelCache.dispose();
     super.dispose();
   }
 
@@ -1306,6 +1311,7 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                         cache: _forceCache,
                         colorScheme: colorScheme,
                         dpr: dpr,
+                        labels: _labelCache,
                         bakePump: _bakePump,
                         requestRepaint: _bakePump.schedule,
                       ),
@@ -1329,6 +1335,7 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                           cache: _derivCache,
                           colorScheme: colorScheme,
                           dpr: dpr,
+                          labels: _labelCache,
                           bakePump: _bakePump,
                           requestRepaint: _bakePump.schedule,
                         ),
@@ -1488,31 +1495,47 @@ String _fmtTick(double sec, int decimals) {
   return '$m:${s.padLeft(decimals == 0 ? 2 : decimals + 3, '0')}';
 }
 
-// Label paragraph cache, bounded: fully cleared on overflow — the per-frame
-// working set is only a few dozen labels, so a clear just rebuilds the
-// visible ones on the next paint.
-const int _labelCacheLimit = 512;
-final Map<String, ui.Paragraph> _labelCache = HashMap();
+// ---------------------------------------------------------------------------
+// Axis label paragraph cache
+// ---------------------------------------------------------------------------
 
-ui.Paragraph _prepareLabel(String text, {Color color = Colors.black}) {
-  final key = '$text|${color.toARGB32()}';
-  if (!_labelCache.containsKey(key) &&
-      _labelCache.length >= _labelCacheLimit) {
-    for (final paragraph in _labelCache.values) {
+/// Bounded cache of laid-out axis-label paragraphs. Owned by a graph host
+/// [State] (which disposes it), NOT by a painter: painters are recreated on
+/// every widget rebuild, so a painter-owned cache would be dropped constantly.
+/// Clear-on-overflow: the per-frame working set is only a few dozen labels,
+/// so a clear just rebuilds the visible ones on the next paint.
+class LabelCache {
+  static const int _limit = 512;
+
+  final Map<String, ui.Paragraph> _cache = HashMap();
+
+  /// The laid-out paragraph for [text] in [color], building and caching it on
+  /// first use.
+  ui.Paragraph prepare(String text, {Color color = Colors.black}) {
+    final key = '$text|${color.toARGB32()}';
+    if (!_cache.containsKey(key) && _cache.length >= _limit) {
+      _clear();
+    }
+    return _cache.putIfAbsent(key, () {
+      final style = ui.TextStyle(color: color, fontSize: 11);
+      final builder =
+          ui.ParagraphBuilder(
+              ui.ParagraphStyle(textAlign: TextAlign.left, maxLines: 1),
+            )
+            ..pushStyle(style)
+            ..addText(text);
+      return builder.build()..layout(const ui.ParagraphConstraints(width: 80));
+    });
+  }
+
+  void _clear() {
+    for (final paragraph in _cache.values) {
       paragraph.dispose();
     }
-    _labelCache.clear();
+    _cache.clear();
   }
-  return _labelCache.putIfAbsent(key, () {
-    final style = ui.TextStyle(color: color, fontSize: 11);
-    final builder =
-        ui.ParagraphBuilder(
-            ui.ParagraphStyle(textAlign: TextAlign.left, maxLines: 1),
-          )
-          ..pushStyle(style)
-          ..addText(text);
-    return builder.build()..layout(const ui.ParagraphConstraints(width: 80));
-  });
+
+  void dispose() => _clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -1560,6 +1583,7 @@ void drawTimeAxis(
   required int viewEnd,
   required int sampleRate,
   required bool showLabels,
+  required LabelCache labels,
   bool drawMinor = false,
   Color textColor = Colors.black,
 }) {
@@ -1584,7 +1608,7 @@ void drawTimeAxis(
     grid.moveTo(xPos, 0);
     grid.lineTo(xPos, graphSz.height);
     if (labeled) {
-      final par = _prepareLabel(_fmtTick(sec, decimals), color: textColor);
+      final par = labels.prepare(_fmtTick(sec, decimals), color: textColor);
       canvas.drawParagraph(
         par,
         Offset(xPos - par.longestLine / 2, graphSz.height + 2),
@@ -1619,6 +1643,7 @@ void drawValueAxis(
   YAxisRange yRange,
   double Function(double value) valueToY, {
   required String Function(double tick) labelFor,
+  required LabelCache labels,
   bool drawMinor = false,
   Color textColor = Colors.black,
 }) {
@@ -1632,7 +1657,7 @@ void drawValueAxis(
     if (yPos >= -1 && yPos <= graphSz.height + 1) {
       grid.moveTo(0, yPos);
       grid.lineTo(graphSz.width, yPos);
-      final par = _prepareLabel(labelFor(tick), color: textColor);
+      final par = labels.prepare(labelFor(tick), color: textColor);
       canvas.drawParagraph(
         par,
         Offset(graphSz.width + 4, yPos - par.height / 2),
@@ -2201,6 +2226,9 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
   /// Device pixel ratio used when rasterizing segment textures.
   final double dpr;
 
+  /// Axis-label paragraph cache, owned (and disposed) by the host [State].
+  final LabelCache labels;
+
   /// Asks the host widget to schedule another frame; called when bake work
   /// remains so the rolling bakes complete even for static sources whose
   /// [GraphDataSource.repaint] never fires.
@@ -2214,6 +2242,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
     required this.cache,
     required this.colorScheme,
     required this.dpr,
+    required this.labels,
     required Listenable bakePump,
     required VoidCallback requestRepaint,
   }) : _activeChannels = activeChannels,
@@ -2296,6 +2325,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       viewEnd: viewEnd,
       sampleRate: _data.sampleRate,
       showLabels: showXLabels,
+      labels: labels,
       drawMinor: drawMinorGrid,
       textColor: colorScheme.onSurface,
     );
@@ -2306,6 +2336,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       yRange,
       valueToY,
       labelFor: yTickLabel,
+      labels: labels,
       drawMinor: drawMinorGrid,
       textColor: colorScheme.onSurface,
     );
@@ -2341,6 +2372,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       data: _data,
       activeChannels: activeIndices,
       keyExtras: [
+        _data.dataGeneration,
         ...cacheKeyTares(),
         _settings.displayUnit,
         _data.calibrationSlope,
@@ -2376,6 +2408,7 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
     required super.cache,
     required super.colorScheme,
     required super.dpr,
+    required super.labels,
     required super.bakePump,
     required super.requestRepaint,
   });
@@ -2466,6 +2499,7 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
     required super.cache,
     required super.colorScheme,
     required super.dpr,
+    required super.labels,
     required super.bakePump,
     required super.requestRepaint,
   });
@@ -2563,7 +2597,7 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
   @override
   void drawOverlay(Canvas canvas, Size graphSz) {
     // "dF/dt" label in top-left
-    final dLabel = _prepareLabel(
+    final dLabel = labels.prepare(
       'dF/dt (${_settings.displayUnit.symbol}/s)',
       color: colorScheme.onSurface.withAlpha(150),
     );

--- a/lib/widgets/status_colors.dart
+++ b/lib/widgets/status_colors.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Semantic Bluetooth link-status colors, resolved per theme brightness.
+///
+/// [ColorScheme] has no "in-progress" / "connected" roles, which is why raw
+/// `Colors.lightBlue` / `Colors.blueAccent` used to be sprinkled through the
+/// BLE widgets. Registered on both app themes in `main.dart`; read via
+/// `Theme.of(context).extension<StatusColors>()!`.
+class StatusColors extends ThemeExtension<StatusColors> {
+  const StatusColors({required this.linkActive, required this.linkConnected});
+
+  /// A link transition is in flight: scanning, connecting, post-connect
+  /// setup, disconnecting, or the post-disconnect cooldown.
+  final Color linkActive;
+
+  /// The link is up and usable (streaming).
+  final Color linkConnected;
+
+  static const StatusColors light = StatusColors(
+    linkActive: Colors.lightBlue,
+    linkConnected: Colors.blueAccent,
+  );
+
+  static const StatusColors dark = StatusColors(
+    linkActive: Color(0xFF81D4FA), // lightBlue 300
+    linkConnected: Color(0xFF82B1FF), // blueAccent 100
+  );
+
+  @override
+  StatusColors copyWith({Color? linkActive, Color? linkConnected}) =>
+      StatusColors(
+        linkActive: linkActive ?? this.linkActive,
+        linkConnected: linkConnected ?? this.linkConnected,
+      );
+
+  @override
+  StatusColors lerp(ThemeExtension<StatusColors>? other, double t) {
+    if (other is! StatusColors) return this;
+    return StatusColors(
+      linkActive: Color.lerp(linkActive, other.linkActive, t)!,
+      linkConnected: Color.lerp(linkConnected, other.linkConnected, t)!,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -368,14 +368,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.0"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   cupertino_icons: ^1.0.8
   cross_file: ^0.3.4+2
   package_info_plus: ^10.1.0
-  google_fonts: ^8.0.2
   file_selector: ^1.1.0
   wakelock_plus: ^1.6.1
 

--- a/test/ble_link_manager_test.dart
+++ b/test/ble_link_manager_test.dart
@@ -170,6 +170,35 @@ void main() {
     });
   });
 
+  test('a failed connect attempt tears the link down and allows a retry', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+      MockBlePlatform.instance.failConnect = true;
+
+      Object? error;
+      unawaited(
+        link.connectToDevice(deviceId).catchError((Object e) => error = e),
+      );
+      async.elapse(const Duration(seconds: 2));
+
+      expect(error, isA<ConnectionException>());
+      // The catch path runs the common teardown: back to idle (VM tests are
+      // non-web, so no cooldown), no connection-lost notice for a link that
+      // never came up.
+      expect(link.link.state, BtLinkState.idle);
+      expect(seen, isEmpty);
+
+      // An immediate retry must not be blocked by leftover busy/cooldown state.
+      MockBlePlatform.instance.failConnect = false;
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isTrue);
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
   test('notifications from foreign sources are dropped', () {
     fakeAsync((async) {
       final (link, _) = wire();
@@ -310,7 +339,3 @@ void main() {
     });
   });
 }
-
-
-
-

--- a/test/data_hub_test.dart
+++ b/test/data_hub_test.dart
@@ -105,6 +105,23 @@ void main() {
     });
   });
 
+  group('lastDataAt', () {
+    test('commitBatch stamps the wall clock; clear resets it', () {
+      final hub = DataHub();
+      expect(hub.lastDataAt, isNull);
+
+      feed(hub, frameOf(100), 20);
+      hub.commitBatch(0);
+      final stamped = hub.lastDataAt;
+      expect(stamped, isNotNull);
+      expect(DateTime.now().difference(stamped!).isNegative, isFalse);
+      expect(DateTime.now().difference(stamped).inSeconds, lessThan(2));
+
+      hub.clear();
+      expect(hub.lastDataAt, isNull);
+    });
+  });
+
   group('tare', () {
     test('does not freeze the stream timeline', () {
       final hub = DataHub();

--- a/test/graph_controller_test.dart
+++ b/test/graph_controller_test.dart
@@ -102,6 +102,23 @@ void main() {
       expect(ctrl.effectiveRange(500, 0), (0, 500));
       expect(ctrl.effectiveRange(700, 0), (0, 700));
     });
+
+    test('a dataset smaller than the 50-sample minimum does not throw', () {
+      // Session detail constructs GraphController() with minLiveSpan 0, so a
+      // <50-sample parked session makes maxSpan < 50: clamp(50, maxSpan)
+      // would have inverted limits and thrown (regression test).
+      final ctrl = GraphController();
+      ctrl.zoom(1.2, 0.5, 30, 0, 30);
+      expect(ctrl.effectiveRange(30, 0), (0, 30));
+      // Zooming out is equally safe.
+      ctrl.zoom(1 / 1.2, 0.5, 30, 0, 30);
+      expect(ctrl.effectiveRange(30, 0), (0, 30));
+      // And the span never exceeds the data once it grows.
+      ctrl.zoom(1.2, 0.5, 100, 0, 100);
+      final (s, e) = ctrl.effectiveRange(100, 0);
+      expect(e - s, greaterThan(0));
+      expect(e - s, lessThanOrEqualTo(100));
+    });
   });
 
   group('GraphController.pan / centerOn', () {

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dynamite_app/services/data_hub.dart';
+import 'package:dynamite_app/services/database.dart';
 import 'package:dynamite_app/services/session_storage.dart';
 
 /// Peak-bias tests for the storage side: a never-positive stream must report
@@ -70,7 +72,8 @@ void main() {
       final writer = LiveSessionWriter(
         1,
         Float64List(channels),
-        chunkSink: (sessionId, chunkIndex, data) async => saved.add(data),
+        chunkSink: (sessionId, chunkIndex, data, gapsJson) async =>
+            saved.add(data),
       );
       final hub = DataHub();
       final frame = Int32List(channels);
@@ -112,7 +115,7 @@ void main() {
       final writer = LiveSessionWriter(
         1,
         Float64List(channels),
-        chunkSink: (sessionId, chunkIndex, data) async {
+        chunkSink: (sessionId, chunkIndex, data, gapsJson) async {
           sinkCalls++;
           if (!entered.isCompleted) entered.complete();
           await gate.future; // wedge every chunk write until released
@@ -149,6 +152,59 @@ void main() {
       expect(sinkCalls, 1);
       expect(saved, hasLength(1));
       expect(saved.single.lengthInBytes, chunkSamples * channels * 4);
+    });
+  });
+
+  group('crash recovery', () {
+    test('gaps persisted on flush survive recoverIncompleteSessions', () async {
+      AppDatabase.instance = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(AppDatabase.closeInstance);
+
+      // A stream with a dropped range: 2100 real samples, a 20-sample gap,
+      // 100 more real samples — past the 16 KB flush threshold.
+      final hub = DataHub();
+      final frame = Int32List(channels);
+      void pump(int count, int value) {
+        frame.fillRange(0, channels, value);
+        for (int i = 0; i < count; i++) {
+          hub.addSampleFrame(frame);
+        }
+      }
+
+      pump(2100, 7);
+      hub.addDroppedFrames(20);
+      pump(100, 9);
+
+      final writer = await SessionStorage.startSession(
+        dataHub: hub,
+        name: 'crash me',
+        channelLabels: const ['a', 'b', 'c', 'd'],
+        visibleChannels: const [true, true, true, true],
+      );
+      // The single append crosses the flush threshold, so the chunk insert
+      // AND the incremental gaps update land in the DB.
+      await writer.appendData(hub, 0, hub.totalSamples);
+
+      final beforeCrash = await AppDatabase.instance.sessionById(
+        writer.sessionId,
+      );
+      expect(beforeCrash!.gaps, '[[2100,2120]]');
+
+      // Simulate the crash: recover without finalizeSession ever running.
+      await SessionStorage.recoverIncompleteSessions();
+
+      final row = await AppDatabase.instance.sessionById(writer.sessionId);
+      expect(row, isNotNull);
+      expect(row!.isCompleted, isTrue);
+      expect(row.sampleCount, hub.totalSamples);
+      // Recovery rebuilt the aggregates but preserved the persisted gaps.
+      expect(row.gaps, '[[2100,2120]]');
+
+      final loaded = await SessionStorage.loadSession(row);
+      expect(loaded, isNotNull);
+      expect(loaded!.gaps.contains(2100), isTrue);
+      expect(loaded.gaps.contains(2119), isTrue);
+      expect(loaded.gaps.contains(2120), isFalse);
     });
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:universal_ble/universal_ble.dart';
@@ -26,11 +25,6 @@ import 'package:dynamite_app/services/recording_controller.dart';
 /// [WidgetTester.pump] calls rather than pumpAndSettle so that pending real
 /// async (the drift connection future) can't stall the test.
 void main() {
-  setUpAll(() {
-    // Don't let GoogleFonts attempt network font fetches during the test.
-    GoogleFonts.config.allowRuntimeFetching = false;
-  });
-
   setUp(() {
     SharedPreferences.setMockInitialValues({});
     // Install the mock regardless of useMockBt so BleLinkManager's unawaited


### PR DESCRIPTION
## Bug fixes

- **Zoom crash** — `GraphController.zoomTo` did `newSpan.clamp(50, maxSpan)`,
  which throws `ArgumentError` when `maxSpan < 50`. The session detail screen
  uses `minLiveSpan: 0`, so any zoom interaction on a <50-sample session
  (50 ms) crashed. Now clamps to `min(50, maxSpan)`.
- **CSV filename** — auto session names (`7/20 14:05:32`) contain `/` and
  `:` and were used verbatim as the save-dialog filename. Now sanitized.
- **Stale settings fields** — channel-label fields used
  `TextFormField(initialValue:)`, so labels loaded asynchronously from
  SharedPreferences never appeared. Tile is now stateful and adopts external
  label changes without clobbering edits.
- **Segment-cache staleness (latent)** — baked graph segments were keyed by
  config/tares/unit but not stream identity; correctness relied on the graph
  unmounting on disconnect. New `GraphDataSource.dataGeneration` (the hub's
  `generation`) is mixed into all segment-cache keys, so a hub reset drops
  stale bakes explicitly.
- **Connect-failure path** — `connectToDevice`'s catch did a bare
  `_link.reset()`, skipping the generation bump and the web reconnect
  cooldown. Now goes through `_endLink`, so an immediate retry can't hit the
  too-soon-reconnect race.

## Improvements

- **Gap persistence across crashes** — the live writer now writes the
  session's gap ranges on every chunk flush (one small row update/sec), and
  crash recovery preserves them instead of writing `'[]'`. A crash
  mid-recording no longer turns dropped packets into invisible flatline
  "data" in playback and CSV export.
- **Data-stall indication** — `DataHub.lastDataAt` stamps each packet batch;
  the live tab grays the stats (existing `stale` styling) when the stream is
  silent >2 s while the link reports streaming. Rebuilds only on edges.
- **Fonts** — dropped `google_fonts`; stat cells use the platform font with
  `FontFeature.tabularFigures()`. No runtime fetch (offline-friendly), no
  bundled font assets, one less dependency.
- **Theming** — new `StatusColors` theme extension (`linkActive`,
  `linkConnected`, light + dark) replaces hardcoded `lightBlue`/`blueAccent`
  in the BLE widgets; adapter states use `ColorScheme` roles.
- **Misc** — `devices` getter unmodifiable; per-State `LabelCache` (was a
  global map); `formatDuration` renders hours (`1h 15m`).

## Tests

- Zoom regression: sub-50-sample datasets zoom without throwing.
- New mock `failConnect` knob + test: failed connect returns to idle
  silently, immediate retry succeeds.
- Crash recovery: gaps persisted on flush survive
  `recoverIncompleteSessions` end-to-end.
- `lastDataAt` stamped on `commitBatch`, reset on `clear`.

`flutter analyze` clean; all 111 tests pass.