### PR TITLE
Fix BLE GATT leaks and connect hangs; unify link teardown, dedupe, trim rebuilds

### DIFF
--- a/lib/models/bucket_series.dart
+++ b/lib/models/bucket_series.dart
@@ -11,6 +11,11 @@ import 'gap_list.dart';
 // bucket-accelerated block reductions (reduceBlockBuckets / foldBucketRange).
 // ---------------------------------------------------------------------------
 
+/// The one bucket-grid resolution shared by live (DataHub) and session
+/// (SessionData) ingest; every consumer of [BucketSeries] relies on both
+/// sides using the same grid, so it is defined exactly once here.
+const int kBucketSize = 100;
+
 /// Min/max/sum aggregates over fixed [bucketSize]-sample windows of some
 /// integer series (raw values or first differences). Addressed by absolute
 /// bucket index `b = sampleIndex ~/ bucketSize`, stored at `b % mins.length`;
@@ -93,6 +98,45 @@ int ingestDiff({
 }) {
   if (sampleIndex == 0 || gaps.contains(sampleIndex - 1)) return 0;
   return value - prevValue;
+}
+
+/// Per-sample, per-channel ingest shared by the live hub (DataHub) and
+/// session loading (SessionData) so both always bucket identically: applies
+/// the gap/first-sample diff rule ([ingestDiff]) and feeds the value and
+/// diff accumulators together. Raw storage and extremes tracking stay with
+/// the caller — those genuinely differ (ring write vs pre-loaded array,
+/// int32 vs double extremes).
+class ChannelIngest {
+  ChannelIngest({
+    required this.valueBuckets,
+    required this.diffBuckets,
+    required this.gaps,
+  });
+
+  final BucketAccumulator valueBuckets;
+  final BucketAccumulator diffBuckets;
+  final GapList gaps;
+
+  /// Ingest one sample. [prevValue] is the previous sample's raw value
+  /// (ignored whenever the diff rule zeroes it — see [ingestDiff]).
+  void add(int sampleIndex, int value, int prevValue) {
+    valueBuckets.add(sampleIndex, value);
+    diffBuckets.add(
+      sampleIndex,
+      ingestDiff(
+        sampleIndex: sampleIndex,
+        value: value,
+        prevValue: prevValue,
+        gaps: gaps,
+      ),
+    );
+  }
+
+  /// Restart both accumulators (new stream / reload).
+  void reset() {
+    valueBuckets.reset();
+    diffBuckets.reset();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/screens/app_shell.dart
+++ b/lib/screens/app_shell.dart
@@ -54,6 +54,7 @@ class AppShellState extends State<AppShell> {
     _settings.addListener(_syncWakelock);
     _link.addListener(_syncWakelock);
     _syncWakelock();
+    _onTabActivated(_currentIndex);
   }
 
   @override
@@ -103,8 +104,20 @@ class AppShellState extends State<AppShell> {
 
   /// Navigate to a specific tab programmatically (e.g. from status bar tap).
   void switchToTab(int index) {
-    if (index >= 0 && index < _tabs.length) {
-      setState(() => _currentIndex = index);
+    if (index < 0 || index >= _tabs.length || index == _currentIndex) return;
+    setState(() => _currentIndex = index);
+    _onTabActivated(index);
+  }
+
+  /// Tab-activation side effects, driven from here (the owner of the tab
+  /// index) so the tabs themselves stay stateless:
+  ///  * Devices tab visible: prompt to enable Bluetooth, and start RSSI
+  ///    polling (RSSI is only displayed there — don't poll off-screen).
+  void _onTabActivated(int index) {
+    final devicesVisible = index == 2;
+    _link.setRssiUiActive(devicesVisible);
+    if (devicesVisible) {
+      unawaited(_link.requestEnableBluetooth());
     }
   }
 
@@ -113,16 +126,11 @@ class AppShellState extends State<AppShell> {
     return Scaffold(
       body: IndexedStack(
         index: _currentIndex,
-        children: [
-          const LiveTab(),
-          const SessionsTab(),
-          DevicesTab(isActive: _currentIndex == 2),
-          const SettingsTab(),
-        ],
+        children: const [LiveTab(), SessionsTab(), DevicesTab(), SettingsTab()],
       ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _currentIndex,
-        onDestinationSelected: (i) => setState(() => _currentIndex = i),
+        onDestinationSelected: switchToTab,
         destinations: [
           for (final tab in _tabs)
             NavigationDestination(icon: Icon(tab.icon), label: tab.label),

--- a/lib/screens/app_shell.dart
+++ b/lib/screens/app_shell.dart
@@ -109,6 +109,10 @@ class AppShellState extends State<AppShell> {
     _onTabActivated(index);
   }
 
+  /// Jump to the Devices tab — the single home of the Devices tab index for
+  /// every "connect a device" prompt across the app.
+  void goToDevices() => switchToTab(2);
+
   /// Tab-activation side effects, driven from here (the owner of the tab
   /// index) so the tabs themselves stay stateless:
   ///  * Devices tab visible: prompt to enable Bluetooth, and start RSSI

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -73,6 +73,10 @@ class _DevicesTabState extends State<DevicesTab> {
     // The link is up (setting up OR streaming) — the connected card is shown for
     // both so the user can see progress and cancel a stuck setup.
     final isLinkUp = bt.isLinkUp;
+    // A connect attempt is in flight; the card shows "Connecting…" with a
+    // Cancel button so a hung attempt (or a changed mind) doesn't have to
+    // wait out the connect timeout.
+    final isConnecting = bt.link.isConnecting;
     // The specific device currently in its post-disconnect cooldown window (web
     // only); its row shows "Please wait…" instead of "Connect".
     final coolingDownDeviceId = bt.isCoolingDown ? bt.link.deviceId : '';
@@ -117,12 +121,17 @@ class _DevicesTabState extends State<DevicesTab> {
           ),
           const SizedBox(height: 16),
 
-          // Connected section — shown while the link is up (setting up OR
-          // streaming) so the user can watch setup progress and cancel a stuck
-          // one. The header/icon distinguish "Setting up…" from "Connected".
-          if (isLinkUp) ...[
+          // Connected section — shown while a link attempt is in flight or the
+          // link is up (connecting / setting up / streaming) so the user can
+          // watch progress and cancel a stuck one. The header/icon distinguish
+          // the three states.
+          if (isLinkUp || isConnecting) ...[
             Text(
-              isStreaming ? 'Connected' : 'Setting up…',
+              isStreaming
+                  ? 'Connected'
+                  : isConnecting
+                  ? 'Connecting…'
+                  : 'Setting up…',
               style: Theme.of(context).textTheme.titleSmall?.copyWith(
                 color: Theme.of(context).colorScheme.primary,
               ),
@@ -143,8 +152,8 @@ class _DevicesTabState extends State<DevicesTab> {
                 title: Text(bt.connectedDeviceName),
                 subtitle: Text(
                   bt.connectedRssi != null
-                      ? 'ID: ${bt.selectedDeviceId}  •  RSSI: ${bt.connectedRssi} dBm'
-                      : 'ID: ${bt.selectedDeviceId}',
+                      ? 'ID: ${bt.link.deviceId}  •  RSSI: ${bt.connectedRssi} dBm'
+                      : 'ID: ${bt.link.deviceId}',
                 ),
                 trailing: TextButton(
                   // Disabled while the disconnect is in flight so the button
@@ -155,7 +164,11 @@ class _DevicesTabState extends State<DevicesTab> {
                           await bt.disconnectSelectedDevice();
                         },
                   child: Text(
-                    bt.isDisconnecting ? 'Disconnecting…' : 'Disconnect',
+                    bt.isDisconnecting
+                        ? 'Disconnecting…'
+                        : isConnecting
+                        ? 'Cancel'
+                        : 'Disconnect',
                   ),
                 ),
               ),

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -6,42 +6,8 @@ import '../widgets/bt_icon.dart';
 import '../widgets/section_header.dart';
 import '../widgets/status_colors.dart';
 
-class DevicesTab extends StatefulWidget {
-  final bool isActive;
-
-  const DevicesTab({super.key, this.isActive = false});
-
-  @override
-  State<DevicesTab> createState() => _DevicesTabState();
-}
-
-class _DevicesTabState extends State<DevicesTab> {
-  @override
-  void initState() {
-    super.initState();
-    if (widget.isActive) {
-      _requestBluetoothIfActive();
-    }
-  }
-
-  @override
-  void didUpdateWidget(covariant DevicesTab oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.isActive && !oldWidget.isActive) {
-      _requestBluetoothIfActive();
-    }
-  }
-
-  void _requestBluetoothIfActive() {
-    // Post-frame callback ensures we don't try to access providers before
-    // the widget tree is fully initialized during the first build.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        // ignore: discarded_futures
-        context.read<BleLinkManager>().requestEnableBluetooth();
-      }
-    });
-  }
+class DevicesTab extends StatelessWidget {
+  const DevicesTab({super.key});
 
   /// Run a connect attempt, surfacing a failure as a snackbar naming
   /// [deviceName] with the underlying error detail (timeout vs GATT error vs
@@ -49,6 +15,7 @@ class _DevicesTabState extends State<DevicesTab> {
   /// buttons are already disabled while a link is busy, so this only handles
   /// the rejected attempt itself.
   Future<void> _connectWithFeedback(
+    BuildContext context,
     Future<void> Function() connect,
     String deviceName,
   ) async {
@@ -56,7 +23,7 @@ class _DevicesTabState extends State<DevicesTab> {
       await connect();
     } catch (e) {
       debugPrint('Connect to $deviceName failed: $e');
-      if (mounted) {
+      if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Failed to connect to $deviceName: $e')),
         );
@@ -228,6 +195,7 @@ class _DevicesTabState extends State<DevicesTab> {
                   onPressed: bt.linkBusy
                       ? null
                       : () => _connectWithFeedback(
+                          context,
                           () => bt.connectToDevice(device.deviceId),
                           device.name ?? 'device',
                         ),
@@ -255,6 +223,7 @@ class _DevicesTabState extends State<DevicesTab> {
                 onPressed: bt.linkBusy
                     ? null
                     : () => _connectWithFeedback(
+                        context,
                         bt.connectToDemoDevice,
                         'Demo Device',
                       ),

--- a/lib/screens/devices_tab.dart
+++ b/lib/screens/devices_tab.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/ble_link_manager.dart';
 import '../widgets/bt_icon.dart';
+import '../widgets/empty_placeholder.dart';
 import '../widgets/section_header.dart';
 import '../widgets/status_colors.dart';
 
@@ -149,30 +150,12 @@ class DevicesTab extends StatelessWidget {
           const SizedBox(height: 8),
 
           if (bt.devices.isEmpty && !bt.isScanning)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 24),
-              child: Center(
-                child: Column(
-                  children: [
-                    Icon(
-                      Icons.bluetooth_searching,
-                      size: 64,
-                      color: Colors.grey.shade400,
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      'No devices found',
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: Colors.grey.shade600,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      'Tap Scan at the top to search for nearby devices',
-                      style: TextStyle(color: Colors.grey.shade500),
-                    ),
-                  ],
-                ),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: EmptyPlaceholder(
+                icon: Icons.bluetooth_searching,
+                title: 'No devices found',
+                hint: 'Tap Scan at the top to search for nearby devices',
               ),
             ),
 

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -29,79 +30,95 @@ class _LiveTabState extends State<LiveTab> {
   final GraphController _graphCtrl = GraphController(
     minLiveSpan: 20 * DataHub.samplesPerSec,
   );
-  bool _showDerivative = false;
-  DataHub? _hub;
 
-  /// Last seen hub generation; a change means the hub was cleared for a new
-  /// device stream (see [RecordingController]).
-  int _lastGeneration = 0;
+  /// dF/dt row + derivative graph visibility. A notifier (not setState) so
+  /// toggling rebuilds only the stats/graph/toggles cluster, not the tab.
+  final ValueNotifier<bool> _showDerivative = ValueNotifier(false);
+
+  /// Stream-stall flag consumed by [LiveStats]; edge-updated by [_stallTimer]
+  /// (running only while streaming) so a stall flips exactly one subtree.
+  final ValueNotifier<bool> _stalled = ValueNotifier(false);
+
+  /// App-lifetime singletons, captured (identity-guarded) in
+  /// [didChangeDependencies] for listener registration only.
+  DataHub? _hub;
+  BleLinkManager? _link;
+
+  /// 1 Hz ticker driving the stall check, started/stopped on streaming edges
+  /// (see [_onLinkChanged]): during a stall no packets arrive, so the hub
+  /// never notifies and nothing else would flip the flag. Runs only while
+  /// streaming — with no live trace there is nothing to stall.
+  Timer? _stallTimer;
 
   /// How long the stream may be silent (while the link reports streaming)
   /// before the live stats read as stalled. Packets normally arrive at 50 Hz.
   static const Duration _stallThreshold = Duration(seconds: 2);
 
-  /// 1 Hz ticker driving the stall check: during a stall no packets arrive,
-  /// so the hub never notifies and nothing else would flip the flag.
-  Timer? _stallTimer;
-  bool _stalled = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _stallTimer = Timer.periodic(
-      const Duration(seconds: 1),
-      (_) => _checkStall(),
-    );
-  }
-
-  /// Recompute the stalled flag; rebuilds ONLY on an edge (per-tick setState
-  /// would be a pointless 1 Hz rebuild of the whole tab).
-  void _checkStall() {
-    final hub = _hub;
-    if (hub == null) return;
-    final last = hub.lastDataAt;
-    final stalled =
-        context.read<BleLinkManager>().isStreaming &&
-        last != null &&
-        DateTime.now().difference(last) > _stallThreshold;
-    if (stalled != _stalled) {
-      setState(() => _stalled = stalled);
-    }
-  }
-
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     // read (not watch): the hub notifies on every decoded packet, which must
-    // NOT retrigger didChangeDependencies/build. It's an app-lifetime
-    // singleton, so the identity check below only fires once.
+    // NOT retrigger didChangeDependencies/build. Both are app-lifetime
+    // singletons, so the identity checks below only fire once.
     final hub = context.read<DataHub>();
     if (_hub != hub) {
-      _hub?.removeListener(_onHubChanged);
+      _hub?.removeClearedListener(_onHubCleared);
       _hub = hub;
-      _lastGeneration = hub.generation;
-      hub.addListener(_onHubChanged);
+      hub.addClearedListener(_onHubCleared);
+    }
+    final link = context.read<BleLinkManager>();
+    if (_link != link) {
+      _link?.removeListener(_onLinkChanged);
+      _link = link;
+      link.addListener(_onLinkChanged);
     }
   }
 
-  /// A hub reset (its generation bumped by [DataHub.clear]) means a new
-  /// device stream just cleared the previous trace: drop any stale pan/zoom
-  /// window and follow the fresh live edge. Without this, a user-panned
-  /// (non-live) window survives the disconnect and
-  /// [GraphController.effectiveRange] would clamp the stale window against a
-  /// now-empty buffer (inverted clamp limits -> throw).
-  void _onHubChanged() {
+  /// A hub reset (a new device stream, see [RecordingController]) means the
+  /// previous trace is gone: drop any stale pan/zoom window and follow the
+  /// fresh live edge. Without this, a user-panned (non-live) window survives
+  /// the disconnect and [GraphController.effectiveRange] would clamp the
+  /// stale window against a now-empty buffer (inverted clamp limits -> throw).
+  void _onHubCleared() {
     final hub = _hub!;
-    if (hub.generation != _lastGeneration) {
-      _lastGeneration = hub.generation;
-      _graphCtrl.goLive(totalSamples: hub.totalSamples, oldestSample: 0);
+    _graphCtrl.goLive(totalSamples: hub.totalSamples, oldestSample: 0);
+  }
+
+  /// Start/stop the stall ticker on streaming edges. The link manager
+  /// notifies for many reasons (RSSI polls included); the edge guard keeps
+  /// this a no-op unless streaming actually flipped.
+  void _onLinkChanged() {
+    final streaming = _link!.isStreaming;
+    if (streaming == (_stallTimer != null)) return;
+    if (streaming) {
+      _stallTimer = Timer.periodic(
+        const Duration(seconds: 1),
+        (_) => _checkStall(),
+      );
+    } else {
+      _stallTimer?.cancel();
+      _stallTimer = null;
+      // No live trace — clear the flag so the next stream starts clean.
+      _stalled.value = false;
     }
+  }
+
+  /// Recompute the stalled flag. The ticker runs only while streaming, so
+  /// the link state needs no re-check here.
+  void _checkStall() {
+    final last = _hub?.lastDataAt;
+    final stalled =
+        last != null && DateTime.now().difference(last) > _stallThreshold;
+    if (stalled != _stalled.value) _stalled.value = stalled;
   }
 
   @override
   void dispose() {
     _stallTimer?.cancel();
-    _hub?.removeListener(_onHubChanged);
+    _hub?.removeClearedListener(_onHubCleared);
+    _link?.removeListener(_onLinkChanged);
+    _showDerivative.dispose();
+    _stalled.dispose();
     _graphCtrl.dispose();
     super.dispose();
   }
@@ -186,12 +203,18 @@ class _LiveTabState extends State<LiveTab> {
   @override
   Widget build(BuildContext context) {
     final settings = context.watch<AppSettings>();
-    final link = context.watch<BleLinkManager>();
+    // Narrow selects: the link manager notifies on every RSSI poll — only
+    // streaming edges and device-name changes may rebuild this tab.
+    final isConnected = context.select<BleLinkManager, bool>(
+      (l) => l.isStreaming,
+    );
+    final deviceName = context.select<BleLinkManager, String>(
+      (l) => l.connectedDeviceName,
+    );
     final recording = context.watch<RecordingController>();
     // read (not watch): rebuilding this whole tab per packet would be a
     // rebuild storm — LiveStats/graph subscribe to the hub themselves.
     final hub = context.read<DataHub>();
-    final isConnected = link.isStreaming;
 
     return SafeArea(
       child: Column(
@@ -203,27 +226,36 @@ class _LiveTabState extends State<LiveTab> {
             listenable: hub,
             builder: (context, _) => LiveStatusBar(
               isConnected: isConnected,
-              connectedDeviceName: link.connectedDeviceName,
+              connectedDeviceName: deviceName,
               protocolErrorSeen: hub.protocolErrorSeen,
             ),
           ),
           if (isConnected)
-            LiveStats(
-              settings: settings,
-              hub: hub,
-              showDerivative: _showDerivative,
-              stalled: _stalled,
-            ),
-          if (isConnected)
-            Expanded(child: _buildGraphArea(settings, hub))
+            Expanded(
+              child: ValueListenableBuilder<bool>(
+                valueListenable: _showDerivative,
+                builder: (context, showDerivative, _) => Column(
+                  children: [
+                    LiveStats(
+                      settings: settings,
+                      hub: hub,
+                      showDerivative: showDerivative,
+                      stalledListenable: _stalled,
+                    ),
+                    Expanded(
+                      child: _buildGraphArea(settings, hub, showDerivative),
+                    ),
+                    ViewToggles(
+                      showDerivative: showDerivative,
+                      onToggleDerivative: () =>
+                          _showDerivative.value = !showDerivative,
+                    ),
+                  ],
+                ),
+              ),
+            )
           else
             const Expanded(child: DisconnectedPrompt()),
-          if (isConnected)
-            ViewToggles(
-              showDerivative: _showDerivative,
-              onToggleDerivative: () =>
-                  setState(() => _showDerivative = !_showDerivative),
-            ),
           if (isConnected)
             ActionButtons(
               isRecording: recording.sessionInProgress,
@@ -235,13 +267,17 @@ class _LiveTabState extends State<LiveTab> {
     );
   }
 
-  Widget _buildGraphArea(AppSettings settings, DataHub hub) {
+  Widget _buildGraphArea(
+    AppSettings settings,
+    DataHub hub,
+    bool showDerivative,
+  ) {
     return GraphWorkspace(
       data: hub,
       ctrl: _graphCtrl,
       settings: settings,
       activeChannels: settings.activeChannelIndices,
-      showDerivative: _showDerivative,
+      showDerivative: showDerivative,
     );
   }
 }
@@ -347,63 +383,66 @@ class LiveStats extends StatelessWidget {
 
   /// The stream has gone silent while the link reports streaming (no packets
   /// for [_LiveTabState._stallThreshold]). Values are grayed out like a gap.
-  final bool stalled;
+  final ValueListenable<bool> stalledListenable;
 
   const LiveStats({
     super.key,
     required this.settings,
     required this.hub,
     this.showDerivative = false,
-    this.stalled = false,
+    required this.stalledListenable,
   });
 
   @override
   Widget build(BuildContext context) {
     final unit = settings.displayUnit;
 
-    return ListenableBuilder(
-      listenable: hub,
-      builder: (context, _) {
-        // During a live gap (dropped packets) the hub reports held values;
-        // gray them out so they read as stale rather than fresh readings.
-        // Same for a stall: the newest "reading" is just the last one.
-        final stale = hub.liveEdgeIsGap || stalled;
+    return ValueListenableBuilder<bool>(
+      valueListenable: stalledListenable,
+      builder: (context, stalled, _) => ListenableBuilder(
+        listenable: hub,
+        builder: (context, _) {
+          // During a live gap (dropped packets) the hub reports held values;
+          // gray them out so they read as stale rather than fresh readings.
+          // Same for a stall: the newest "reading" is just the last one.
+          final stale = hub.liveEdgeIsGap || stalled;
 
-        return ChannelStatsTable(
-          labels: settings.channelLabels,
-          activeChannels: settings.activeChannels,
-          onToggleChannel: (i) =>
-              settings.setChannelActive(i, !settings.activeChannels[i]),
-          unit: unit,
-          rows: [
-            ChannelStatsRow(
-              label: 'Live',
-              values: [
-                for (int i = 0; i < DataHub.numAdcChannels; i++)
-                  hub.currentForce(i, unit),
-              ],
-              emphasized: true,
-              stale: stale,
-            ),
-            ChannelStatsRow(
-              label: 'Peak',
-              values: [
-                for (int i = 0; i < DataHub.numAdcChannels; i++)
-                  hub.peakForce(i, unit),
-              ],
-            ),
-            if (showDerivative)
+          return ChannelStatsTable(
+            labels: settings.channelLabels,
+            activeChannels: settings.activeChannels,
+            onToggleChannel: (i) =>
+                settings.setChannelActive(i, !settings.activeChannels[i]),
+            unit: unit,
+            rows: [
               ChannelStatsRow(
-                label: 'dF/dt',
+                label: 'Live',
                 values: [
                   for (int i = 0; i < DataHub.numAdcChannels; i++)
-                    hub.currentDerivative(i, unit),
+                    hub.currentForce(i, unit),
                 ],
+                emphasized: true,
                 stale: stale,
               ),
-          ],
-        );
-      },
+              ChannelStatsRow(
+                label: 'Peak',
+                values: [
+                  for (int i = 0; i < DataHub.numAdcChannels; i++)
+                    hub.peakForce(i, unit),
+                ],
+              ),
+              if (showDerivative)
+                ChannelStatsRow(
+                  label: 'dF/dt',
+                  values: [
+                    for (int i = 0; i < DataHub.numAdcChannels; i++)
+                      hub.currentDerivative(i, unit),
+                  ],
+                  stale: stale,
+                ),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -8,11 +8,11 @@ import '../models/app_settings.dart';
 
 import '../services/ble_link_manager.dart';
 import '../services/data_hub.dart';
-import '../services/database.dart';
 import '../services/recording_controller.dart';
 import '../screens/app_shell.dart';
 import '../widgets/channel_stats_table.dart';
 import '../widgets/dialogs.dart';
+import '../widgets/empty_placeholder.dart';
 import '../widgets/graph_components.dart';
 
 // ---------------------------------------------------------------------------
@@ -188,17 +188,13 @@ class _LiveTabState extends State<LiveTab> {
     }
   }
 
-  Future<void> _showRenameDialog(int sessionId, String currentName) async {
-    final newName = await showTextPrompt(
-      context,
-      title: 'Name this session',
-      label: 'Session name',
-      initial: currentName,
-    );
-    if (newName != null && newName.isNotEmpty) {
-      await AppDatabase.instance.renameSession(sessionId, newName);
-    }
-  }
+  Future<void> _showRenameDialog(int sessionId, String currentName) =>
+      renameSessionFlow(
+        context,
+        sessionId: sessionId,
+        currentName: currentName,
+        title: 'Name this session',
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -310,7 +306,7 @@ class LiveStatusBar extends StatelessWidget {
           : () {
               // Navigate to Devices tab
               final shell = context.findAncestorStateOfType<AppShellState>();
-              shell?.switchToTab(2);
+              shell?.goToDevices();
             },
       child: Container(
         width: double.infinity,
@@ -456,31 +452,15 @@ class DisconnectedPrompt extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.bluetooth_searching,
-            size: 64,
-            color: Theme.of(context).colorScheme.outline,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'No device connected',
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: Theme.of(context).colorScheme.outline,
-            ),
-          ),
-          const SizedBox(height: 8),
-          FilledButton.tonal(
-            onPressed: () {
-              final shell = context.findAncestorStateOfType<AppShellState>();
-              shell?.switchToTab(2);
-            },
-            child: const Text('Connect a device'),
-          ),
-        ],
+    return EmptyPlaceholder(
+      icon: Icons.bluetooth_searching,
+      title: 'No device connected',
+      action: FilledButton.tonal(
+        onPressed: () {
+          final shell = context.findAncestorStateOfType<AppShellState>();
+          shell?.goToDevices();
+        },
+        child: const Text('Connect a device'),
       ),
     );
   }

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:file_selector/file_selector.dart';
 
 import '../models/app_settings.dart';
+import '../models/force_unit.dart';
 import '../services/database.dart';
 import '../services/session_storage.dart';
 import '../utils/format.dart';
@@ -284,18 +285,11 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     }
   }
 
-  Future<void> _showRenameDialog(Session session) async {
-    final newName = await showTextPrompt(
-      context,
-      title: 'Rename session',
-      label: 'Session name',
-      initial: session.name,
-    );
-    if (newName != null && newName.isNotEmpty) {
-      // The row stream refreshes the UI.
-      await AppDatabase.instance.renameSession(session.id, newName);
-    }
-  }
+  Future<void> _showRenameDialog(Session session) => renameSessionFlow(
+    context,
+    sessionId: session.id,
+    currentName: session.name,
+  );
 
   Future<void> _showNotesDialog(Session session) async {
     final newNotes = await showTextPrompt(
@@ -311,18 +305,27 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
   }
 
   Future<void> _deleteAndPop(Session session) async {
-    if (await showDeleteConfirm(context, what: session.name)) {
-      await AppDatabase.instance.deleteSession(session.id);
+    if (await deleteSessionFlow(context, session)) {
       if (mounted) Navigator.of(context).pop();
     }
   }
 
   Future<void> _exportCsv(Session session, SessionData data) async {
-    // Build CSV string
+    final labels = parseJsonColumn(
+      session.channelLabels,
+      data.channels.length,
+      convert: (e) => e.toString(),
+      fallback: (i) => 'Ch ${i + 1}',
+    );
+
+    // TODO(perf): build this incrementally (chunked writes) — a long session
+    // produces a very large single string (see SessionStorage.loadSession's
+    // own note about whole-session materialization).
     final buf = StringBuffer();
     buf.write('time_s');
     for (int ch = 0; ch < data.channels.length; ch++) {
-      buf.write(',ch${ch + 1}_raw,ch${ch + 1}_kgf');
+      final label = _csvCell(labels[ch]);
+      buf.write(',${label}_raw,${label}_kgf');
     }
     buf.writeln();
 
@@ -337,7 +340,10 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
       } else {
         for (int ch = 0; ch < data.channels.length; ch++) {
           final raw = data.channels[ch][s];
-          final kgf = (raw - data.tares[ch]) * data.calibrationSlope;
+          final kgf = ForceUnit.kgf.fromRaw(
+            raw - data.tares[ch],
+            data.calibrationSlope,
+          );
           buf.write(',$raw,${kgf.toStringAsFixed(6)}');
         }
       }
@@ -382,6 +388,10 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
 }
 
 // -- Load state --
+
+/// Escape a CSV header cell that contains separators, quotes or newlines.
+String _csvCell(String s) =>
+    s.contains(RegExp(r'[,"\n]')) ? '"${s.replaceAll('"', '""')}"' : s;
 
 /// The CSV filename for a session: the session name with characters that are
 /// illegal in Windows/macOS/Android filenames replaced (auto session names

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -28,20 +28,18 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
   /// Load state of the session's sample data (see [_LoadState]).
   _LoadState _loadState = const _Loading();
 
-  late Session _session;
   final GraphController _graphCtrl = GraphController();
 
-  /// Per-session channel visibility (persisted on the session row).
-  late List<bool> _visibleChannels;
+  /// The session row, reactively. Single source of truth for name, notes,
+  /// duration, and the per-session channel-visibility set: edits (from here
+  /// or anywhere else) are written to the DB and surface via this stream, so
+  /// no mirrored copies (and no manual reload calls) live in this widget.
+  late final Stream<Session?> _sessionStream;
 
   @override
   void initState() {
     super.initState();
-    _session = widget.session;
-    _visibleChannels = _parseVisibleChannels(
-      _session.visibleChannels,
-      _session.channelCount,
-    );
+    _sessionStream = AppDatabase.instance.watchSessionById(widget.session.id);
     unawaited(_loadData());
   }
 
@@ -55,13 +53,17 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
         fallback: (_) => true,
       );
 
-  void _onToggleChannel(int index) {
-    setState(() => _visibleChannels[index] = !_visibleChannels[index]);
-    unawaited(
-      AppDatabase.instance.setSessionVisibleChannels(
-        _session.id,
-        jsonEncode(_visibleChannels),
-      ),
+  /// Persist a channel-visibility flip; the row stream drives the UI update.
+  Future<void> _toggleChannel(
+    Session session,
+    List<bool> current,
+    int index,
+  ) async {
+    final updated = [...current];
+    updated[index] = !updated[index];
+    await AppDatabase.instance.setSessionVisibleChannels(
+      session.id,
+      jsonEncode(updated),
     );
   }
 
@@ -73,7 +75,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
 
   Future<void> _loadData() async {
     try {
-      final data = await SessionStorage.loadSession(_session);
+      final data = await SessionStorage.loadSession(widget.session);
       if (!mounted) return;
       setState(() => _loadState = _Ready(data));
     } catch (e) {
@@ -86,45 +88,67 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
   Widget build(BuildContext context) {
     final settings = context.watch<AppSettings>();
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_session.name.isEmpty ? 'Untitled Session' : _session.name),
-        actions: [
-          PopupMenuButton<String>(
-            onSelected: _onMenuAction,
-            itemBuilder: (_) => [
-              const PopupMenuItem(value: 'rename', child: Text('Rename')),
-              const PopupMenuItem(value: 'notes', child: Text('Edit notes')),
-              const PopupMenuItem(
-                value: 'export_csv',
-                child: Text('Export CSV'),
-              ),
-              const PopupMenuItem(
-                value: 'delete',
-                child: Text('Delete', style: TextStyle(color: Colors.red)),
+    return StreamBuilder<Session?>(
+      stream: _sessionStream,
+      builder: (context, snapshot) {
+        // Until the stream's first emission — and after the row is deleted on
+        // the way out — fall back to the row this screen was pushed with.
+        final session = snapshot.data ?? widget.session;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(
+              session.name.isEmpty ? 'Untitled Session' : session.name,
+            ),
+            actions: [
+              PopupMenuButton<String>(
+                onSelected: (action) => _onMenuAction(action, session),
+                itemBuilder: (_) => [
+                  const PopupMenuItem(value: 'rename', child: Text('Rename')),
+                  const PopupMenuItem(
+                    value: 'notes',
+                    child: Text('Edit notes'),
+                  ),
+                  const PopupMenuItem(
+                    value: 'export_csv',
+                    child: Text('Export CSV'),
+                  ),
+                  const PopupMenuItem(
+                    value: 'delete',
+                    child: Text('Delete', style: TextStyle(color: Colors.red)),
+                  ),
+                ],
               ),
             ],
           ),
-        ],
-      ),
-      body: switch (_loadState) {
-        _Loading() => const Center(child: CircularProgressIndicator()),
-        _Failed(:final error) => Center(child: Text('Error: $error')),
-        // A session without chunks (e.g. deleted externally) has nothing to
-        // show; loadSession returns null there.
-        _Ready(data: null) => const Center(
-          child: Text('No recorded data for this session'),
-        ),
-        _Ready(:final data) => _buildContent(settings, data!),
+          body: switch (_loadState) {
+            _Loading() => const Center(child: CircularProgressIndicator()),
+            _Failed(:final error) => Center(child: Text('Error: $error')),
+            // A session without chunks (e.g. deleted externally) has nothing to
+            // show; loadSession returns null there.
+            _Ready(data: null) => const Center(
+              child: Text('No recorded data for this session'),
+            ),
+            _Ready(:final data) => _buildContent(settings, session, data!),
+          },
+        );
       },
     );
   }
 
-  Widget _buildContent(AppSettings settings, SessionData data) {
+  Widget _buildContent(
+    AppSettings settings,
+    Session session,
+    SessionData data,
+  ) {
     final unit = settings.displayUnit;
+    final visibleChannels = _parseVisibleChannels(
+      session.visibleChannels,
+      session.channelCount,
+    );
 
     final channelLabels = parseJsonColumn(
-      _session.channelLabels,
+      session.channelLabels,
       data.channels.length,
       convert: (e) => e.toString(),
       fallback: (i) => 'Ch ${i + 1}',
@@ -138,8 +162,9 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
           // this session's per-session channel visibility).
           ChannelStatsTable(
             labels: channelLabels,
-            activeChannels: _visibleChannels,
-            onToggleChannel: _onToggleChannel,
+            activeChannels: visibleChannels,
+            onToggleChannel: (index) =>
+                unawaited(_toggleChannel(session, visibleChannels, index)),
             unit: unit,
             rows: [
               ChannelStatsRow(
@@ -166,8 +191,8 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 ctrl: _graphCtrl,
                 settings: settings,
                 activeChannels: [
-                  for (int i = 0; i < _visibleChannels.length; i++)
-                    if (_visibleChannels[i]) i,
+                  for (int i = 0; i < visibleChannels.length; i++)
+                    if (visibleChannels[i]) i,
                 ],
                 showDerivative: false,
                 isLiveGraph: false,
@@ -191,12 +216,12 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 _StatRow(
                   label: 'Duration',
                   value: formatDuration(
-                    Duration(milliseconds: _session.durationMs),
+                    Duration(milliseconds: session.durationMs),
                   ),
                 ),
                 _StatRow(
                   label: 'Sample Rate',
-                  value: '${_session.sampleRate} Hz',
+                  value: '${session.sampleRate} Hz',
                 ),
                 _StatRow(label: 'Samples', value: '${data.sampleCount}'),
               ],
@@ -204,7 +229,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
           ),
 
           // Notes
-          if (_session.notes.isNotEmpty) ...[
+          if (session.notes.isNotEmpty) ...[
             const Divider(height: 24),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -213,7 +238,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                 children: [
                   Text('Notes', style: Theme.of(context).textTheme.titleMedium),
                   const SizedBox(height: 8),
-                  Text(_session.notes),
+                  Text(session.notes),
                 ],
               ),
             ),
@@ -228,7 +253,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
               children: [
                 Expanded(
                   child: OutlinedButton.icon(
-                    onPressed: () => _exportCsv(data),
+                    onPressed: () => _exportCsv(session, data),
                     icon: const Icon(Icons.download),
                     label: const Text('Export CSV'),
                   ),
@@ -243,65 +268,56 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     );
   }
 
-  Future<void> _onMenuAction(String action) async {
+  Future<void> _onMenuAction(String action, Session session) async {
     switch (action) {
       case 'rename':
-        await _showRenameDialog();
+        await _showRenameDialog(session);
       case 'notes':
-        await _showNotesDialog();
+        await _showNotesDialog(session);
       case 'export_csv':
         final state = _loadState;
         if (state is _Ready && state.data != null) {
-          await _exportCsv(state.data!);
+          await _exportCsv(session, state.data!);
         }
       case 'delete':
-        await _deleteAndPop();
+        await _deleteAndPop(session);
     }
   }
 
-  /// Re-read the session row after a metadata edit so the UI reflects it.
-  Future<void> _reloadSession() async {
-    final updated = await AppDatabase.instance.sessionById(_session.id);
-    if (updated != null && mounted) {
-      setState(() => _session = updated);
-    }
-  }
-
-  Future<void> _showRenameDialog() async {
+  Future<void> _showRenameDialog(Session session) async {
     final newName = await showTextPrompt(
       context,
       title: 'Rename session',
       label: 'Session name',
-      initial: _session.name,
+      initial: session.name,
     );
     if (newName != null && newName.isNotEmpty) {
-      await AppDatabase.instance.renameSession(_session.id, newName);
-      await _reloadSession();
+      // The row stream refreshes the UI.
+      await AppDatabase.instance.renameSession(session.id, newName);
     }
   }
 
-  Future<void> _showNotesDialog() async {
+  Future<void> _showNotesDialog(Session session) async {
     final newNotes = await showTextPrompt(
       context,
       title: 'Edit notes',
       label: 'Notes',
-      initial: _session.notes,
+      initial: session.notes,
       maxLines: 5,
     );
     if (newNotes != null) {
-      await AppDatabase.instance.setSessionNotes(_session.id, newNotes);
-      await _reloadSession();
+      await AppDatabase.instance.setSessionNotes(session.id, newNotes);
     }
   }
 
-  Future<void> _deleteAndPop() async {
-    if (await showDeleteConfirm(context, what: _session.name)) {
-      await AppDatabase.instance.deleteSession(_session.id);
+  Future<void> _deleteAndPop(Session session) async {
+    if (await showDeleteConfirm(context, what: session.name)) {
+      await AppDatabase.instance.deleteSession(session.id);
       if (mounted) Navigator.of(context).pop();
     }
   }
 
-  Future<void> _exportCsv(SessionData data) async {
+  Future<void> _exportCsv(Session session, SessionData data) async {
     // Build CSV string
     final buf = StringBuffer();
     buf.write('time_s');
@@ -331,7 +347,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     // Save via a native "Save As" dialog. On web there is no save-location
     // picker, so hand the bytes to the browser, which downloads the file.
     final bytes = Uint8List.fromList(utf8.encode(buf.toString()));
-    final csvName = _csvFileName(_session.name);
+    final csvName = _csvFileName(session.name);
     final xFile = XFile.fromData(bytes, mimeType: 'text/csv', name: csvName);
 
     String savedTo;

--- a/lib/screens/sessions_tab.dart
+++ b/lib/screens/sessions_tab.dart
@@ -113,8 +113,17 @@ class _SessionsTabState extends State<SessionsTab> {
     );
   }
 
-  Future<void> _deleteSession(Session session) =>
-      deleteSessionFlow(context, session);
+  Future<void> _deleteSession(Session session) async {
+    try {
+      await deleteSessionFlow(context, session);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to delete session: $e')));
+      }
+    }
+  }
 }
 
 class _SessionCard extends StatelessWidget {
@@ -128,7 +137,7 @@ class _SessionCard extends StatelessWidget {
   final Session session;
   final ForceUnit unit;
   final VoidCallback onTap;
-  final VoidCallback onDelete;
+  final Future<void> Function() onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -148,7 +157,7 @@ class _SessionCard extends StatelessWidget {
         child: Icon(Icons.delete, color: Theme.of(context).colorScheme.onError),
       ),
       confirmDismiss: (_) async {
-        onDelete();
+        await onDelete();
         return false; // We handle deletion ourselves
       },
       child: Card(

--- a/lib/screens/sessions_tab.dart
+++ b/lib/screens/sessions_tab.dart
@@ -16,6 +16,12 @@ class SessionsTab extends StatefulWidget {
 }
 
 class _SessionsTabState extends State<SessionsTab> {
+  /// Created once: a fresh `watchAllSessions()` per build would make the
+  /// [StreamBuilder] unsubscribe and re-run the query on every rebuild
+  /// (this tab rebuilds on each shell tab switch).
+  late final Stream<List<Session>> _sessions = AppDatabase.instance
+      .watchAllSessions();
+
   @override
   Widget build(BuildContext context) {
     final settings = context.watch<AppSettings>();
@@ -37,7 +43,7 @@ class _SessionsTabState extends State<SessionsTab> {
           ),
           Expanded(
             child: StreamBuilder<List<Session>>(
-              stream: AppDatabase.instance.watchAllSessions(),
+              stream: _sessions,
               builder: (context, snapshot) {
                 if (snapshot.hasError) {
                   return Center(

--- a/lib/screens/sessions_tab.dart
+++ b/lib/screens/sessions_tab.dart
@@ -6,6 +6,7 @@ import '../models/force_unit.dart';
 import '../services/database.dart';
 import '../utils/format.dart';
 import '../widgets/dialogs.dart';
+import '../widgets/empty_placeholder.dart';
 import 'session_detail_screen.dart';
 
 class SessionsTab extends StatefulWidget {
@@ -79,23 +80,10 @@ class _SessionsTabState extends State<SessionsTab> {
                 final sessions = snapshot.data ?? [];
 
                 if (sessions.isEmpty) {
-                  return const Center(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.folder_open, size: 64, color: Colors.grey),
-                        SizedBox(height: 16),
-                        Text(
-                          'No recorded sessions yet',
-                          style: TextStyle(color: Colors.grey, fontSize: 16),
-                        ),
-                        SizedBox(height: 8),
-                        Text(
-                          'Start a recording from the Live tab',
-                          style: TextStyle(color: Colors.grey),
-                        ),
-                      ],
-                    ),
+                  return const EmptyPlaceholder(
+                    icon: Icons.folder_open,
+                    title: 'No recorded sessions yet',
+                    hint: 'Start a recording from the Live tab',
                   );
                 }
 
@@ -105,7 +93,6 @@ class _SessionsTabState extends State<SessionsTab> {
                   itemBuilder: (context, index) => _SessionCard(
                     session: sessions[index],
                     unit: settings.displayUnit,
-                    calibrationSlope: sessions[index].calibrationSlope,
                     onTap: () => _openDetail(sessions[index]),
                     onDelete: () => _deleteSession(sessions[index]),
                   ),
@@ -126,25 +113,20 @@ class _SessionsTabState extends State<SessionsTab> {
     );
   }
 
-  Future<void> _deleteSession(Session session) async {
-    if (await showDeleteConfirm(context, what: session.name)) {
-      await AppDatabase.instance.deleteSession(session.id);
-    }
-  }
+  Future<void> _deleteSession(Session session) =>
+      deleteSessionFlow(context, session);
 }
 
 class _SessionCard extends StatelessWidget {
   const _SessionCard({
     required this.session,
     required this.unit,
-    required this.calibrationSlope,
     required this.onTap,
     required this.onDelete,
   });
 
   final Session session;
   final ForceUnit unit;
-  final double calibrationSlope;
   final VoidCallback onTap;
   final VoidCallback onDelete;
 
@@ -153,7 +135,7 @@ class _SessionCard extends StatelessWidget {
     final duration = Duration(milliseconds: session.durationMs);
     final durationStr = formatDuration(duration);
     final peakDisplay = unit.format(
-      unit.fromRaw(session.peakForceRaw.toDouble(), calibrationSlope),
+      unit.fromRaw(session.peakForceRaw.toDouble(), session.calibrationSlope),
     );
 
     return Dismissible(

--- a/lib/screens/settings_tab.dart
+++ b/lib/screens/settings_tab.dart
@@ -15,7 +15,14 @@ class SettingsTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final settings = context.watch<AppSettings>();
-    final bt = context.watch<BleLinkManager>();
+    // Narrow selects: the link manager notifies on every RSSI poll, but the
+    // device section only cares about identity changes.
+    final deviceId = context.select<BleLinkManager, String>(
+      (l) => l.selectedDeviceId,
+    );
+    final deviceName = context.select<BleLinkManager, String>(
+      (l) => l.connectedDeviceName,
+    );
     const bool dart2wasm = bool.fromEnvironment('dart.tool.dart2wasm');
 
     return SafeArea(
@@ -75,7 +82,7 @@ class SettingsTab extends StatelessWidget {
           // Device name — not editable yet. Keyed by the name so the field
           // rebuilds with the new value on connect/disconnect. While no link
           // is up, a blurb with a jump to the Devices tab takes its place.
-          if (bt.selectedDeviceId.isEmpty)
+          if (deviceId.isEmpty)
             Card(
               child: ListTile(
                 leading: const Icon(
@@ -99,8 +106,8 @@ class SettingsTab extends StatelessWidget {
             )
           else
             TextFormField(
-              key: ValueKey(bt.connectedDeviceName),
-              initialValue: bt.connectedDeviceName,
+              key: ValueKey(deviceName),
+              initialValue: deviceName,
               enabled: false,
               decoration: const InputDecoration(
                 labelText: 'Device name',
@@ -146,7 +153,7 @@ class SettingsTab extends StatelessWidget {
   }
 }
 
-class _ChannelConfigTile extends StatefulWidget {
+class _ChannelConfigTile extends StatelessWidget {
   const _ChannelConfigTile({
     required this.index,
     required this.label,
@@ -158,38 +165,6 @@ class _ChannelConfigTile extends StatefulWidget {
   final ValueChanged<String> onLabelChanged;
 
   @override
-  State<_ChannelConfigTile> createState() => _ChannelConfigTileState();
-}
-
-class _ChannelConfigTileState extends State<_ChannelConfigTile> {
-  late final TextEditingController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = TextEditingController(text: widget.label);
-  }
-
-  @override
-  void didUpdateWidget(covariant _ChannelConfigTile oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // The label changed from OUTSIDE this field (e.g. the async SharedPrefs
-    // load completing after the first build): adopt it. A bare
-    // TextFormField(initialValue:) would keep showing the stale default.
-    // Changes caused by this field's own submit are excluded so the caret
-    // isn't disturbed.
-    if (widget.label != oldWidget.label && widget.label != _controller.text) {
-      _controller.text = widget.label;
-    }
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
@@ -198,19 +173,24 @@ class _ChannelConfigTileState extends State<_ChannelConfigTile> {
           children: [
             const SizedBox(width: 8),
             Text(
-              'Ch ${widget.index + 1}',
+              'Ch ${index + 1}',
               style: const TextStyle(fontWeight: FontWeight.w500),
             ),
             const SizedBox(width: 12),
             Expanded(
-              child: TextField(
-                controller: _controller,
+              // Keyed by the label so an externally-changed value (e.g. the
+              // async SharedPrefs load completing after the first build)
+              // rebuilds the field with the fresh label — the same pattern
+              // the device-name field above uses.
+              child: TextFormField(
+                key: ValueKey(label),
+                initialValue: label,
                 decoration: const InputDecoration(
                   isDense: true,
                   border: UnderlineInputBorder(),
                   hintText: 'Label',
                 ),
-                onSubmitted: widget.onLabelChanged,
+                onFieldSubmitted: onLabelChanged,
               ),
             ),
           ],

--- a/lib/screens/settings_tab.dart
+++ b/lib/screens/settings_tab.dart
@@ -98,7 +98,7 @@ class SettingsTab extends StatelessWidget {
                     // Navigate to the Devices tab (same pattern as Live tab).
                     final shell = context
                         .findAncestorStateOfType<AppShellState>();
-                    shell?.switchToTab(2);
+                    shell?.goToDevices();
                   },
                   child: const Text('Connect'),
                 ),

--- a/lib/services/adc_packet_decoder.dart
+++ b/lib/services/adc_packet_decoder.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import 'adc_protocol.dart';
 import 'data_hub.dart';
+import '../utils/log.dart';
 
 /// Protocol layer: decodes the device's ADC-feed notification packets and the
 /// calibration characteristic into [DataHub] updates.
@@ -67,7 +68,7 @@ class AdcPacketDecoder {
     if (_prevSampleCount != -1) {
       final int diff = (count - _prevSampleCount) & 0xFFFF;
       if (diff != 0) {
-        debugPrint('# lost $diff samples');
+        logTrace(() => '# lost $diff samples');
         // Report the dropped range to the hub (capped inside the hub to avoid
         // OOM if the device reboots and the counter jumps).
         hub.addDroppedFrames(diff);

--- a/lib/services/adc_protocol.dart
+++ b/lib/services/adc_protocol.dart
@@ -6,6 +6,8 @@
 /// packets in this format).
 library;
 
+import 'dart:typed_data';
+
 /// Bytes per sample on the wire: [nwNumAdcChan] channels x 3 bytes (24-bit).
 const int nwAdcSampleLength = 12;
 
@@ -17,3 +19,42 @@ const int nwNumAdcChan = 4;
 
 /// Packet header bytes (16-bit little-endian running sample counter).
 const int nwHeaderSize = 2;
+
+/// Encode one sample frame: [nwNumAdcChan] channel values as 24-bit
+/// little-endian. Values are masked to 24 bits (callers clamp to the signed
+/// 24-bit range as needed).
+Uint8List encodeAdcFrame(List<int> channels) {
+  final out = Uint8List(nwAdcSampleLength);
+  for (int ch = 0; ch < nwNumAdcChan; ch++) {
+    final v = channels[ch] & 0xFFFFFF;
+    out[ch * 3] = v & 0xFF;
+    out[ch * 3 + 1] = (v >> 8) & 0xFF;
+    out[ch * 3 + 2] = (v >> 16) & 0xFF;
+  }
+  return out;
+}
+
+/// Encode one ADC feed packet: the 16-bit LE running sample [counter] (the
+/// starting sample index of the packet) followed by exactly [nwAdcNumSamples]
+/// frames. The single packet encoder for the wire format — used by the demo
+/// signal source and the mock BLE platform so they can never drift off-format
+/// ([AdcPacketDecoder] decodes it).
+Uint8List encodeAdcPacket({
+  required int counter,
+  required Iterable<Uint8List> frames,
+}) {
+  assert(
+    frames.length == nwAdcNumSamples,
+    'a packet holds exactly $nwAdcNumSamples frames',
+  );
+  final out = Uint8List(nwHeaderSize + nwAdcNumSamples * nwAdcSampleLength);
+  out[0] = counter & 0xFF;
+  out[1] = (counter >> 8) & 0xFF;
+  int offset = nwHeaderSize;
+  for (final frame in frames) {
+    assert(frame.length == nwAdcSampleLength);
+    out.setAll(offset, frame);
+    offset += nwAdcSampleLength;
+  }
+  return out;
+}

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -7,6 +7,7 @@ import 'app_events.dart';
 import 'bt_device_config.dart';
 import 'demo_signal_source.dart';
 import 'mockble.dart';
+import '../utils/log.dart';
 
 /// Lifecycle of a single device's BLE link.
 ///
@@ -107,6 +108,24 @@ class DeviceLink {
   }
 }
 
+/// Cancellation token for one async post-connect setup pass. Captured at pass
+/// start; after every `await` the pass checks [isCurrent] and bails silently
+/// when false. A token stops being current when the epoch moved on (a newer
+/// connect, a disconnect, or any teardown — see
+/// [BleLinkManager._supersedeSetupPasses]) or the active link is no longer
+/// the token's device. Issuing and checking tokens is the only API, so a pass
+/// can never forget to stamp itself.
+class _SetupToken {
+  const _SetupToken(this._manager, this._epoch, this.deviceId);
+
+  final BleLinkManager _manager;
+  final int _epoch;
+  final String deviceId;
+
+  bool get isCurrent =>
+      _manager._setupEpoch == _epoch && _manager._link.deviceId == deviceId;
+}
+
 /// The BLE link state machine: adapter availability, scanning, connect /
 /// post-connect setup / disconnect / cooldown, and live RSSI polling.
 ///
@@ -152,13 +171,21 @@ class BleLinkManager extends ChangeNotifier {
   /// link is superseded before it fires.
   Timer? _cooldownTimer;
 
-  /// Monotonic counter bumped on every connect request, disconnect request, and
-  /// teardown. The async post-connect setup in [_onConnectionChange] captures
-  /// the value at its start and re-checks it after each `await`; if it changed,
-  /// a newer connect/disconnect superseded this setup pass, so it bails out
-  /// silently (no state writes, no failure toast). This is what stops the
-  /// "furious clicking" races from corrupting link state or spamming toasts.
-  int _setupGeneration = 0;
+  /// Epoch counter for the async post-connect setup cancellation tokens (see
+  /// [_SetupToken]). Bumped on every connect request, disconnect request, and
+  /// teardown via [_supersedeSetupPasses]; async setup code captures a token
+  /// and re-checks it after each `await`, bailing out silently when
+  /// superseded. This is what stops the "furious clicking" races from
+  /// corrupting link state or spamming toasts.
+  int _setupEpoch = 0;
+
+  /// Issue a cancellation token for a new setup pass over the current epoch.
+  _SetupToken _setupTokenFor(String deviceId) =>
+      _SetupToken(this, _setupEpoch, deviceId);
+
+  /// Supersede every outstanding setup pass (a newer connect, a disconnect,
+  /// or a teardown happened).
+  void _supersedeSetupPasses() => _setupEpoch++;
 
   AvailabilityState _bluetoothState = AvailabilityState.unknown;
   AvailabilityState get bluetoothState => _bluetoothState;
@@ -454,7 +481,7 @@ class BleLinkManager extends ChangeNotifier {
   void _teardownLink(String deviceId, String name, {bool releaseGatt = false}) {
     // Supersede any in-flight post-connect setup pass so it bails out instead of
     // writing state for a link we're tearing down.
-    _setupGeneration++;
+    _supersedeSetupPasses();
     _stopRssiPolling();
     _cooldownTimer?.cancel();
     _cooldownTimer = null;
@@ -495,13 +522,6 @@ class BleLinkManager extends ChangeNotifier {
     }
   }
 
-  /// True if the post-connect setup pass that captured [gen] for [deviceId] has
-  /// been superseded — i.e. the generation moved on (a newer connect or a
-  /// teardown happened) or the active link is no longer this device. Setup code
-  /// calls this after each await and bails out silently when true.
-  bool _setupSuperseded(int gen, String deviceId) =>
-      gen != _setupGeneration || _link.deviceId != deviceId;
-
   void _onConnectionChange(
     String deviceId,
     bool isConnected,
@@ -537,11 +557,12 @@ class BleLinkManager extends ChangeNotifier {
     }
 
     if (isConnected) {
-      // Capture the generation for this setup pass. Every connect/disconnect/
-      // teardown bumps [_setupGeneration]; if it changes under us (user clicked
-      // again, the device dropped, etc.) we abandon this pass without touching
-      // state or surfacing a toast — see [_setupSuperseded].
-      final int gen = ++_setupGeneration;
+      // Capture a cancellation token for this setup pass. Every connect/
+      // disconnect/teardown supersedes outstanding tokens (see
+      // [_supersedeSetupPasses]); after every await below we re-check it and
+      // abandon the pass silently — no state writes, no failure toast — when
+      // a newer attempt (or a teardown) moved on.
+      final token = _setupTokenFor(deviceId);
 
       _link.deviceId = deviceId;
       _link.state = BtLinkState.connected; // "Setting up…" until streaming.
@@ -557,15 +578,13 @@ class BleLinkManager extends ChangeNotifier {
 
       // Post-connect setup. If the device drops mid-setup (common when Chrome
       // accepts a too-soon reconnect then tears it down), these calls throw
-      // ("Cannot discover services…") or time out via the command queue. We
-      // re-check the generation after every await: if superseded, bail silently
-      // so a stale pass can't clobber a newer attempt or emit a spurious toast.
+      // ("Cannot discover services…") or time out via the command queue.
       try {
         if (!kIsWeb) {
           debugPrint('Requested MTU change');
           final int mtu = await UniversalBle.requestMtu(deviceId, 247);
           debugPrint('MTU set to: $mtu');
-          if (_setupSuperseded(gen, deviceId)) return;
+          if (!token.isCurrent) return;
           // TODO(perf): investigate requesting high-performance connection
           // priority here for the 1 kHz ADC stream:
           //   await UniversalBle.requestConnectionPriority(
@@ -576,12 +595,12 @@ class BleLinkManager extends ChangeNotifier {
           // samples before enabling.
         }
         final discovered = await UniversalBle.discoverServices(deviceId);
-        if (_setupSuperseded(gen, deviceId)) return;
+        if (!token.isCurrent) return;
         bool subscribed = false;
         for (final srv in discovered) {
           if (srv.uuid == btServiceId) {
             subscribed = await subscribeToAdcFeed(srv);
-            if (_setupSuperseded(gen, deviceId)) return;
+            if (!token.isCurrent) return;
             break;
           }
         }
@@ -600,7 +619,7 @@ class BleLinkManager extends ChangeNotifier {
         // A superseded pass failing is expected (the device was torn down or a
         // queued command was cancelled/timed out) — swallow it silently. Only a
         // genuine failure of the *current* attempt resets the link and toasts.
-        if (_setupSuperseded(gen, deviceId)) {
+        if (!token.isCurrent) {
           debugPrint('Ignoring stale post-connect failure for $deviceId: $e');
           return;
         }
@@ -639,14 +658,41 @@ class BleLinkManager extends ChangeNotifier {
     }
   }
 
-  Future<void> connectToDemoDevice() async {
-    if (_isScanning) {
-      await _stopScan();
-    }
+  /// Synchronous part of the connect preamble: refuse while a link is
+  /// mid-transition (the device row's Connect button is disabled until the
+  /// link returns to idle — first via the disconnect callback or the
+  /// disconnect() timeout reconciliation, then through the post-disconnect
+  /// cooldown window on web — so we never start a connect against a link the
+  /// stack isn't ready for), cancel a now-moot pending cooldown timer, and
+  /// supersede any lingering setup pass from a prior attempt.
+  ///
+  /// Kept synchronous so callers write their busy state in the same task —
+  /// a Scan tap dispatched right after a Connect tap then sees `connecting`
+  /// and bails (see [_startScan]).
+  ///
+  /// NOTE: we deliberately track link state from the event callbacks
+  /// (_onConnectionChange) rather than from UniversalBle.getConnectionState().
+  /// The latter is a one-shot async *query*, not an event source — it can't
+  /// push updates, so it can't replace callback-driven state without polling
+  /// (just a different timer).
+  ///
+  /// MULTI-DEVICE (Path A): the idle guard becomes per-device — a different,
+  /// idle device can connect while another is mid-transition.
+  bool _beginConnect() {
     if (_link.state != BtLinkState.idle) {
-      return;
+      return false;
     }
-    _setupGeneration++;
+    // A pending cooldown timer (from a prior teardown) is now moot: its guard
+    // would no-op once we move to `connecting`, but cancel it eagerly so it
+    // can't fire against this new attempt.
+    _cooldownTimer?.cancel();
+    _cooldownTimer = null;
+    _supersedeSetupPasses();
+    return true;
+  }
+
+  Future<void> connectToDemoDevice() async {
+    if (!_beginConnect()) return;
     _link.deviceId = 'demo_device';
     _link.name = 'Demo Device';
     _link.state = BtLinkState.streaming;
@@ -657,42 +703,21 @@ class BleLinkManager extends ChangeNotifier {
     });
 
     notifyListeners();
+    if (_isScanning) await _stopScan();
   }
 
   Future<void> connectToDevice(String deviceId) async {
-    if (_isScanning) {
-      await _stopScan();
-    }
-    // Block connecting while a link is busy (connecting/connected/disconnecting)
-    // or cooling down. The disconnecting/cooldown cases are what stop the
-    // "double-click after Disconnect" race: the device row's Connect button is
-    // disabled until the link returns to idle — first via the disconnect
-    // callback (or the disconnect() timeout reconciliation), then through the
-    // post-disconnect cooldown window on web — so we never reach here against a
-    // link that the stack isn't yet ready to reconnect.
-    //
-    // NOTE: we deliberately track link state from the event callbacks
-    // (_onConnectionChange) rather than from UniversalBle.getConnectionState().
-    // The latter is a one-shot async *query*, not an event source — it can't
-    // push updates, so it can't replace callback-driven state without polling
-    // (just a different timer). It's only worth a one-shot reconciliation call
-    // (e.g. on app resume), which we don't need today.
-    //
-    // MULTI-DEVICE (Path A): this guard becomes per-device — a different,
-    // idle device can connect while another is mid-transition.
-    if (_link.state != BtLinkState.idle) {
-      return;
-    }
-    // A pending cooldown timer (from a prior teardown) is now moot: its guard
-    // would no-op once we move to `connecting`, but cancel it eagerly so it
-    // can't fire against this new attempt.
-    _cooldownTimer?.cancel();
-    _cooldownTimer = null;
-    // Supersede any lingering setup pass from a prior attempt.
-    _setupGeneration++;
+    if (!_beginConnect()) return;
     _link.deviceId = deviceId;
     _link.state = BtLinkState.connecting;
     notifyListeners();
+
+    // Stop scanning before connecting (the package advises it). The busy
+    // state is already written above, so this await can't reopen the
+    // Scan-tap race.
+    if (_isScanning) {
+      await _stopScan();
+    }
 
     // The post-disconnect settle window is enforced as the visible
     // [BtLinkState.cooldown] state (see [_teardownLink]) BEFORE Connect is
@@ -739,7 +764,7 @@ class BleLinkManager extends ChangeNotifier {
     final String deviceName = _link.name.isEmpty ? deviceId : _link.name;
     // Supersede any in-flight post-connect setup pass immediately so it stops
     // mutating state while we tear the link down.
-    _setupGeneration++;
+    _supersedeSetupPasses();
 
     if (_link.isDemoDevice) {
       _demoSource?.stop();
@@ -835,10 +860,11 @@ class BleLinkManager extends ChangeNotifier {
     // lowercase, so an exact match is safe.
     // MULTI-DEVICE (Path A): route by deviceId instead of dropping.
     if (deviceId != _link.deviceId || characteristicId != btChrAdcFeedId) {
-      debugPrint(
-        'Dropping notification from unexpected source: device $deviceId, '
-        'characteristic $characteristicId (${data.length} B); '
-        'active link is ${_link.deviceId.isEmpty ? '(none)' : _link.deviceId}',
+      logTrace(
+        () =>
+            'Dropping notification from unexpected source: device $deviceId, '
+            'characteristic $characteristicId (${data.length} B); '
+            'active link is ${_link.deviceId.isEmpty ? '(none)' : _link.deviceId}',
       );
       return;
     }
@@ -867,7 +893,7 @@ class BleLinkManager extends ChangeNotifier {
     _cooldownTimer?.cancel();
     _cooldownTimer = null;
     // Supersede any in-flight post-connect setup pass so it bails out.
-    _setupGeneration++;
+    _supersedeSetupPasses();
 
     // Best-effort from here: the app is being torn down, so failures are
     // irrelevant — just make sure they can't propagate.

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -220,9 +220,26 @@ class BleLinkManager extends ChangeNotifier {
   /// gate on `!kIsWeb`.
   bool get _supportsRssi => !kIsWeb;
 
-  /// Periodic poller for [connectedRssi]; runs only while a link is connected
-  /// and the platform supports RSSI reads.
+  /// Periodic poller for [connectedRssi]; runs only while a link is streaming
+  /// AND the surface displaying RSSI (the Devices tab) is visible.
   Timer? _rssiPollTimer;
+
+  /// Whether the surface displaying live RSSI (the Devices tab's connected
+  /// card) is currently visible. Polling runs only while this is true and a
+  /// link is streaming: off-screen RSSI reads would wake the radio every
+  /// [rssiPollInterval] for nothing.
+  bool _rssiUiActive = false;
+
+  /// Called by the shell when the RSSI-displaying tab becomes visible/hidden.
+  void setRssiUiActive(bool active) {
+    if (_rssiUiActive == active) return;
+    _rssiUiActive = active;
+    if (!active) {
+      _stopRssiPolling();
+    } else if (_link.isStreaming) {
+      _startRssiPolling(_link.deviceId);
+    }
+  }
 
   /// Raw ADC-feed notification bytes, exactly as received. Wired to the
   /// protocol layer ([AdcPacketDecoder.onDataPacket]) at app startup; the link
@@ -380,14 +397,15 @@ class BleLinkManager extends ChangeNotifier {
     );
   }
 
-  /// Begin polling the connected device's RSSI for the live signal display.
-  /// No-op on platforms that don't implement readRssi (e.g. web). Cancels any
-  /// previous poller first. Reads are best-effort: a failed read is swallowed
-  /// silently and retried on the next tick (no per-tick logging — it would spam
-  /// the console).
+  /// Begin polling the connected device's RSSI for the signal display.
+  /// No-op on platforms that don't implement readRssi (e.g. web) and while
+  /// the RSSI-displaying surface is off-screen (see [setRssiUiActive]).
+  /// Cancels any previous poller first. Reads are best-effort: a failed read
+  /// is swallowed silently and retried on the next tick (no per-tick logging
+  /// — it would spam the console).
   void _startRssiPolling(String deviceId) {
     _stopRssiPolling();
-    if (!_supportsRssi) {
+    if (!_supportsRssi || !_rssiUiActive) {
       return;
     }
     _rssiPollTimer = Timer.periodic(rssiPollInterval, (_) async {

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -123,6 +123,15 @@ class BleLinkManager extends ChangeNotifier {
   /// already-disconnected case), so we no longer hand-roll a parallel Timer.
   static const Duration disconnectTimeout = Duration(milliseconds: 2500);
 
+  /// Upper bound passed to [UniversalBle.connect] so a hung connect attempt
+  /// can't strand the UI on "Connecting…". connect() bypasses the package's
+  /// command queue — so [UniversalBle.timeout] does NOT cover it — and
+  /// defaults to 60 s; 15 s is comfortably past a slow connect or a platform
+  /// pairing prompt without feeling wedged. When it fires, the platform
+  /// connect may still complete later — that late callback is released and
+  /// ignored by the unwanted-link guard in [_onConnectionChange].
+  static const Duration connectTimeout = Duration(seconds: 15);
+
   /// How often to poll the connected device's RSSI for the live signal display.
   static const Duration rssiPollInterval = Duration(seconds: 2);
 
@@ -139,7 +148,7 @@ class BleLinkManager extends ChangeNotifier {
 
   /// One-shot timer that returns the active link from [BtLinkState.cooldown]
   /// back to [BtLinkState.idle] once [reconnectSettleDelay] has elapsed since
-  /// the last teardown. Web-only (see [_endLink]). Cancelled if the
+  /// the last teardown. Web-only (see [_teardownLink]). Cancelled if the
   /// link is superseded before it fires.
   Timer? _cooldownTimer;
 
@@ -406,9 +415,17 @@ class BleLinkManager extends ChangeNotifier {
   }
 
   /// Common teardown for every path that ends a link (clean disconnect, failed
-  /// post-connect setup, disconnect timeout): stop RSSI polling and clear the
-  /// link. Recording is NOT handled here — [RecordingController] observes this
-  /// notifier and stops its session when streaming ends.
+  /// post-connect setup, disconnect timeout, abandoned connect): stop RSSI
+  /// polling, supersede in-flight setup, and clear the link. Recording is NOT
+  /// handled here — [RecordingController] observes this notifier and stops its
+  /// session when streaming ends.
+  ///
+  /// [releaseGatt] must be true when the platform-level GATT link is (or may
+  /// still be) up: a failed post-connect setup, or an abandoned/timed-out
+  /// connect. It triggers a best-effort [UniversalBle.disconnect] so the
+  /// OS/browser connection can't leak. Local state is reset FIRST, so the
+  /// resulting disconnect callback arrives to an unwanted link and is ignored
+  /// by the guard in [_onConnectionChange].
   ///
   /// On web (real BLE devices only) the link is NOT returned straight to
   /// [BtLinkState.idle]: it is parked in [BtLinkState.cooldown] for
@@ -416,7 +433,7 @@ class BleLinkManager extends ChangeNotifier {
   /// until Chrome has finished GATT teardown. Native stacks and the demo
   /// device don't exhibit the too-soon-reconnect race, so they reset directly
   /// to idle. Does NOT call [notifyListeners] — callers do.
-  void _endLink(String deviceId, String name) {
+  void _teardownLink(String deviceId, String name, {bool releaseGatt = false}) {
     // Supersede any in-flight post-connect setup pass so it bails out instead of
     // writing state for a link we're tearing down.
     _setupGeneration++;
@@ -427,20 +444,37 @@ class BleLinkManager extends ChangeNotifier {
     // Cooldown applies to real BLE links on web only — not native, not demo.
     if (!kIsWeb || _link.isDemoDevice) {
       _link.reset();
-      return;
+    } else {
+      // Web: hold the link in cooldown for the settle window, then release it.
+      _link.enterCooldown(deviceId, name);
+      _cooldownTimer = Timer(reconnectSettleDelay, () {
+        _cooldownTimer = null;
+        // Only release if we're still cooling down THIS device (a new connect
+        // attempt to a different device, or a fresh teardown, may have moved on).
+        if (_link.isCoolingDown && _link.deviceId == deviceId) {
+          _link.reset();
+          notifyListeners();
+        }
+      });
     }
 
-    // Web: hold the link in cooldown for the settle window, then release it.
-    _link.enterCooldown(deviceId, name);
-    _cooldownTimer = Timer(reconnectSettleDelay, () {
-      _cooldownTimer = null;
-      // Only release if we're still cooling down THIS device (a new connect
-      // attempt to a different device, or a fresh teardown, may have moved on).
-      if (_link.isCoolingDown && _link.deviceId == deviceId) {
-        _link.reset();
-        notifyListeners();
-      }
-    });
+    if (releaseGatt) {
+      unawaited(_releaseGatt(deviceId));
+    }
+  }
+
+  /// Best-effort release of a platform-level GATT link that has no app-side
+  /// owner (a timed-out/cancelled connect that later completes, or a link
+  /// whose post-connect setup failed). Fire-and-forget: the resulting
+  /// connection-change callback arrives to find the link unwanted and is
+  /// ignored by the guard in [_onConnectionChange]. Errors are swallowed —
+  /// this runs on teardown paths that must never throw.
+  Future<void> _releaseGatt(String deviceId) async {
+    try {
+      await UniversalBle.disconnect(deviceId, timeout: disconnectTimeout);
+    } catch (_) {
+      // Best effort only: the link is unwanted either way.
+    }
   }
 
   /// True if the post-connect setup pass that captured [gen] for [deviceId] has
@@ -459,11 +493,28 @@ class BleLinkManager extends ChangeNotifier {
       'isConnected $deviceId, $isConnected ${(err == null) ? '' : err}',
     );
 
-    // MULTI-DEVICE (Path A): look up `_links[deviceId]` instead of assuming the
-    // event is for the single active link. For now we only track one link, so a
-    // callback for a different deviceId is ignored.
-    if (_link.deviceId.isNotEmpty && _link.deviceId != deviceId) {
-      debugPrint('Ignoring connection change for non-active device $deviceId');
+    // Unwanted-link guard: ignore any connection event that has no app-side
+    // owner — events for a different device than the active link, or events
+    // for OUR device arriving when no connect result is expected (idle,
+    // cooldown, disconnecting). A platform-level connect can complete AFTER
+    // we gave up on it (connect timeout, user cancel); the GATT link is then
+    // live at the platform level with nothing tracking it. Release such links
+    // so they can't leak, then ignore the event.
+    //
+    // MULTI-DEVICE (Path A): look up `_links[deviceId]` instead of assuming
+    // the event is for the single active link.
+    final bool isActiveDevice =
+        _link.deviceId.isNotEmpty && _link.deviceId == deviceId;
+    if (!isActiveDevice ||
+        (isConnected && !_link.isConnecting && !_link.isLinkUp)) {
+      if (isConnected) {
+        debugPrint('Releasing unexpected GATT link for $deviceId');
+        unawaited(_releaseGatt(deviceId));
+      } else {
+        debugPrint(
+          'Ignoring connection change for non-active device $deviceId',
+        );
+      }
       return;
     }
 
@@ -537,7 +588,9 @@ class BleLinkManager extends ChangeNotifier {
         }
         debugPrint('Post-connect setup failed for $deviceId: $e');
         final String name = _link.name.isEmpty ? deviceId : _link.name;
-        _endLink(deviceId, name);
+        // The GATT link came up (connect succeeded) — release it so the
+        // platform can't hold a connection the app considers failed.
+        _teardownLink(deviceId, name, releaseGatt: true);
         _events.emit(BleConnectionFailed(name));
         notifyListeners();
       }
@@ -549,7 +602,8 @@ class BleLinkManager extends ChangeNotifier {
       if (_link.deviceId.isEmpty) return;
 
       // Disconnect resolved (whether user-requested or unexpected): run the
-      // common teardown, which (on web) parks the link in cooldown for the
+      // common teardown (the platform side is already down, so no GATT
+      // release), which (on web) parks the link in cooldown for the
       // reconnect settle window before returning it to the idle sentinel.
       final String name = _link.name.isEmpty ? deviceId : _link.name;
       // An unexpected drop while the link was up (setting up or streaming)
@@ -559,7 +613,7 @@ class BleLinkManager extends ChangeNotifier {
       final bool wasActive =
           _link.state == BtLinkState.connected ||
           _link.state == BtLinkState.streaming;
-      _endLink(deviceId, name);
+      _teardownLink(deviceId, name);
       if (wasActive) {
         _events.emit(BleConnectionLost(name));
       }
@@ -623,30 +677,44 @@ class BleLinkManager extends ChangeNotifier {
     notifyListeners();
 
     // The post-disconnect settle window is enforced as the visible
-    // [BtLinkState.cooldown] state (see [_endLink]) BEFORE Connect is
+    // [BtLinkState.cooldown] state (see [_teardownLink]) BEFORE Connect is
     // re-enabled, so by the time we get here the stack has already had time
     // to finish GATT teardown. No inline sleep is needed.
 
     try {
-      await UniversalBle.connect(deviceId);
+      // connect() bypasses the package command queue and defaults to a 60 s
+      // timeout — pass ours explicitly (see [connectTimeout]).
+      await UniversalBle.connect(deviceId, timeout: connectTimeout);
     } catch (e) {
+      // This attempt was abandoned while its future was outstanding (user
+      // cancel, or superseded by a newer one): the teardown already ran, so
+      // fail quietly instead of running a second teardown (which would park
+      // a phantom cooldown on web) or toasting an error the user asked for.
+      if (_link.deviceId != deviceId || !_link.isConnecting) {
+        return;
+      }
       // Connection result (success) arrives via _onConnectionChange; on a
       // failed connect attempt that callback may never fire, so tear the link
       // down here and let the caller surface the error. Go through the common
-      // [_endLink] teardown (not a bare reset): it supersedes any lingering
-      // setup pass and, on web, parks the link in cooldown so an immediate
-      // retry doesn't hit the too-soon-reconnect race.
+      // [_teardownLink] (not a bare reset): it supersedes any lingering
+      // setup pass, releases the platform GATT link (a timed-out connect can
+      // still complete later — the guard in [_onConnectionChange] handles
+      // that callback), and, on web, parks the link in cooldown so an
+      // immediate retry doesn't hit the too-soon-reconnect race.
       final device = _devices.where((d) => d.deviceId == deviceId).firstOrNull;
-      _endLink(deviceId, device?.name ?? deviceId);
+      _teardownLink(deviceId, device?.name ?? deviceId, releaseGatt: true);
       notifyListeners();
       rethrow;
     }
   }
 
   Future<void> disconnectSelectedDevice() async {
-    // Allow disconnecting whenever the GATT link is up — whether still "setting
-    // up" or fully streaming — so the user can cancel a stuck setup too.
-    if (!_link.isLinkUp) {
+    // Allow disconnecting whenever a link attempt is in flight or the GATT
+    // link is up — connecting (cancel a stuck/hung attempt), connected
+    // (cancel a stuck setup), or streaming. The teardown releases the
+    // platform side; a connect that completes after we gave up on it is
+    // caught by the unwanted-link guard in [_onConnectionChange].
+    if (!_link.isConnecting && !_link.isLinkUp) {
       return;
     }
     final String deviceId = _link.deviceId;
@@ -657,7 +725,7 @@ class BleLinkManager extends ChangeNotifier {
 
     if (_link.isDemoDevice) {
       _demoSource?.stop();
-      _endLink(_link.deviceId, _link.name);
+      _teardownLink(_link.deviceId, _link.name);
       notifyListeners();
       return;
     }
@@ -687,7 +755,9 @@ class BleLinkManager extends ChangeNotifier {
     if (_link.deviceId == deviceId &&
         _link.state == BtLinkState.disconnecting) {
       debugPrint('Disconnect did not settle for $deviceId; forcing idle');
-      _endLink(deviceId, deviceName);
+      // No GATT release here: the disconnect above already went out to the
+      // platform; a late callback is handled by the unwanted-link guard.
+      _teardownLink(deviceId, deviceName);
       _events.emit(BleDisconnectTimeout(deviceName));
       notifyListeners();
     }

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -37,7 +37,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   static const int _tareWindow = 1024;
   static const int samplesPerSec = 1000;
   static const int maxDataSz = samplesPerSec * 60 * 10;
-  static const int bucketSize = 100;
+  static const int bucketSize = kBucketSize;
   static const int numBuckets = maxDataSz ~/ bucketSize;
 
   /// "No sample seen yet" sentinels for [rawMax]/[rawMin]: int32 min/max, so
@@ -78,6 +78,18 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   final List<BucketAccumulator> diffBuckets = List.generate(
     DataHub.numAdcChannels,
     (_) => BucketAccumulator(bucketSize: bucketSize, numBuckets: numBuckets),
+    growable: false,
+  );
+
+  /// The shared per-sample ingester feeding [valueBuckets]/[diffBuckets]
+  /// (see [ChannelIngest]).
+  late final List<ChannelIngest> _ingest = List.generate(
+    DataHub.numAdcChannels,
+    (i) => ChannelIngest(
+      valueBuckets: valueBuckets[i],
+      diffBuckets: diffBuckets[i],
+      gaps: gaps,
+    ),
     growable: false,
   );
   int _tareCount = 0;
@@ -162,8 +174,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
       tare[i] = 0;
       _runningTotal[i] = 0;
       _currentRaw[i] = 0;
-      valueBuckets[i].reset();
-      diffBuckets[i].reset();
+      _ingest[i].reset();
     }
     for (final listener in _clearedListeners) {
       listener();
@@ -354,17 +365,9 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   }
 
   void _addData(int val, int idx) {
-    // First difference vs the previous sample, ingested alongside the value;
-    // the 0-for-first-sample/gap/gap-exit rule lives in [ingestDiff]. The
-    // ring read is safe for totalSamples == 0 (Dart % is non-negative) and
-    // ignored by rule there.
-    final int diff = ingestDiff(
-      sampleIndex: totalSamples,
-      value: val,
-      prevValue: rawData[idx][(totalSamples - 1) % maxDataSz],
-      gaps: gaps,
-    );
-
+    // The previous-value read is safe for totalSamples == 0 (Dart % is
+    // non-negative) and ignored by the ingest diff rule there.
+    final int prev = rawData[idx][(totalSamples - 1) % maxDataSz];
     rawData[idx][totalSamples % maxDataSz] = val;
     if (val > rawMax[idx]) {
       rawMax[idx] = val;
@@ -372,9 +375,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
     if (val < rawMin[idx]) {
       rawMin[idx] = val;
     }
-
-    valueBuckets[idx].add(totalSamples, val);
-    diffBuckets[idx].add(totalSamples, diff);
+    _ingest[idx].add(totalSamples, val, prev);
   }
 }
 

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -241,6 +241,11 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   /// reboots and the counter jumps. Held samples are real ring-buffer time
   /// (they advance [totalSamples]) but are NOT real readings, so they are
   /// never accumulated into an in-progress tare average.
+  ///
+  /// TODO(perf): a reboot jump can inject up to ~262k held samples (65,535 x
+  /// 4 channels) synchronously inside one BLE callback, stalling the UI
+  /// isolate for a beat. If that becomes visible, chunk the injection across
+  /// frames (or fast-forward the ring/bucket state without per-sample work).
   void addDroppedFrames(int count) {
     final int toInject = math.min(count, maxDataSz);
     gaps.append(totalSamples, totalSamples + toInject);

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -123,6 +123,19 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   void removeSamplesAppendedListener(SamplesAppendedListener listener) =>
       _samplesAppendedListeners.remove(listener);
 
+  /// Observers notified once per [clear] — a new device stream just reset the
+  /// hub, so views must drop stale pan/zoom windows instead of clamping them
+  /// against an empty buffer. Lets observers react to resets explicitly
+  /// instead of mirroring [generation] and comparing on every notify.
+  final ObserverList<void Function()> _clearedListeners =
+      ObserverList<void Function()>();
+
+  void addClearedListener(void Function() listener) =>
+      _clearedListeners.add(listener);
+
+  void removeClearedListener(void Function() listener) =>
+      _clearedListeners.remove(listener);
+
   DataHub() {
     clear();
   }
@@ -151,6 +164,9 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
       _currentRaw[i] = 0;
       valueBuckets[i].reset();
       diffBuckets[i].reset();
+    }
+    for (final listener in _clearedListeners) {
+      listener();
     }
     notifyListeners();
   }

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -192,6 +192,15 @@ class AppDatabase extends _$AppDatabase {
     return (select(sessions)..where((t) => t.id.equals(id))).getSingleOrNull();
   }
 
+  /// Watch a single session row (reactive). The detail screen's source of
+  /// truth: edits made from anywhere (rename, notes, channel visibility)
+  /// surface without manual reloads.
+  Stream<Session?> watchSessionById(int id) {
+    return (select(
+      sessions,
+    )..where((t) => t.id.equals(id))).watchSingleOrNull();
+  }
+
   /// Sessions that were never finalized (e.g. the app died mid-recording).
   Future<List<Session>> incompleteSessions() {
     return (select(sessions)..where((t) => t.isCompleted.equals(false))).get();

--- a/lib/services/demo_signal_source.dart
+++ b/lib/services/demo_signal_source.dart
@@ -28,15 +28,7 @@ class DemoSignalSource {
 
     // 20 ms timer emitting 1 packet (20 samples @ 1 kHz).
     _timer = Timer.periodic(const Duration(milliseconds: 20), (_) {
-      final packet = Uint8List(
-        nwHeaderSize + nwAdcNumSamples * nwAdcSampleLength,
-      );
-
-      // 16-bit header counter
-      packet[0] = _counter & 0xFF;
-      packet[1] = (_counter >> 8) & 0xFF;
-
-      int offset = nwHeaderSize;
+      final frames = <Uint8List>[];
 
       for (int i = 0; i < nwAdcNumSamples; i++) {
         // Time in seconds since start
@@ -92,19 +84,12 @@ class DemoSignalSource {
           8388607,
         );
 
-        final samples = [c1, c2, c3, c4];
-
-        for (int ch = 0; ch < nwNumAdcChan; ch++) {
-          final int val = samples[ch];
-          packet[offset++] = (val >> 0) & 0xFF;
-          packet[offset++] = (val >> 8) & 0xFF;
-          packet[offset++] = (val >> 16) & 0xFF;
-        }
+        frames.add(encodeAdcFrame([c1, c2, c3, c4]));
 
         _globalSampleIndex++;
       }
 
-      onData(packet);
+      onData(encodeAdcPacket(counter: _counter, frames: frames));
       // Bump counter by nwAdcNumSamples (20) to maintain continuity
       _counter = (_counter + nwAdcNumSamples) & 0xFFFF;
     });

--- a/lib/services/mockble.dart
+++ b/lib/services/mockble.dart
@@ -247,18 +247,14 @@ class MockBlePlatform extends UniversalBlePlatform {
         _generatedPacketCount++;
         if (drop) return;
 
-        final ev = Uint8List(
-          nwHeaderSize + nwAdcSampleLength * nwAdcNumSamples,
+        final ev = encodeAdcPacket(
+          counter: thisCounter,
+          frames: [
+            for (int i = 0; i < nwAdcNumSamples; ++i)
+              _mockData[(_mockDataCount + i) % _mockData.length],
+          ],
         );
-        // 2-byte little-endian running sample counter (the *starting* sample
-        // index of this packet), per adc_protocol.dart.
-        ev[0] = thisCounter & 0xFF;
-        ev[1] = (thisCounter >> 8) & 0xFF;
-        for (int i = 0; i < nwAdcNumSamples; ++i) {
-          final frame = _mockData[_mockDataCount];
-          ev.setAll(nwHeaderSize + i * nwAdcSampleLength, frame);
-          _mockDataCount = (_mockDataCount + 1) % _mockData.length;
-        }
+        _mockDataCount = (_mockDataCount + nwAdcNumSamples) % _mockData.length;
         updateCharacteristicValue(deviceId, characteristic, ev, null);
       });
     }
@@ -324,19 +320,6 @@ class MockBlePlatform extends UniversalBlePlatform {
     return ([]);
   }
 
-  /// Pack 4 channel values (24-bit signed) into the 12-byte wire sample.
-  static Uint8List _packSample(int c0, int c1, int c2, int c3) {
-    final out = Uint8List(nwAdcSampleLength);
-    final ch = [c0, c1, c2, c3];
-    for (int i = 0; i < nwNumAdcChan; ++i) {
-      final v = ch[i] & 0xFFFFFF;
-      out[i * 3] = v & 0xFF;
-      out[i * 3 + 1] = (v >> 8) & 0xFF;
-      out[i * 3 + 2] = (v >> 16) & 0xFF;
-    }
-    return out;
-  }
-
   /// Generate [count] deterministic multi-channel frames so the mock feed
   /// looks like real data when no MockData.txt is present. Channel 0/1 are
   /// sines with a phase offset, channel 2 a cosine, channel 3 a slow sawtooth;
@@ -354,7 +337,7 @@ class MockBlePlatform extends UniversalBlePlatform {
       final c1 = (sin(2 * pi * cycles * t + pi / 4) * amp1).round();
       final c2 = (cos(2 * pi * cycles * t) * amp2).round();
       final c3 = ((s % 200) - 100) * amp3;
-      frames.add(_packSample(c0, c1, c2, c3));
+      frames.add(encodeAdcFrame([c0, c1, c2, c3]));
     }
     return frames;
   }

--- a/lib/services/mockble.dart
+++ b/lib/services/mockble.dart
@@ -58,6 +58,21 @@ class MockBlePlatform extends UniversalBlePlatform {
   /// link down.
   bool hangDisconnect = false;
 
+  /// When true, [connect] takes [slowConnectDelay] instead of [netDelay] —
+  /// far longer than the client's connect timeout, so the attempt is torn
+  /// down before the platform link comes up. The late success still fires
+  /// its connection-change callback afterwards (the "connect completed after
+  /// the client gave up" race).
+  bool slowConnect = false;
+  static const slowConnectDelay = Duration(seconds: 20);
+
+  /// Test spy: every deviceId passed to [disconnect], in order. Lets tests
+  /// assert that leaked/unwanted GATT links were released.
+  final List<String> disconnectCalls = [];
+
+  /// The device the mock currently considers linked (test assertions only).
+  String? get connectedDeviceId => _connectedDeviceId;
+
   /// Reset every knob to its default and silently sever any leftover link
   /// (no callbacks), so the singleton is clean for the next test.
   void resetKnobs() {
@@ -66,8 +81,12 @@ class MockBlePlatform extends UniversalBlePlatform {
     failCalibrationRead = false;
     failConnect = false;
     hangDisconnect = false;
+    slowConnect = false;
+    disconnectCalls.clear();
     _connectedDeviceId = null;
     _connectionState = BleConnectionState.disconnected;
+    _scanTimer?.cancel();
+    _scanTimer = null;
     _notificationTimer?.cancel();
     _notificationTimer = null;
   }
@@ -155,7 +174,7 @@ class MockBlePlatform extends UniversalBlePlatform {
 
     _connectedDeviceId = deviceId;
     _connectionState = BleConnectionState.connecting;
-    await Future<void>.delayed(netDelay);
+    await Future<void>.delayed(slowConnect ? slowConnectDelay : netDelay);
     if (failConnect) {
       // A refused/failed attempt: no link, and no connection-change callback
       // — the client's connect() catch path is what tears its state down.
@@ -169,6 +188,7 @@ class MockBlePlatform extends UniversalBlePlatform {
 
   @override
   Future<void> disconnect(String deviceId) async {
+    disconnectCalls.add(deviceId);
     if (hangDisconnect) {
       // Never fire the connection-change callback: the link stays "connected"
       // here and the client's disconnect-timeout reconciliation tears it down.

--- a/lib/services/recording_controller.dart
+++ b/lib/services/recording_controller.dart
@@ -80,8 +80,9 @@ class RecordingController extends ChangeNotifier {
   /// so the first packet after a boundary isn't diffed against a stale counter.
   final AdcPacketDecoder _decoder;
 
-  bool _sessionInProgress = false;
-  bool get sessionInProgress => _sessionInProgress;
+  /// True while a session writer is latched. Derived (not stored) so the flag
+  /// can never disagree with the writer it describes.
+  bool get sessionInProgress => _sessionWriter != null;
 
   /// Link state at the previous [_onLinkChanged] notification; used to detect
   /// the not-streaming -> streaming edge (a new device stream starting).
@@ -109,7 +110,7 @@ class RecordingController extends ChangeNotifier {
     required List<bool> visibleChannels,
   }) async {
     assert(_linkManager.isStreaming);
-    if (_sessionInProgress) return null;
+    if (sessionInProgress) return null;
     // A tare is still averaging; recording now would persist a zero tare.
     if (_dataHub.taring) return const StartSessionTareInProgress();
 
@@ -128,7 +129,6 @@ class RecordingController extends ChangeNotifier {
 
     _sessionWriter = writer;
     _sessionName = sessionName;
-    _sessionInProgress = true;
     _decoder.resetContinuity();
     notifyListeners();
     return const StartSessionOk();
@@ -149,24 +149,21 @@ class RecordingController extends ChangeNotifier {
   /// [RecordingStorageError] on [AppEvents]); callers only use the returned
   /// error to branch (e.g. suppress the "Session saved" notice).
   Future<({int? sessionId, String? name, Object? error})> stopSession() async {
-    if (_sessionInProgress) {
-      _sessionInProgress = false;
-      final writer = _sessionWriter;
+    final writer = _sessionWriter;
+    if (writer != null) {
       final name = _sessionName;
       _sessionWriter = null;
       _sessionName = null;
       _decoder.resetContinuity();
       notifyListeners();
 
-      if (writer != null) {
-        // finalizeSession flushes through the writer's serialized queue, which
-        // drains any in-flight (unawaited) appends first.
-        final error = await SessionStorage.finalizeSession(writer: writer);
-        if (error != null) {
-          _events.emit(RecordingStorageError(error));
-        }
-        return (sessionId: writer.sessionId, name: name, error: error);
+      // finalizeSession flushes through the writer's serialized queue, which
+      // drains any in-flight (unawaited) appends first.
+      final error = await SessionStorage.finalizeSession(writer: writer);
+      if (error != null) {
+        _events.emit(RecordingStorageError(error));
       }
+      return (sessionId: writer.sessionId, name: name, error: error);
     }
     return (sessionId: null, name: null, error: null);
   }
@@ -177,7 +174,7 @@ class RecordingController extends ChangeNotifier {
   /// finalization re-detects the latched error and surfaces it).
   void _onSamplesAppended(int startIdx, int count) {
     final writer = _sessionWriter;
-    if (!_sessionInProgress || writer == null) {
+    if (writer == null) {
       return;
     }
     if (writer.hasError) {
@@ -192,7 +189,7 @@ class RecordingController extends ChangeNotifier {
   /// started stream resets the hub and packet continuity.
   void _onLinkChanged() {
     final bool streaming = _linkManager.isStreaming;
-    if (_sessionInProgress && !streaming) {
+    if (sessionInProgress && !streaming) {
       unawaited(stopSession());
     }
     if (streaming && !_wasStreaming) {

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -133,6 +133,12 @@ class SessionStorage {
   }
 
   /// Read a session's recorded data back from its chunks.
+  ///
+  /// TODO(perf): this materializes every chunk blob AND the full
+  /// deinterleaved channel arrays (~2x session size transiently — a 1-hour
+  /// session is ~58 MB of samples). If long sessions become common, stream
+  /// the deinterleave (and consider isolating the [SessionData] stats scan,
+  /// which currently runs eagerly on the UI thread below).
   static Future<SessionData?> loadSession(Session session) async {
     final chunks = await AppDatabase.instance.sessionChunkData(session.id);
 

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -46,7 +46,7 @@ class SessionStorage {
       visibleChannels: jsonEncode(visibleChannels),
     );
 
-    return LiveSessionWriter(sessionId, tare);
+    return LiveSessionWriter(sessionId, tare, DataHub.samplesPerSec);
   }
 
   /// Finalize a streaming session: flush any buffered samples, then record the
@@ -59,17 +59,36 @@ class SessionStorage {
   }) async {
     await writer.flush();
 
-    await AppDatabase.instance.completeSession(
-      writer.sessionId,
+    await _completeSession(
+      sessionId: writer.sessionId,
       sampleCount: writer.totalSamplesRecorded,
-      durationMs: (writer.totalSamplesRecorded * 1000) ~/ DataHub.samplesPerSec,
-      // A session that captured no samples leaves peakRaw at -infinity; that
-      // must not reach the DB (or the session list's peak display).
-      peakForceRaw: writer.peakRaw.isFinite ? writer.peakRaw : 0.0,
-      gaps: writer.gaps.toJson(),
+      sampleRate: writer.sampleRate,
+      peakRaw: writer.peakRaw,
+      gapsJson: writer.gaps.toJson(),
     );
 
     return writer.writeError;
+  }
+
+  /// Write a finished (or recovered) session's aggregates to its row and mark
+  /// it completed. Shared by [finalizeSession] and [recoverIncompleteSessions]
+  /// so both paths apply identical guards and duration math.
+  static Future<void> _completeSession({
+    required int sessionId,
+    required int sampleCount,
+    required int sampleRate,
+    required double peakRaw,
+    required String gapsJson,
+  }) {
+    return AppDatabase.instance.completeSession(
+      sessionId,
+      sampleCount: sampleCount,
+      durationMs: (sampleCount * 1000) ~/ sampleRate,
+      // A session that captured no samples leaves peakRaw at -infinity; that
+      // must not reach the DB (or the session list's peak display).
+      peakForceRaw: peakRaw.isFinite ? peakRaw : 0.0,
+      gaps: gapsJson,
+    );
   }
 
   /// Recovers any sessions left incomplete (e.g. the app crashed mid-recording)
@@ -99,12 +118,15 @@ class SessionStorage {
 
       // Preserve the gaps persisted incrementally by the live writer (chunk
       // bytes alone can't reconstruct them).
-      await AppDatabase.instance.completeSession(
-        session.id,
+      await _completeSession(
+        sessionId: session.id,
         sampleCount: agg.samples,
-        durationMs: (agg.samples * 1000) ~/ session.sampleRate,
-        peakForceRaw: agg.peakRaw,
-        gaps: session.gaps,
+        // Recovery uses the rate persisted on the row (finalize uses the
+        // writer's, which is the same value from recording start) so a future
+        // configurable rate can't skew reconstructed durations.
+        sampleRate: session.sampleRate,
+        peakRaw: agg.peakRaw,
+        gapsJson: session.gaps,
       );
     }
   }
@@ -361,7 +383,8 @@ class SessionData implements GraphDataSource {
 class LiveSessionWriter {
   LiveSessionWriter(
     this.sessionId,
-    this.tare, {
+    this.tare,
+    this.sampleRate, {
     @visibleForTesting
     Future<void> Function(
       int sessionId,
@@ -378,6 +401,10 @@ class LiveSessionWriter {
   /// in the session's `tares` column, so the peak computed here always matches
   /// what playback shows, regardless of later re-tares.
   final Float64List tare;
+
+  /// The rate persisted on the session row at recording start, kept here so
+  /// finalization math uses the same value the row carries.
+  final int sampleRate;
 
   int _chunkIndex = 0;
   int totalSamplesRecorded = 0;

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -11,9 +11,10 @@ import '../models/graph_data_source.dart';
 
 /// Chunk format: packed int32 LE values, interleaved
 /// `[ch0_s0, ch1_s0, ..., ch0_s1, ch1_s1, ...]`, with one value per ADC channel
-/// ([DataHub.numAdcChannels]) per sample. Each [SessionChunks] row holds a
-/// whole number of samples. The owning [Sessions] row carries all metadata
-/// (channel count, sample rate, calibration, etc.).
+/// ([DataHub.numAdcChannels]) per sample — see [SessionChunkCodec], the
+/// single implementation. Each [SessionChunks] row holds a whole number of
+/// samples. The owning [Sessions] row carries all metadata (channel count,
+/// sample rate, calibration, etc.).
 class SessionStorage {
   /// Start a new streaming session. The returned [LiveSessionWriter] is fed
   /// sample slices via [LiveSessionWriter.appendData] as data arrives and is
@@ -143,20 +144,18 @@ class SessionStorage {
     final channelCount = session.channelCount;
     final sampleCount = session.sampleCount;
     final channels = List.generate(channelCount, (_) => Int32List(sampleCount));
+    final codec = SessionChunkCodec(channelCount);
 
     int globalS = 0;
     for (final chunk in chunks) {
-      final data = ByteData.sublistView(chunk);
-      final chunkSamples = data.lengthInBytes ~/ (channelCount * 4);
-      int offset = 0;
-      for (int s = 0; s < chunkSamples; s++) {
-        if (globalS >= sampleCount) break;
-        for (int ch = 0; ch < channelCount; ch++) {
-          channels[ch][globalS] = data.getInt32(offset, Endian.little);
-          offset += 4;
-        }
-        globalS++;
-      }
+      // Frames beyond the metadata's sampleCount are silently truncated
+      // (chunk/metadata disagreement is not surfaced today).
+      codec.decode(chunk, (s, ch, raw) {
+        final g = globalS + s;
+        if (g < sampleCount) channels[ch][g] = raw;
+      });
+      globalS += codec.framesOf(chunk);
+      if (globalS >= sampleCount) break;
     }
 
     return SessionData(
@@ -229,20 +228,57 @@ class _ChunkAggregate {
   double peakRaw = double.negativeInfinity;
 
   void scan(Uint8List bytes, Float64List tare) {
-    final data = ByteData.sublistView(bytes);
-    final chunkSamples = data.lengthInBytes ~/ (channelCount * 4);
+    final codec = SessionChunkCodec(channelCount);
+    samples += codec.framesOf(bytes);
+    codec.decode(bytes, (_, ch, raw) {
+      final val = raw - (ch < tare.length ? tare[ch] : 0);
+      if (val > peakRaw) {
+        peakRaw = val.toDouble();
+      }
+    });
+  }
+}
+
+/// The one home of the packed chunk format: interleaved int32 LE values
+/// `[ch0_s0, ch1_s0, ..., ch0_s1, ch1_s1, ...]`, [channelCount] values per
+/// sample frame. Live writes ([LiveSessionWriter.appendData]), session loads
+/// ([SessionStorage.loadSession]) and aggregate scans ([_ChunkAggregate])
+/// share this so the layout, endianness and frame math can't drift apart.
+class SessionChunkCodec {
+  const SessionChunkCodec(this.channelCount);
+
+  final int channelCount;
+
+  /// Whole sample frames in [bytes] (trailing partial bytes are ignored).
+  int framesOf(Uint8List bytes) => bytes.lengthInBytes ~/ (channelCount * 4);
+
+  /// Pack [frames] samples, pulling each value from [valueAt].
+  Uint8List pack(int frames, int Function(int sample, int channel) valueAt) {
+    final out = ByteData(frames * channelCount * 4);
     int offset = 0;
-    for (int s = 0; s < chunkSamples; s++) {
+    for (int s = 0; s < frames; s++) {
       for (int ch = 0; ch < channelCount; ch++) {
-        final raw = data.getInt32(offset, Endian.little);
+        out.setInt32(offset, valueAt(s, ch), Endian.little);
         offset += 4;
-        final val = raw - (ch < tare.length ? tare[ch] : 0);
-        if (val > peakRaw) {
-          peakRaw = val.toDouble();
-        }
       }
     }
-    samples += chunkSamples;
+    return out.buffer.asUint8List();
+  }
+
+  /// Invoke [visit] once per value, in packed order (sample-major).
+  void decode(
+    Uint8List bytes,
+    void Function(int sample, int channel, int raw) visit,
+  ) {
+    final data = ByteData.sublistView(bytes);
+    final frames = framesOf(bytes);
+    int offset = 0;
+    for (int s = 0; s < frames; s++) {
+      for (int ch = 0; ch < channelCount; ch++) {
+        visit(s, ch, data.getInt32(offset, Endian.little));
+        offset += 4;
+      }
+    }
   }
 }
 
@@ -275,13 +311,14 @@ class SessionData implements GraphDataSource {
   /// so the graphs can downsample cheaply. Gap samples hold the previous
   /// real value, so buckets are always fully populated and need no
   /// missing-data handling.
-  final int bucketSize = 100;
+  final int bucketSize = kBucketSize;
   late final List<BucketAccumulator> valueBuckets;
 
   /// Per-channel bucket aggregates of the first-difference series
   /// (`diff[i] = raw[i] - raw[i-1]`), same bucket grid. Used by the
   /// derivative graph's bucket fast path; the gap/first-sample diff rule
-  /// lives in [ingestDiff], mirroring DataHub's live ingest.
+  /// lives in [ingestDiff], applied through the same [ChannelIngest] the
+  /// live hub uses.
   late final List<BucketAccumulator> diffBuckets;
 
   SessionData({
@@ -310,21 +347,17 @@ class SessionData implements GraphDataSource {
       if (sampleCount == 0) continue;
       double mn = double.infinity;
       double mx = double.negativeInfinity;
+      final ingest = ChannelIngest(
+        valueBuckets: valueBuckets[ch],
+        diffBuckets: diffBuckets[ch],
+        gaps: this.gaps,
+      );
 
       for (int i = 0; i < sampleCount; i++) {
         final v = channels[ch][i];
         if (v < mn) mn = v.toDouble();
         if (v > mx) mx = v.toDouble();
-
-        final int diff = ingestDiff(
-          sampleIndex: i,
-          value: v,
-          prevValue: i > 0 ? channels[ch][i - 1] : 0,
-          gaps: this.gaps,
-        );
-
-        valueBuckets[ch].add(i, v);
-        diffBuckets[ch].add(i, diff);
+        ingest.add(i, v, i > 0 ? channels[ch][i - 1] : 0);
       }
       mins[ch] = mn;
       maxs[ch] = mx;
@@ -467,20 +500,11 @@ class LiveSessionWriter {
     }
 
     // Snapshot the sample slice before enqueueing.
-    const numLines = DataHub.numAdcChannels;
-    final buffer = ByteData(count * numLines * 4);
-    int offset = 0;
-    for (int s = startIdx; s < startIdx + count; s++) {
-      for (int ch = 0; ch < numLines; ch++) {
-        buffer.setInt32(
-          offset,
-          dataHub.rawData[ch][s % DataHub.maxDataSz],
-          Endian.little,
-        );
-        offset += 4;
-      }
-    }
-    final bytes = buffer.buffer.asUint8List();
+    const codec = SessionChunkCodec(DataHub.numAdcChannels);
+    final bytes = codec.pack(
+      count,
+      (s, ch) => dataHub.rawData[ch][(startIdx + s) % DataHub.maxDataSz],
+    );
 
     return _enqueue(() async {
       if (writeError != null) return;

--- a/lib/utils/log.dart
+++ b/lib/utils/log.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/foundation.dart';
+
+/// High-frequency diagnostic logging (packet-rate paths). Stripped in
+/// release/profile builds, where per-packet [debugPrint] would throttle the
+/// band and spam end-user consoles. The message is built lazily (only in
+/// debug), so call sites pay nothing in release — wrap interpolation in the
+/// closure: `logTrace(() => 'lost $diff samples')`.
+void logTrace(String Function() message) {
+  if (kDebugMode) debugPrint(message());
+}

--- a/lib/widgets/bt_icon.dart
+++ b/lib/widgets/bt_icon.dart
@@ -6,6 +6,98 @@ import 'package:universal_ble/universal_ble.dart' show AvailabilityState;
 import '../services/ble_link_manager.dart' show BtLinkState;
 import 'status_colors.dart';
 
+/// Everything the [BluetoothIndicator] displays, resolved from link/adapter/
+/// scan state by [btStatusVisual] (a pure, context-free function — the
+/// mapping is unit-tested; colors are supplied from the theme).
+typedef BtStatusVisual = ({
+  IconData icon,
+  Color color,
+  String label,
+  bool showSpinner,
+});
+
+/// Map the link/adapter/scan state to the indicator visual. Link states
+/// outrank scan status, which outranks adapter status. [status]/[colors]
+/// carry the theme's semantic + scheme colors.
+BtStatusVisual btStatusVisual({
+  required BtLinkState linkState,
+  required AvailabilityState availability,
+  required bool isScanning,
+  required bool hasDevices,
+  required StatusColors status,
+  required ColorScheme colors,
+}) {
+  final active = status.linkActive;
+  final connected = status.linkConnected;
+
+  (IconData, Color, String) resolve() {
+    switch (linkState) {
+      case BtLinkState.disconnecting:
+        return (Icons.bluetooth_searching, active, 'Disconnecting…');
+      case BtLinkState.cooldown:
+        // Web: the link has torn down but the stack isn't ready to reconnect
+        // yet. Connect stays disabled through this settle window.
+        return (Icons.bluetooth_searching, active, 'Almost ready…');
+      case BtLinkState.streaming:
+        return (Icons.bluetooth_connected, connected, 'Connected');
+      case BtLinkState.connected:
+        // GATT link is up but service discovery / ADC subscription is still
+        // in progress. Not usable yet.
+        return (Icons.bluetooth_searching, active, 'Setting up…');
+      case BtLinkState.connecting:
+        return (Icons.bluetooth_searching, active, 'Connecting…');
+      case BtLinkState.idle:
+        break; // Fall through to scan / adapter status.
+    }
+    if (isScanning) {
+      // On web the device list lives in the browser's own picker popup, not
+      // in our list, so we tell the user to choose there.
+      return (
+        Icons.bluetooth_searching,
+        active,
+        kIsWeb ? 'Choose a device…' : 'Scanning for devices…',
+      );
+    }
+    switch (availability) {
+      case AvailabilityState.poweredOn:
+        // A previously-discovered device can remain connectable after a scan
+        // stops, so surface that rather than implying a scan is required.
+        if (hasDevices) {
+          return (Icons.bluetooth, connected, 'Tap a device to connect');
+        }
+        // NOTE: availability is not reliably signalled on all platforms
+        // (e.g. web, or Bluetooth already off at launch), so we avoid
+        // claiming "ready" and just state the action the user can take.
+        return (Icons.bluetooth, connected, 'Tap Scan to find devices');
+      case AvailabilityState.poweredOff:
+        return (Icons.bluetooth_disabled, colors.outline, 'Bluetooth is off');
+      case AvailabilityState.unknown:
+        return (Icons.question_mark, colors.outline, 'Starting up Bluetooth…');
+      case AvailabilityState.resetting:
+        return (Icons.question_mark, active, 'Bluetooth resetting…');
+      case AvailabilityState.unsupported:
+        return (Icons.stop, colors.error, 'Bluetooth not supported');
+      case AvailabilityState.unauthorized:
+        return (Icons.stop, colors.tertiary, 'Bluetooth permission needed');
+      // ignore: unreachable_switch_default
+      default:
+        return (Icons.question_mark, colors.outline, 'Bluetooth unavailable');
+    }
+  }
+
+  final (icon, color, label) = resolve();
+  return (
+    icon: icon,
+    color: color,
+    label: label,
+    // Spinner while anything is in flight (scanning or a link transition);
+    // the steady "streaming" state gets the plain connected icon.
+    showSpinner:
+        isScanning ||
+        (linkState != BtLinkState.idle && linkState != BtLinkState.streaming),
+  );
+}
+
 /// Compact Bluetooth status readout (icon + hint text, with a spinner while
 /// anything is in flight). Driven directly by the per-device link state plus
 /// the global adapter availability and scan flag — no derived flags to keep
@@ -32,82 +124,22 @@ class BluetoothIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final status = Theme.of(context).extension<StatusColors>()!;
-    final active = status.linkActive;
-    final connected = status.linkConnected;
+    final visual = btStatusVisual(
+      linkState: linkState,
+      availability: state,
+      isScanning: isScanning,
+      hasDevices: hasDevices,
+      status: Theme.of(context).extension<StatusColors>()!,
+      colors: Theme.of(context).colorScheme,
+    );
 
-    (IconData, Color, String) indicator() {
-      // Link states first: any active link or transition outranks scan and
-      // adapter status.
-      switch (linkState) {
-        case BtLinkState.disconnecting:
-          return (Icons.bluetooth_searching, active, 'Disconnecting…');
-        case BtLinkState.cooldown:
-          // Web: the link has torn down but the stack isn't ready to reconnect
-          // yet. Connect stays disabled through this settle window.
-          return (Icons.bluetooth_searching, active, 'Almost ready…');
-        case BtLinkState.streaming:
-          return (Icons.bluetooth_connected, connected, 'Connected');
-        case BtLinkState.connected:
-          // GATT link is up but service discovery / ADC subscription is still
-          // in progress. Not usable yet.
-          return (Icons.bluetooth_searching, active, 'Setting up…');
-        case BtLinkState.connecting:
-          return (Icons.bluetooth_searching, active, 'Connecting…');
-        case BtLinkState.idle:
-          break; // Fall through to scan / adapter status.
-      }
-      if (isScanning) {
-        // On web the device list lives in the browser's own picker popup, not
-        // in our list, so we tell the user to choose there.
-        return (
-          Icons.bluetooth_searching,
-          active,
-          kIsWeb ? 'Choose a device…' : 'Scanning for devices…',
-        );
-      }
-      switch (state) {
-        case AvailabilityState.poweredOn:
-          // A previously-discovered device can remain connectable after a scan
-          // stops, so surface that rather than implying a scan is required.
-          if (hasDevices) {
-            return (Icons.bluetooth, connected, 'Tap a device to connect');
-          }
-          // NOTE: availability is not reliably signalled on all platforms
-          // (e.g. web, or Bluetooth already off at launch), so we avoid
-          // claiming "ready" and just state the action the user can take.
-          return (Icons.bluetooth, connected, 'Tap Scan to find devices');
-        case AvailabilityState.poweredOff:
-          return (Icons.bluetooth_disabled, cs.outline, 'Bluetooth is off');
-        case AvailabilityState.unknown:
-          return (Icons.question_mark, cs.outline, 'Starting up Bluetooth…');
-        case AvailabilityState.resetting:
-          return (Icons.question_mark, active, 'Bluetooth resetting…');
-        case AvailabilityState.unsupported:
-          return (Icons.stop, cs.error, 'Bluetooth not supported');
-        case AvailabilityState.unauthorized:
-          return (Icons.stop, cs.tertiary, 'Bluetooth permission needed');
-        // ignore: unreachable_switch_default
-        default:
-          return (Icons.question_mark, cs.outline, 'Bluetooth unavailable');
-      }
-    }
-
-    final (IconData icon, Color color, String label) = indicator();
     const double size = 32;
-    // Spinner while anything is in flight (scanning or a link transition);
-    // the steady "streaming" state gets the plain connected icon.
-    final bool showSpinner =
-        isScanning ||
-        (linkState != BtLinkState.idle && linkState != BtLinkState.streaming);
-
     final iconStack = Stack(
       clipBehavior: Clip.none,
       alignment: Alignment.center,
       children: [
-        Icon(icon, size: size, color: color),
-        if (showSpinner)
+        Icon(visual.icon, size: size, color: visual.color),
+        if (visual.showSpinner)
           const SizedBox(
             height: size,
             width: size,
@@ -121,11 +153,11 @@ class BluetoothIndicator extends StatelessWidget {
       children: [
         Flexible(
           child: Text(
-            label,
+            visual.label,
             textAlign: TextAlign.right,
-            style: Theme.of(
-              context,
-            ).textTheme.bodySmall?.copyWith(color: Colors.grey.shade600),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.outline,
+            ),
           ),
         ),
         const SizedBox(width: 8),

--- a/lib/widgets/channel_stats_table.dart
+++ b/lib/widgets/channel_stats_table.dart
@@ -31,14 +31,25 @@ class ChannelStatsRow {
 /// channel via [onToggleChannel]; the owner decides what the toggle means
 /// (live-tab setting, per-session visibility, ...).
 class ChannelStatsTable extends StatelessWidget {
-  const ChannelStatsTable({
+  ChannelStatsTable({
     super.key,
     required this.labels,
     required this.activeChannels,
     required this.onToggleChannel,
     required this.unit,
     required this.rows,
-  });
+  }) : assert(
+         _oneValuePerChannel(labels, activeChannels, rows),
+         'labels, activeChannels and every row must have the same length',
+       );
+
+  static bool _oneValuePerChannel(
+    List<String> labels,
+    List<bool> activeChannels,
+    List<ChannelStatsRow> rows,
+  ) =>
+      activeChannels.length == labels.length &&
+      rows.every((r) => r.values.length == labels.length);
 
   /// Display label per channel.
   final List<String> labels;
@@ -93,29 +104,25 @@ class ChannelStatsTable extends StatelessWidget {
                 children: [
                   const SizedBox.shrink(), // Empty top-left corner
                   for (int i = 0; i < channelCount; i++)
-                    MouseRegion(
-                      cursor: SystemMouseCursors.click,
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: () => onToggleChannel(i),
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            bottom: 4,
-                            left: 4,
-                            right: 4,
-                          ),
-                          child: Text(
-                            labels[i],
-                            textAlign: TextAlign.right,
-                            style: Theme.of(context).textTheme.labelSmall
-                                ?.copyWith(
-                                  color: activeChannels[i]
-                                      ? getChannelColor(i)
-                                      : staleColor.withValues(alpha: 0.5),
-                                ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
+                    _TappableChannelCell(
+                      onTap: () => onToggleChannel(i),
+                      child: Padding(
+                        padding: const EdgeInsets.only(
+                          bottom: 4,
+                          left: 4,
+                          right: 4,
+                        ),
+                        child: Text(
+                          labels[i],
+                          textAlign: TextAlign.right,
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(
+                                color: activeChannels[i]
+                                    ? getChannelColor(i)
+                                    : staleColor.withValues(alpha: 0.5),
+                              ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                     ),
@@ -128,23 +135,19 @@ class ChannelStatsTable extends StatelessWidget {
                 children: [
                   const SizedBox.shrink(),
                   for (int i = 0; i < channelCount; i++)
-                    MouseRegion(
-                      cursor: SystemMouseCursors.click,
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: () => onToggleChannel(i),
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            bottom: 8,
-                            left: 2,
-                            right: 2,
-                          ),
-                          child: Container(
-                            height: 3,
-                            color: activeChannels[i]
-                                ? getChannelColor(i)
-                                : staleColor.withValues(alpha: 0.3),
-                          ),
+                    _TappableChannelCell(
+                      onTap: () => onToggleChannel(i),
+                      child: Padding(
+                        padding: const EdgeInsets.only(
+                          bottom: 8,
+                          left: 2,
+                          right: 2,
+                        ),
+                        child: Container(
+                          height: 3,
+                          color: activeChannels[i]
+                              ? getChannelColor(i)
+                              : staleColor.withValues(alpha: 0.3),
                         ),
                       ),
                     ),
@@ -183,6 +186,28 @@ class ChannelStatsTable extends StatelessWidget {
   }
 }
 
+/// Shared tap-target wrapper for every channel cell (label, color bar, stat
+/// value): pointer cursor + opaque hit testing + the toggle callback, so the
+/// hit behavior can't drift between cell kinds.
+class _TappableChannelCell extends StatelessWidget {
+  const _TappableChannelCell({required this.onTap, required this.child});
+
+  final VoidCallback onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: child,
+      ),
+    );
+  }
+}
+
 class _TableCellValue extends StatelessWidget {
   const _TableCellValue({
     required this.value,
@@ -211,20 +236,16 @@ class _TableCellValue extends StatelessWidget {
         ? staleColor.withValues(alpha: 0.4)
         : (isStale ? staleColor : null);
 
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 1, horizontal: 1),
-          child: Text(
-            displayText,
-            textAlign: TextAlign.right,
-            style: textStyle?.copyWith(color: color),
-            maxLines: 1,
-            overflow: TextOverflow.visible,
-          ),
+    return _TappableChannelCell(
+      onTap: onTap ?? () {},
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 1, horizontal: 1),
+        child: Text(
+          displayText,
+          textAlign: TextAlign.right,
+          style: textStyle?.copyWith(color: color),
+          maxLines: 1,
+          overflow: TextOverflow.visible,
         ),
       ),
     );

--- a/lib/widgets/dialogs.dart
+++ b/lib/widgets/dialogs.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../services/database.dart';
+
 /// Shared dialog helpers: one text prompt and one delete confirmation, used by
 /// the live tab, the session list and the session detail screen.
 
@@ -73,4 +75,32 @@ Future<bool> showDeleteConfirm(
     ),
   );
   return confirmed ?? false;
+}
+
+/// The full rename-a-session flow: prompt pre-filled with the current name,
+/// then persist a non-empty result. No-op on cancel/empty input. Callers
+/// relying on reactive session streams need no further refresh.
+Future<void> renameSessionFlow(
+  BuildContext context, {
+  required int sessionId,
+  required String currentName,
+  String title = 'Rename session',
+}) async {
+  final newName = await showTextPrompt(
+    context,
+    title: title,
+    label: 'Session name',
+    initial: currentName,
+  );
+  if (newName != null && newName.isNotEmpty) {
+    await AppDatabase.instance.renameSession(sessionId, newName);
+  }
+}
+
+/// The full delete-a-session flow: confirm, then delete. Returns true when
+/// the session was deleted (so callers can e.g. pop a detail screen).
+Future<bool> deleteSessionFlow(BuildContext context, Session session) async {
+  if (!await showDeleteConfirm(context, what: session.name)) return false;
+  await AppDatabase.instance.deleteSession(session.id);
+  return true;
 }

--- a/lib/widgets/empty_placeholder.dart
+++ b/lib/widgets/empty_placeholder.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Shared empty-state placeholder: a large dim icon over a title and optional
+/// hint, with an optional action widget below (e.g. a Connect button). Used by
+/// the Devices, Sessions and Live tabs so empty states look identical.
+class EmptyPlaceholder extends StatelessWidget {
+  const EmptyPlaceholder({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.hint,
+    this.action,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? hint;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    final dim = Theme.of(context).colorScheme.outline;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 64, color: dim),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(color: dim),
+          ),
+          if (hint != null) ...[
+            const SizedBox(height: 8),
+            Text(hint!, style: TextStyle(color: dim)),
+          ],
+          if (action != null) ...[const SizedBox(height: 8), action!],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -1177,10 +1177,12 @@ class _InteractiveGraphAreaState extends State<InteractiveGraphArea> {
 
     if (details.scale != 1.0 && _scaleStartSpan != null) {
       // Pinch zoom, anchored to the gesture-start window so tracking stays
-      // stable while totalSamples grows.
+      // stable while totalSamples grows. The focal fraction is measured from
+      // the plot area's left edge (same convention as wheel zoom), not from
+      // the widget's left padding.
       widget.ctrl.zoomTo(
         (_scaleStartSpan! / details.scale).round(),
-        (_pinchFocalX! / graphWidth).clamp(0.0, 1.0),
+        ((_pinchFocalX! - kGraphLeftSpace) / graphWidth).clamp(0.0, 1.0),
         baseStart: origStart,
         baseSpan: origSpan,
         anchorLiveEdge: _wasLiveOnScaleStart,

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -1142,13 +1142,13 @@ class InteractiveGraphArea extends StatefulWidget {
 }
 
 class _InteractiveGraphAreaState extends State<InteractiveGraphArea> {
-  // Gesture tracking
-  double? _panStartX;
-  int? _panStartSample;
-  int? _panEndSample;
-  double? _scaleStartSpan;
-  double? _pinchFocalX;
-  bool _wasLiveOnScaleStart = false;
+  /// One in-flight scale (pan/pinch) gesture. Everything is captured together
+  /// at gesture start, so a single nullable session — instead of one nullable
+  /// per field — makes partial gesture states unrepresentable. [focalX] is
+  /// the gesture-start focal point (both pan origin and pinch anchor);
+  /// [startSample]/[span] are the gesture-start window; [wasLive] is whether
+  /// the viewport followed the live edge at gesture start.
+  ({double focalX, int startSample, int span, bool wasLive})? _session;
 
   void _onScaleStart(ScaleStartDetails details) {
     final total = widget.data.totalSamples;
@@ -1159,44 +1159,43 @@ class _InteractiveGraphAreaState extends State<InteractiveGraphArea> {
       widget.data.oldestSample,
       bufferCapacity: widget.data.bufferCapacity,
     );
-    _panStartSample = s;
-    _panEndSample = e;
-    _panStartX = details.localFocalPoint.dx;
-    _scaleStartSpan = (e - s).toDouble();
-    _pinchFocalX = details.localFocalPoint.dx;
-    _wasLiveOnScaleStart = widget.ctrl.isLive;
+    _session = (
+      focalX: details.localFocalPoint.dx,
+      startSample: s,
+      span: e - s,
+      wasLive: widget.ctrl.isLive,
+    );
   }
 
   void _onScaleUpdate(ScaleUpdateDetails details, double graphWidth) {
     final total = widget.data.totalSamples;
-    if (total == 0 || _panStartSample == null || graphWidth <= 0) return;
+    final session = _session;
+    if (total == 0 || session == null || graphWidth <= 0) return;
 
-    final origStart = _panStartSample!;
-    final origSpan = _panEndSample! - origStart;
     final oldestSample = widget.data.oldestSample;
 
-    if (details.scale != 1.0 && _scaleStartSpan != null) {
+    if (details.scale != 1.0) {
       // Pinch zoom, anchored to the gesture-start window so tracking stays
       // stable while totalSamples grows. The focal fraction is measured from
       // the plot area's left edge (same convention as wheel zoom), not from
       // the widget's left padding.
       widget.ctrl.zoomTo(
-        (_scaleStartSpan! / details.scale).round(),
-        ((_pinchFocalX! - kGraphLeftSpace) / graphWidth).clamp(0.0, 1.0),
-        baseStart: origStart,
-        baseSpan: origSpan,
-        anchorLiveEdge: _wasLiveOnScaleStart,
+        (session.span / details.scale).round(),
+        ((session.focalX - kGraphLeftSpace) / graphWidth).clamp(0.0, 1.0),
+        baseStart: session.startSample,
+        baseSpan: session.span,
+        anchorLiveEdge: session.wasLive,
         totalSamples: total,
         oldestSample: oldestSample,
       );
     } else {
       // Pan by the horizontal drag distance, relative to the gesture-start
       // window.
-      final dx = details.localFocalPoint.dx - _panStartX!;
-      final deltaSamples = -(dx * origSpan / graphWidth).round();
+      final dx = details.localFocalPoint.dx - session.focalX;
+      final deltaSamples = -(dx * session.span / graphWidth).round();
       widget.ctrl.applyWindow(
-        origStart + deltaSamples,
-        origSpan,
+        session.startSample + deltaSamples,
+        session.span,
         total,
         oldestSample,
       );

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -18,14 +18,14 @@ import '../models/graph_data_source.dart';
 // ---------------------------------------------------------------------------
 
 /// Horizontal/vertical padding shared by the graph painters and the gesture
-/// areas. [kGraphRightSpace] reserves room for the Y-axis labels.
-const double kGraphLeftSpace = 8;
-const double kGraphRightSpace = 56;
-const double kGraphBottomSpace = 24;
+/// areas. [_kGraphRightSpace] reserves room for the Y-axis labels.
+const double _kGraphLeftSpace = 8;
+const double _kGraphRightSpace = 56;
+const double _kGraphBottomSpace = 24;
 
 /// Width available for plotting given a full widget [totalWidth].
-double graphPlotWidth(double totalWidth) =>
-    totalWidth - kGraphLeftSpace - kGraphRightSpace;
+double _graphPlotWidth(double totalWidth) =>
+    totalWidth - _kGraphLeftSpace - _kGraphRightSpace;
 
 /// Record [draw] and synchronously rasterize it into a [widthPx] x [heightPx]
 /// physical-pixel [ui.Image]. The canvas is pre-scaled by [dpr] so [draw]
@@ -34,7 +34,7 @@ double graphPlotWidth(double totalWidth) =>
 /// This is the only place a [ui.Picture] appears in this file: `toImageSync`
 /// requires one as an intermediate, so it is created and disposed here and
 /// only the image escapes.
-ui.Image bakeImage(
+ui.Image _bakeImage(
   int widthPx,
   int heightPx,
   double dpr,
@@ -112,6 +112,22 @@ const double kSegmentImagePad = 4;
 typedef SegmentRenderer =
     double Function(Canvas canvas, int start, int end, int texW);
 
+/// Everything one (re)bake needs, computed once per
+/// [SegmentedGraphCache.paint] call.
+typedef _BakeEnv = ({
+  double pps,
+  double gh,
+  int viewStart,
+  int viewEnd,
+  double yMin,
+  double yMax,
+  int totalSamples,
+  int targetSpan,
+  double hPad,
+  double vPad,
+  SegmentRenderer render,
+});
+
 /// One baked segment: an immutable vector render of samples [start, end)
 /// plus the mapping it was baked under. Never mutated and never re-blitted
 /// into another texture (so resampling loss cannot compound); replaced by a
@@ -179,8 +195,10 @@ class SegmentedGraphCache {
   /// and vector-draw uncovered gaps up to [maxDirectGapPx] wide (wider gaps
   /// stay blank until the rolling bakes cover them).
   ///
-  /// Returns true when bake work remains; the owner should then schedule
-  /// another frame (static sources never fire repaint on their own).
+  /// Returns true when a bake happened this frame; the owner should then
+  /// schedule another frame so rolling bakes continue (one extra frame may
+  /// be scheduled after the final bake — static sources never fire repaint
+  /// on their own).
   bool paint(
     Canvas canvas, {
     required List<Object?> configKey,
@@ -209,6 +227,19 @@ class SegmentedGraphCache {
     final double pps = gw / viewSpan; // logical px per sample
     final int viewEnd = viewStart + viewSpan;
     final int targetSpan = math.max(1, (kSegmentTargetPx / pps).round());
+    final env = (
+      pps: pps,
+      gh: gh,
+      viewStart: viewStart,
+      viewEnd: viewEnd,
+      yMin: yMin,
+      yMax: yMax,
+      totalSamples: totalSamples,
+      targetSpan: targetSpan,
+      hPad: hPad,
+      vPad: vPad,
+      render: render,
+    );
 
     // Evict segments far outside the view.
     final int margin = kSegmentEvictionMargin * targetSpan;
@@ -222,19 +253,7 @@ class SegmentedGraphCache {
 
     bool baked = false;
     for (int i = 0; i < kSegmentBakeBudget; i++) {
-      if (!_bakeOne(
-        pps,
-        gh,
-        viewStart,
-        viewEnd,
-        yMin,
-        yMax,
-        totalSamples,
-        targetSpan,
-        hPad,
-        vPad,
-        render,
-      )) {
+      if (!_bakeOne(env)) {
         break;
       }
       baked = true;
@@ -279,58 +298,50 @@ class SegmentedGraphCache {
   ///      (rolling refresh, merging undersized neighbors and splitting
   ///      oversized ranges).
   /// Returns whether a bake happened.
-  bool _bakeOne(
-    double pps,
-    double gh,
-    int viewStart,
-    int viewEnd,
-    double yMin,
-    double yMax,
-    int totalSamples,
-    int targetSpan,
-    double hPad,
-    double vPad,
-    SegmentRenderer render,
-  ) {
-    // --- Priority 1: widest gap past the bake threshold -------------------
+  bool _bakeOne(_BakeEnv env) =>
+      _bakeWidestGap(env) || _refreshStalestSegment(env);
+
+  /// Priority 1: bake the widest uncovered gap past the threshold. Left
+  /// neighbors are absorbed while the merged bake stays within one target
+  /// width, so the live-edge segment grows in place (one bake per sliver)
+  /// instead of accumulating sliver-wide strips.
+  bool _bakeWidestGap(_BakeEnv env) {
     (int, int)? bakeGap;
     double widestPx = kSegmentGapBakePx;
-    for (final g in _gaps(viewStart, viewEnd, totalSamples)) {
-      final double w = (g.$2 - g.$1) * pps;
+    for (final g in _gaps(env.viewStart, env.viewEnd, env.totalSamples)) {
+      final double w = (g.$2 - g.$1) * env.pps;
       if (w > widestPx) {
         widestPx = w;
         bakeGap = g;
       }
     }
-    if (bakeGap != null) {
-      int start = bakeGap.$1;
-      final int end = math.min(bakeGap.$2, start + targetSpan);
-      if (end <= start) return false;
+    if (bakeGap == null) return false;
 
-      // Insertion point: first segment starting inside/after the gap.
-      int at = 0;
-      while (at < _segments.length && _segments[at].start < start) {
-        at++;
-      }
-      // Absorb left neighbors while the merged bake stays within one target
-      // width, so the live-edge segment grows in place (one bake per sliver)
-      // instead of accumulating sliver-wide strips.
-      while (at > 0 &&
-          (end - _segments[at - 1].start) * pps <= kSegmentTargetPx) {
-        at--;
-        start = _segments[at].start;
-        _segments[at].dispose();
-        _segments.removeAt(at);
-      }
+    int start = bakeGap.$1;
+    final int end = math.min(bakeGap.$2, start + env.targetSpan);
+    if (end <= start) return false;
 
-      _segments.insert(
-        at,
-        _bake(start, end, pps, gh, yMin, yMax, hPad, vPad, render),
-      );
-      return true;
+    // Insertion point: first segment starting inside/after the gap.
+    int at = 0;
+    while (at < _segments.length && _segments[at].start < start) {
+      at++;
+    }
+    while (at > 0 &&
+        (end - _segments[at - 1].start) * env.pps <= kSegmentTargetPx) {
+      at--;
+      start = _segments[at].start;
+      _segments[at].dispose();
+      _segments.removeAt(at);
     }
 
-    // --- Priority 2: staleness refresh -------------------------------------
+    _segments.insert(at, _bake(start, end, env));
+    return true;
+  }
+
+  /// Priority 2: refresh the visible segment furthest past its drift/size
+  /// thresholds, merging undersized neighbors and splitting oversized ranges
+  /// (see [_refreshRange]).
+  bool _refreshStalestSegment(_BakeEnv env) {
     // Score each visible segment; > 1.0 means past a threshold. Under
     // uniform squeeze all segments drift together, so picking the worst
     // (first on ties) degenerates into a round-robin.
@@ -338,10 +349,10 @@ class SegmentedGraphCache {
     double worstScore = 1.0;
     for (int i = 0; i < _segments.length; i++) {
       final s = _segments[i];
-      if (s.end <= viewStart || s.start >= viewEnd) continue;
-      final double w = (s.end - s.start) * pps;
+      if (s.end <= env.viewStart || s.start >= env.viewEnd) continue;
+      final double w = (s.end - s.start) * env.pps;
       final double xScale = w / s.contentW;
-      final double yScale = (s.yMax - s.yMin) / (yMax - yMin);
+      final double yScale = (s.yMax - s.yMin) / (env.yMax - env.yMin);
       double score =
           math.max((1 - xScale).abs(), (1 - yScale).abs()) / kMaxSegmentDrift;
       // Oversized (zoom-in stretched it): refresh-with-split.
@@ -358,75 +369,71 @@ class SegmentedGraphCache {
     }
     if (worst < 0) return false;
 
-    final s = _segments[worst];
+    final range = _refreshRange(worst, env);
+    if (range.end <= range.start) return false;
+
+    final seg = _bake(range.start, range.end, env);
+    _splice(worst, range.removeTo, seg);
+    return true;
+  }
+
+  /// The (re)bake range for refreshing segment [i], plus the inclusive last
+  /// segment index it replaces: merge right neighbors while the result stays
+  /// under 1.5 targets (never merging across a gap); when still undersized,
+  /// extend into the oversized right neighbor (the overlap is clipped at
+  /// blit time in this segment's favor, and fully-covered neighbors are
+  /// replaced outright); when oversized, clamp to one target width (the
+  /// remainder becomes a gap that refills over the following frames).
+  ({int start, int end, int removeTo}) _refreshRange(int i, _BakeEnv env) {
+    final s = _segments[i];
     final int newStart = s.start;
     int newEnd = s.end;
-    int removeTo = worst;
+    int removeTo = i;
     // Merge right neighbors while the result stays under 1.5 targets.
     while (removeTo + 1 < _segments.length) {
       final n = _segments[removeTo + 1];
       if (n.start > newEnd) break; // never merge across a gap
-      if ((n.end - newStart) * pps > 1.5 * kSegmentTargetPx) break;
+      if ((n.end - newStart) * env.pps > 1.5 * kSegmentTargetPx) break;
       newEnd = math.max(newEnd, n.end);
       removeTo++;
     }
-    if ((newEnd - newStart) * pps < kSegmentTargetPx / 2) {
+    if ((newEnd - newStart) * env.pps < kSegmentTargetPx / 2) {
       // Still undersized (right neighbor too big to swallow whole): extend
-      // into it; the overlap is clipped at blit time in this segment's
-      // favor, and fully-covered neighbors are replaced outright.
-      newEnd = math.min(totalSamples, newStart + targetSpan);
+      // into it.
+      newEnd = math.min(env.totalSamples, newStart + env.targetSpan);
       while (removeTo + 1 < _segments.length &&
           _segments[removeTo + 1].end <= newEnd) {
         removeTo++;
       }
     }
-    if ((newEnd - newStart) * pps > 2 * kSegmentTargetPx) {
-      // Oversized: bake only the leading target-width range; the remainder
-      // becomes a gap that fills in over the following frames.
-      newEnd = newStart + targetSpan;
+    if ((newEnd - newStart) * env.pps > 2 * kSegmentTargetPx) {
+      // Oversized: bake only the leading target-width range.
+      newEnd = newStart + env.targetSpan;
     }
-    if (newEnd <= newStart) return false;
+    return (start: newStart, end: newEnd, removeTo: removeTo);
+  }
 
-    final seg = _bake(
-      newStart,
-      newEnd,
-      pps,
-      gh,
-      yMin,
-      yMax,
-      hPad,
-      vPad,
-      render,
-    );
-    for (int k = worst; k <= removeTo; k++) {
+  /// Replace segments [from..to] (inclusive) with [seg], disposing the
+  /// replaced ones.
+  void _splice(int from, int to, GraphSegment seg) {
+    for (int k = from; k <= to; k++) {
       _segments[k].dispose();
     }
-    _segments.replaceRange(worst, removeTo + 1, [seg]);
-    return true;
+    _segments.replaceRange(from, to + 1, [seg]);
   }
 
   /// Vector-render samples [start, end) into a fresh texture sized to the
   /// range's current on-screen width, so its blit starts at scale ~1.
-  GraphSegment _bake(
-    int start,
-    int end,
-    double pps,
-    double gh,
-    double yMin,
-    double yMax,
-    double hPad,
-    double vPad,
-    SegmentRenderer render,
-  ) {
-    final int texW = math.max(1, ((end - start) * pps).ceil());
+  GraphSegment _bake(int start, int end, _BakeEnv env) {
+    final int texW = math.max(1, ((end - start) * env.pps).ceil());
     double contentW = texW.toDouble();
-    final img = bakeImage(
-      ((texW + 2 * hPad) * _dpr).ceil(),
-      ((gh + 2 * vPad) * _dpr).ceil(),
+    final img = _bakeImage(
+      ((texW + 2 * env.hPad) * _dpr).ceil(),
+      ((env.gh + 2 * env.vPad) * _dpr).ceil(),
       _dpr,
       (c) {
-        c.translate(hPad, vPad);
-        contentW = render(c, start, end, texW);
+        c.translate(env.hPad, env.vPad);
+        contentW = env.render(c, start, end, texW);
       },
     );
     return GraphSegment(
@@ -434,10 +441,10 @@ class SegmentedGraphCache {
       start: start,
       end: end,
       contentW: math.max(contentW, 0.001),
-      yMin: yMin,
-      yMax: yMax,
-      hPad: hPad,
-      vPad: vPad,
+      yMin: env.yMin,
+      yMax: env.yMax,
+      hPad: env.hPad,
+      vPad: env.vPad,
     );
   }
 
@@ -538,7 +545,7 @@ class SegmentedGraphCache {
 /// One block becomes one min/avg/max reduction and one polyline vertex. When
 /// zoomed in past 1 sample/pixel this clamps to 1 (one block per sample). The
 /// last block in a range is allowed to be short.
-int blockSizeFor(int viewSamples, double graphW) {
+int _blockSizeFor(int viewSamples, double graphW) {
   assert(graphW > 0); // callers only paint into non-degenerate plot areas
   // floor => >= 1 sample/block, so the polyline never has more vertices than
   // pixels. The remainder (viewSamples % blockSize) lands in the short final block.
@@ -809,7 +816,7 @@ void _handleGraphPointerScroll(
   final totalSamples = data.totalSamples;
   if (totalSamples == 0 || graphWidth <= 0) return;
 
-  final focalFrac = ((event.localPosition.dx - kGraphLeftSpace) / graphWidth)
+  final focalFrac = ((event.localPosition.dx - _kGraphLeftSpace) / graphWidth)
       .clamp(0.0, 1.0);
   final zoomFactor = event.scrollDelta.dy < 0 ? 1.2 : 1 / 1.2;
   ctrl.zoom(
@@ -831,7 +838,7 @@ void _handleGraphPointerScroll(
 /// Needed for static sources (loaded sessions) whose [GraphDataSource.repaint]
 /// never fires; harmless for live ones. Owned and disposed by the host
 /// widget's State.
-class BakePump implements Listenable {
+class _BakePump implements Listenable {
   final ValueNotifier<int> _notifier = ValueNotifier<int>(0);
   bool _scheduled = false;
   bool _disposed = false;
@@ -865,10 +872,10 @@ class BakePump implements Listenable {
 
 /// Span of samples the minimap squeezes into its width: all available data,
 /// clamped below by the controller's minimum live span.
-int minimapSpan(int totalSamples, int oldestSample, int minLiveSpan) =>
+int _minimapSpan(int totalSamples, int oldestSample, int minLiveSpan) =>
     math.max(totalSamples - oldestSample, minLiveSpan);
 
-class Minimap extends StatefulWidget {
+class _Minimap extends StatefulWidget {
   final GraphDataSource dataSource;
   final AppSettings settings;
   final GraphController graphCtrl;
@@ -876,8 +883,7 @@ class Minimap extends StatefulWidget {
   /// Indices of the channels to plot (per-view; see [GraphWorkspace]).
   final List<int> activeChannels;
 
-  const Minimap({
-    super.key,
+  const _Minimap({
     required this.dataSource,
     required this.settings,
     required this.graphCtrl,
@@ -885,12 +891,12 @@ class Minimap extends StatefulWidget {
   });
 
   @override
-  State<Minimap> createState() => _MinimapState();
+  State<_Minimap> createState() => _MinimapState();
 }
 
-class _MinimapState extends State<Minimap> {
+class _MinimapState extends State<_Minimap> {
   final SegmentedGraphCache _cache = SegmentedGraphCache();
-  final BakePump _bakePump = BakePump();
+  final _BakePump _bakePump = _BakePump();
 
   @override
   void dispose() {
@@ -903,11 +909,11 @@ class _MinimapState extends State<Minimap> {
     final totalSamples = widget.dataSource.totalSamples;
     if (totalSamples == 0 || graphWidth <= 0) return;
     final oldestSample = widget.dataSource.oldestSample;
-    final frac = ((d.localPosition.dx - kGraphLeftSpace) / graphWidth).clamp(
+    final frac = ((d.localPosition.dx - _kGraphLeftSpace) / graphWidth).clamp(
       0.0,
       1.0,
     );
-    final mapSpan = minimapSpan(
+    final mapSpan = _minimapSpan(
       totalSamples,
       oldestSample,
       widget.graphCtrl.minLiveSpan,
@@ -926,7 +932,7 @@ class _MinimapState extends State<Minimap> {
     if (totalSamples == 0 || graphWidth <= 0) return;
     final oldestSample = widget.dataSource.oldestSample;
     final samplesPerPixel =
-        minimapSpan(totalSamples, oldestSample, widget.graphCtrl.minLiveSpan) /
+        _minimapSpan(totalSamples, oldestSample, widget.graphCtrl.minLiveSpan) /
         graphWidth;
     widget.graphCtrl.pan(
       (d.delta.dx * samplesPerPixel).round(),
@@ -942,7 +948,7 @@ class _MinimapState extends State<Minimap> {
     final dpr = MediaQuery.devicePixelRatioOf(context);
     return LayoutBuilder(
       builder: (context, constraints) {
-        final graphWidth = graphPlotWidth(constraints.maxWidth);
+        final graphWidth = _graphPlotWidth(constraints.maxWidth);
         return SizedBox(
           height: 32,
           child: Listener(
@@ -967,7 +973,6 @@ class _MinimapState extends State<Minimap> {
                   dpr,
                   _cache,
                   _bakePump,
-                  _bakePump.schedule,
                 ),
                 size: Size.infinite,
               ),
@@ -988,10 +993,11 @@ class _MinimapPainter extends CustomPainter {
   final double _dpr;
   final SegmentedGraphCache _cache;
 
-  /// Asks the host widget to schedule another frame; called when bake work
-  /// remains (rolling bootstrap / staleness passes) so it completes even for
-  /// static sources whose [GraphDataSource.repaint] never fires.
-  final VoidCallback _requestRepaint;
+  /// Drives the rolling segment bakes: a repaint listenable for this painter
+  /// and the scheduler for extra frames when bake work remains (rolling
+  /// bootstrap / staleness passes must complete even for static sources
+  /// whose [GraphDataSource.repaint] never fires).
+  final _BakePump _bakePump;
 
   _MinimapPainter(
     this._data,
@@ -1001,16 +1007,15 @@ class _MinimapPainter extends CustomPainter {
     this._colorScheme,
     this._dpr,
     this._cache,
-    Listenable bakePump,
-    this._requestRepaint,
-  ) : super(repaint: Listenable.merge([_data.repaint, _ctrl, bakePump]));
+    this._bakePump,
+  ) : super(repaint: Listenable.merge([_data.repaint, _ctrl, _bakePump]));
 
   @override
   void paint(Canvas canvas, Size size) {
     const double vPad = 2;
 
-    canvas.translate(kGraphLeftSpace, vPad);
-    final gw = size.width - kGraphLeftSpace - kGraphRightSpace;
+    canvas.translate(_kGraphLeftSpace, vPad);
+    final gw = size.width - _kGraphLeftSpace - _kGraphRightSpace;
     final gh = size.height - vPad * 2;
 
     if (gw <= 0 || gh <= 0) return;
@@ -1023,7 +1028,7 @@ class _MinimapPainter extends CustomPainter {
     if (totalSamples == 0) return;
 
     final oldestSample = _data.oldestSample;
-    final mapSpan = minimapSpan(totalSamples, oldestSample, _ctrl.minLiveSpan);
+    final mapSpan = _minimapSpan(totalSamples, oldestSample, _ctrl.minLiveSpan);
     final mapStart = totalSamples - mapSpan;
 
     final activeIndices = _activeChannels;
@@ -1054,7 +1059,7 @@ class _MinimapPainter extends CustomPainter {
 
     // Missing-data hatching, behind the data lines (same layering as the
     // main graphs).
-    drawMissingDataHatching(
+    _drawMissingDataHatching(
       canvas,
       Size(gw, gh),
       viewStart: mapStart,
@@ -1068,12 +1073,12 @@ class _MinimapPainter extends CustomPainter {
     // Segment-cached envelope data layer, shared with the main graphs. The
     // bucket-accelerated reduction keeps both segment bakes and direct gap
     // draws cheap even though every block spans many samples here.
-    final workRemains = paintEnvelopeDataLayer(
+    final workRemains = _paintEnvelopeDataLayer(
       canvas,
       cache: _cache,
       data: _data,
       activeChannels: activeIndices,
-      keyExtras: envelopeCacheKeyExtras(_data, tares, unit),
+      keyExtras: _envelopeCacheKeyExtras(_data, tares, unit),
       gw: gw,
       gh: gh,
       dpr: _dpr,
@@ -1082,11 +1087,11 @@ class _MinimapPainter extends CustomPainter {
       yMin: yMin,
       yMax: yMax,
       firstUsableSample: oldestSample,
-      seriesFor: (ch) => taredEnvelopeSeries(_data, ch, unit),
+      seriesFor: (ch) => _taredEnvelopeSeries(_data, ch, unit),
       avgStrokeWidth: 1.0,
       avgAlpha: 180,
     );
-    if (workRemains) _requestRepaint();
+    if (workRemains) _bakePump.schedule();
 
     // Viewport highlight
     final (viewStart, viewEnd) = _ctrl.effectiveRange(
@@ -1121,23 +1126,22 @@ class _MinimapPainter extends CustomPainter {
 // Interactive Graph Area (handles gestures)
 // ---------------------------------------------------------------------------
 
-class InteractiveGraphArea extends StatefulWidget {
+class _InteractiveGraphArea extends StatefulWidget {
   final GraphDataSource data;
   final GraphController ctrl;
   final Widget child;
 
-  const InteractiveGraphArea({
-    super.key,
+  const _InteractiveGraphArea({
     required this.data,
     required this.ctrl,
     required this.child,
   });
 
   @override
-  State<InteractiveGraphArea> createState() => _InteractiveGraphAreaState();
+  State<_InteractiveGraphArea> createState() => _InteractiveGraphAreaState();
 }
 
-class _InteractiveGraphAreaState extends State<InteractiveGraphArea> {
+class _InteractiveGraphAreaState extends State<_InteractiveGraphArea> {
   /// One in-flight scale (pan/pinch) gesture. Everything is captured together
   /// at gesture start, so a single nullable session — instead of one nullable
   /// per field — makes partial gesture states unrepresentable. [focalX] is
@@ -1177,7 +1181,7 @@ class _InteractiveGraphAreaState extends State<InteractiveGraphArea> {
       // the widget's left padding.
       widget.ctrl.zoomTo(
         (session.span / details.scale).round(),
-        ((session.focalX - kGraphLeftSpace) / graphWidth).clamp(0.0, 1.0),
+        ((session.focalX - _kGraphLeftSpace) / graphWidth).clamp(0.0, 1.0),
         baseStart: session.startSample,
         baseSpan: session.span,
         anchorLiveEdge: session.wasLive,
@@ -1202,7 +1206,7 @@ class _InteractiveGraphAreaState extends State<InteractiveGraphArea> {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final graphWidth = graphPlotWidth(constraints.maxWidth);
+        final graphWidth = _graphPlotWidth(constraints.maxWidth);
         return Listener(
           behavior: HitTestBehavior.opaque,
           onPointerSignal: (e) => _handleGraphPointerScroll(
@@ -1237,7 +1241,6 @@ class GraphWorkspace extends StatefulWidget {
   final List<int> activeChannels;
   final bool showDerivative;
   final bool isLiveGraph;
-  final bool showZoomSpan;
 
   const GraphWorkspace({
     super.key,
@@ -1247,7 +1250,6 @@ class GraphWorkspace extends StatefulWidget {
     required this.activeChannels,
     this.showDerivative = false,
     this.isLiveGraph = true,
-    this.showZoomSpan = true,
   });
 
   @override
@@ -1256,15 +1258,18 @@ class GraphWorkspace extends StatefulWidget {
 
 class _GraphWorkspaceState extends State<GraphWorkspace> {
   final SegmentedGraphCache _forceCache = SegmentedGraphCache();
-  final SegmentedGraphCache _derivCache = SegmentedGraphCache();
-  final BakePump _bakePump = BakePump();
-  final LabelCache _labelCache = LabelCache();
+
+  /// Allocated on first use: session playback (showDerivative: false
+  /// forever) never pays for it.
+  SegmentedGraphCache? _derivCache;
+  final _BakePump _bakePump = _BakePump();
+  final _LabelCache _labelCache = _LabelCache();
 
   @override
   void dispose() {
     _bakePump.dispose();
     _forceCache.dispose();
-    _derivCache.dispose();
+    _derivCache?.dispose();
     _labelCache.dispose();
     super.dispose();
   }
@@ -1295,24 +1300,20 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                 // Main force graph
                 Expanded(
                   flex: widget.showDerivative ? 6 : 10,
-                  child: InteractiveGraphArea(
+                  child: _GraphPane(
                     data: widget.data,
                     ctrl: widget.ctrl,
-                    child: CustomPaint(
-                      foregroundPainter: ForceGraphPainter(
-                        widget.data,
-                        widget.settings,
-                        widget.ctrl,
-                        activeChannels: widget.activeChannels,
-                        showXLabels: !widget.showDerivative,
-                        cache: _forceCache,
-                        colorScheme: colorScheme,
-                        dpr: dpr,
-                        labels: _labelCache,
-                        bakePump: _bakePump,
-                        requestRepaint: _bakePump.schedule,
-                      ),
-                      size: Size.infinite,
+                    painter: _ForceGraphPainter(
+                      widget.data,
+                      widget.settings,
+                      widget.ctrl,
+                      activeChannels: widget.activeChannels,
+                      showXLabels: !widget.showDerivative,
+                      cache: _forceCache,
+                      colorScheme: colorScheme,
+                      dpr: dpr,
+                      labels: _labelCache,
+                      bakePump: _bakePump,
                     ),
                   ),
                 ),
@@ -1320,28 +1321,24 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
                 if (widget.showDerivative)
                   Expanded(
                     flex: 4,
-                    child: InteractiveGraphArea(
+                    child: _GraphPane(
                       data: widget.data,
                       ctrl: widget.ctrl,
-                      child: CustomPaint(
-                        foregroundPainter: DerivativeGraphPainter(
-                          widget.data,
-                          widget.settings,
-                          widget.ctrl,
-                          activeChannels: widget.activeChannels,
-                          cache: _derivCache,
-                          colorScheme: colorScheme,
-                          dpr: dpr,
-                          labels: _labelCache,
-                          bakePump: _bakePump,
-                          requestRepaint: _bakePump.schedule,
-                        ),
-                        size: Size.infinite,
+                      painter: _DerivativeGraphPainter(
+                        widget.data,
+                        widget.settings,
+                        widget.ctrl,
+                        activeChannels: widget.activeChannels,
+                        cache: _derivCache ??= SegmentedGraphCache(),
+                        colorScheme: colorScheme,
+                        dpr: dpr,
+                        labels: _labelCache,
+                        bakePump: _bakePump,
                       ),
                     ),
                   ),
                 // Minimap
-                Minimap(
+                _Minimap(
                   dataSource: widget.data,
                   settings: widget.settings,
                   graphCtrl: widget.ctrl,
@@ -1350,108 +1347,16 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
               ],
             ),
             // LIVE button (appears when not following live edge)
-            ListenableBuilder(
-              listenable: widget.ctrl,
-              builder: (context, _) {
-                if (widget.ctrl.isLive ||
-                    widget.data.totalSamples == 0 ||
-                    !widget.isLiveGraph) {
-                  return const SizedBox.shrink();
-                }
-                return Positioned(
-                  right: 64,
-                  top: 8,
-                  child: FilledButton.tonalIcon(
-                    onPressed: () => widget.ctrl.goLive(
-                      totalSamples: widget.data.totalSamples,
-                      oldestSample: widget.data.oldestSample,
-                    ),
-                    icon: const Icon(Icons.fast_forward, size: 16),
-                    label: const Text('LIVE'),
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 4,
-                      ),
-                      minimumSize: Size.zero,
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                  ),
-                );
-              },
-            ),
+            if (widget.isLiveGraph)
+              _LiveButton(data: widget.data, ctrl: widget.ctrl),
             // Zoom controls
             Positioned(
               right: 72,
               bottom: 72,
-              child: Material(
-                elevation: 4,
-                borderRadius: BorderRadius.circular(24),
-                color: Theme.of(context).colorScheme.primary,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    IconButton(
-                      icon: Icon(
-                        Icons.zoom_out,
-                        color: Theme.of(context).colorScheme.onPrimary,
-                      ),
-                      onPressed: () => _zoomBy(1 / 1.2),
-                    ),
-                    if (widget.showZoomSpan)
-                      ListenableBuilder(
-                        listenable: Listenable.merge([
-                          widget.ctrl,
-                          widget.data.repaint,
-                        ]),
-                        builder: (context, _) {
-                          final (start, end) = widget.ctrl.effectiveRange(
-                            widget.data.totalSamples,
-                            widget.data.oldestSample,
-                            bufferCapacity: widget.data.bufferCapacity,
-                          );
-                          final spanSec =
-                              (end - start) / widget.data.sampleRate;
-
-                          String text;
-                          if (spanSec < 1.0) {
-                            text = '${(spanSec * 1000).round()} ms';
-                          } else if (spanSec < 60.0) {
-                            text = '${spanSec.toStringAsFixed(1)} s';
-                          } else {
-                            final m = spanSec ~/ 60;
-                            final s = (spanSec % 60).floor().toString().padLeft(
-                              2,
-                              '0',
-                            );
-                            text = '$m:$s';
-                          }
-
-                          return Container(
-                            width: 60,
-                            alignment: Alignment.center,
-                            child: Text(
-                              text,
-                              style: TextStyle(
-                                color: Theme.of(context).colorScheme.onPrimary,
-                                fontWeight: FontWeight.bold,
-                                fontFeatures: const [
-                                  ui.FontFeature.tabularFigures(),
-                                ],
-                              ),
-                            ),
-                          );
-                        },
-                      ),
-                    IconButton(
-                      icon: Icon(
-                        Icons.zoom_in,
-                        color: Theme.of(context).colorScheme.onPrimary,
-                      ),
-                      onPressed: () => _zoomBy(1.2),
-                    ),
-                  ],
-                ),
+              child: _ZoomControls(
+                data: widget.data,
+                ctrl: widget.ctrl,
+                onZoom: _zoomBy,
               ),
             ),
           ],
@@ -1459,6 +1364,149 @@ class _GraphWorkspaceState extends State<GraphWorkspace> {
       },
     );
   }
+}
+
+/// One interactive plot surface (gestures + the painted graph), shared by the
+/// force and derivative panes.
+class _GraphPane extends StatelessWidget {
+  const _GraphPane({
+    required this.data,
+    required this.ctrl,
+    required this.painter,
+  });
+
+  final GraphDataSource data;
+  final GraphController ctrl;
+  final CustomPainter painter;
+
+  @override
+  Widget build(BuildContext context) {
+    return _InteractiveGraphArea(
+      data: data,
+      ctrl: ctrl,
+      child: CustomPaint(foregroundPainter: painter, size: Size.infinite),
+    );
+  }
+}
+
+/// The "return to live edge" button, visible only when the user has panned
+/// away from a live graph's edge.
+class _LiveButton extends StatelessWidget {
+  const _LiveButton({required this.data, required this.ctrl});
+
+  final GraphDataSource data;
+  final GraphController ctrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: ctrl,
+      builder: (context, _) {
+        if (ctrl.isLive || data.totalSamples == 0) {
+          return const SizedBox.shrink();
+        }
+        return Positioned(
+          right: 64,
+          top: 8,
+          child: FilledButton.tonalIcon(
+            onPressed: () => ctrl.goLive(
+              totalSamples: data.totalSamples,
+              oldestSample: data.oldestSample,
+            ),
+            icon: const Icon(Icons.fast_forward, size: 16),
+            label: const Text('LIVE'),
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Zoom in/out buttons with the current window-span readout between them.
+class _ZoomControls extends StatelessWidget {
+  const _ZoomControls({
+    required this.data,
+    required this.ctrl,
+    required this.onZoom,
+  });
+
+  final GraphDataSource data;
+  final GraphController ctrl;
+  final void Function(double factor) onZoom;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(24),
+      color: cs.primary,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: Icon(Icons.zoom_out, color: cs.onPrimary),
+            onPressed: () => onZoom(1 / 1.2),
+          ),
+          _SpanReadout(data: data, ctrl: ctrl),
+          IconButton(
+            icon: Icon(Icons.zoom_in, color: cs.onPrimary),
+            onPressed: () => onZoom(1.2),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The current zoom-window span ("800 ms", "4.2 s", "2:05"), updating with
+/// both viewport moves and live-edge growth.
+class _SpanReadout extends StatelessWidget {
+  const _SpanReadout({required this.data, required this.ctrl});
+
+  final GraphDataSource data;
+  final GraphController ctrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: Listenable.merge([ctrl, data.repaint]),
+      builder: (context, _) {
+        final (start, end) = ctrl.effectiveRange(
+          data.totalSamples,
+          data.oldestSample,
+          bufferCapacity: data.bufferCapacity,
+        );
+        return Container(
+          width: 60,
+          alignment: Alignment.center,
+          child: Text(
+            _formatSpan((end - start) / data.sampleRate),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onPrimary,
+              fontWeight: FontWeight.bold,
+              fontFeatures: const [ui.FontFeature.tabularFigures()],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Format a zoom-window span in seconds for the readout: sub-second as
+/// rounded ms, under a minute as seconds with one decimal, else m:ss.
+String _formatSpan(double spanSec) {
+  if (spanSec < 1.0) return '${(spanSec * 1000).round()} ms';
+  if (spanSec < 60.0) return '${spanSec.toStringAsFixed(1)} s';
+  final m = spanSec ~/ 60;
+  final s = (spanSec % 60).floor().toString().padLeft(2, '0');
+  return '$m:$s';
 }
 
 typedef _ScaleConfigItem = ({int limit, int delta});
@@ -1501,7 +1549,7 @@ String _fmtTick(double sec, int decimals) {
 /// every widget rebuild, so a painter-owned cache would be dropped constantly.
 /// Clear-on-overflow: the per-frame working set is only a few dozen labels,
 /// so a clear just rebuilds the visible ones on the next paint.
-class LabelCache {
+class _LabelCache {
   static const int _limit = 512;
 
   final Map<String, ui.Paragraph> _cache = HashMap();
@@ -1572,7 +1620,7 @@ YAxisRange _computeYRange(double dataMin, double dataMax) {
 /// window [viewStart, viewEnd) to [grid]. Times are absolute -- seconds since
 /// sample 0 (session start) -- at every zoom level. When [drawMinor] is true,
 /// half-step minor lines are added between the major ticks.
-void drawTimeAxis(
+void _drawTimeAxis(
   Canvas canvas,
   Path grid,
   Size graphSz, {
@@ -1580,7 +1628,7 @@ void drawTimeAxis(
   required int viewEnd,
   required int sampleRate,
   required bool showLabels,
-  required LabelCache labels,
+  required _LabelCache labels,
   bool drawMinor = false,
   Color textColor = Colors.black,
 }) {
@@ -1633,14 +1681,14 @@ void drawTimeAxis(
 /// Append horizontal Y-axis grid lines and labels (formatted by [labelFor]) for
 /// [yRange] to [grid]. When [drawMinor] is true, half-delta minor lines are
 /// added. [valueToY] maps an axis value to a pixel Y.
-void drawValueAxis(
+void _drawValueAxis(
   Canvas canvas,
   Path grid,
   Size graphSz,
   YAxisRange yRange,
   double Function(double value) valueToY, {
   required String Function(double tick) labelFor,
-  required LabelCache labels,
+  required _LabelCache labels,
   bool drawMinor = false,
   Color textColor = Colors.black,
 }) {
@@ -1679,7 +1727,7 @@ void drawValueAxis(
 }
 
 /// Draw a horizontal zero baseline if the axis range crosses zero.
-void drawZeroBaseline(
+void _drawZeroBaseline(
   Canvas canvas,
   Size graphSz,
   YAxisRange yRange,
@@ -1701,7 +1749,7 @@ void drawZeroBaseline(
 
 /// Draws a diagonal warning hatch pattern over the [GraphDataSource.gaps]
 /// ranges visible in the window (regions where packets were dropped).
-void drawMissingDataHatching(
+void _drawMissingDataHatching(
   Canvas canvas,
   Size graphSz, {
   required int viewStart,
@@ -1818,6 +1866,14 @@ class VertexBatcher {
       _len = preserveFloats;
     }
   }
+
+  /// Drop the preserved tail after a [flush]: the primitive ends here, so the
+  /// next [add] starts a fresh polyline instead of bridging the gap. The
+  /// break idiom is `flush(); reset();` — [reset] alone would silently drop
+  /// un-emitted vertices.
+  void reset() {
+    _len = 0;
+  }
 }
 
 /// The (average polyline, min/max envelope fill) [VertexBatcher] pair shared
@@ -1878,7 +1934,7 @@ class VertexBatcher {
 /// whenever `blockSize >= 2 * bucketSize`; see its doc for the ACCURACY
 /// TRADEOFF at partial bucket boundaries and the ring-wrap handling.
 ///
-/// Gap handling: [paintEnvelopeDataLayer] clips all data ink out of the gap
+/// Gap handling: [_paintEnvelopeDataLayer] clips all data ink out of the gap
 /// x-ranges, so neither reduction path draws inside a gap. Within the
 /// remaining (clipped-in) area the paths still differ slightly at gap edges:
 /// the exact path excludes gap samples via NaN, while the buckets contain
@@ -1887,7 +1943,7 @@ class VertexBatcher {
 ///
 /// Vertices are flushed in <=4096-float chunks to stay within the web
 /// (Skwasm/Emscripten) stack-allocation limit.
-void drawChannelEnvelope(
+void _drawChannelEnvelope(
   Canvas canvas, {
   required Color color,
   required double graphW,
@@ -1910,7 +1966,7 @@ void drawChannelEnvelope(
   );
 
   // Calculate alignment block size
-  final int blockSize = blockSizeFor(viewSamples, graphW);
+  final int blockSize = _blockSizeFor(viewSamples, graphW);
 
   // Bucket acceleration only pays off (and only stays accurate, see the
   // ACCURACY TRADEOFF on reduceBlockBuckets) once a block spans at least
@@ -1945,9 +2001,13 @@ void drawChannelEnvelope(
         : reduceBlockExact(series.sampleAt, drawStart, sEnd);
 
     if (r.count == 0) {
-      // Entire block is dropped samples. Break the polyline.
+      // Entire block is dropped samples. Break the polyline: flush whatever
+      // accumulated, then drop the preserved tail so the next valid block
+      // starts a fresh primitive instead of bridging the gap.
       env.flush();
+      env.reset();
       avg.flush();
+      avg.reset();
       continue;
     }
 
@@ -1981,8 +2041,8 @@ void drawChannelEnvelope(
 
 /// Per-sample evaluator for [channel]'s tared value in [unit] (NaN marks a
 /// gap sample, breaking the polyline). The exact-path counterpart of
-/// [taredDisplayFromRaw]; used by the force graph and the minimap.
-double Function(int j) taredDisplaySampleAt(
+/// [_taredDisplayFromRaw]; used by the force graph and the minimap.
+double Function(int j) _taredDisplaySampleAt(
   GraphDataSource data,
   int channel,
   ForceUnit unit,
@@ -2000,9 +2060,9 @@ double Function(int j) taredDisplaySampleAt(
 }
 
 /// Affine raw-counts -> display-units map for [channel] (tare offset + unit
-/// scale). Must agree with [taredDisplaySampleAt] outside gaps; feeds the
-/// bucket fast path of [drawChannelEnvelope].
-double Function(double raw) taredDisplayFromRaw(
+/// scale). Must agree with [_taredDisplaySampleAt] outside gaps; feeds the
+/// bucket fast path of [_drawChannelEnvelope].
+double Function(double raw) _taredDisplayFromRaw(
   GraphDataSource data,
   int channel,
   ForceUnit unit,
@@ -2015,20 +2075,20 @@ double Function(double raw) taredDisplayFromRaw(
 /// The tared-force rendering recipe for one channel (exact per-sample
 /// evaluator + bucket acceleration). Shared by the force graph and the
 /// minimap so both plot the identical series.
-EnvelopeSeries taredEnvelopeSeries(
+EnvelopeSeries _taredEnvelopeSeries(
   GraphDataSource data,
   int channel,
   ForceUnit unit,
 ) => EnvelopeSeries.bucketed(
-  sampleAt: taredDisplaySampleAt(data, channel, unit),
+  sampleAt: _taredDisplaySampleAt(data, channel, unit),
   buckets: data.channel(channel).buckets,
-  rawToDisplay: taredDisplayFromRaw(data, channel, unit),
+  rawToDisplay: _taredDisplayFromRaw(data, channel, unit),
 );
 
 /// The envelope-layer cache-key extras identifying one data/configuration
 /// combination: stream identity, per-channel tares, display unit, and
 /// calibration. Shared by every surface rendering the envelope data layer.
-List<Object?> envelopeCacheKeyExtras(
+List<Object?> _envelopeCacheKeyExtras(
   GraphDataSource data,
   List<double> tares,
   ForceUnit unit,
@@ -2040,7 +2100,7 @@ List<Object?> envelopeCacheKeyExtras(
 /// [adjust] maps each folded bound per channel (tare offset, display scale).
 /// BOTH adjusted bounds feed each end of the range, so a negative display
 /// multiplier can't invert it. Returns null when no channel covers a sample.
-(double, double)? foldChannelExtremes(
+(double, double)? _foldChannelExtremes(
   Iterable<int> channels,
   int start,
   int end,
@@ -2069,7 +2129,7 @@ List<Object?> envelopeCacheKeyExtras(
 /// [viewStart, viewStart + viewSpan) mapped to x in [0, gw): the pipeline
 /// shared by the force graph, derivative graph, and minimap. Handles the
 /// cache configuration (keying, pads, block sizing) and renders one
-/// min/avg/max envelope per active channel via [drawChannelEnvelope].
+/// min/avg/max envelope per active channel via [_drawChannelEnvelope].
 ///
 /// [seriesFor] returns the per-channel rendering recipe ([EnvelopeSeries]):
 /// the exact per-sample evaluator plus optional bucket acceleration for the
@@ -2078,7 +2138,7 @@ List<Object?> envelopeCacheKeyExtras(
 ///
 /// Returns true when bake work remains; the owner should then schedule
 /// another frame.
-bool paintEnvelopeDataLayer(
+bool _paintEnvelopeDataLayer(
   Canvas canvas, {
   required SegmentedGraphCache cache,
   required GraphDataSource data,
@@ -2102,7 +2162,7 @@ bool paintEnvelopeDataLayer(
   double valueToY(double val) =>
       (gh - (val - yMin) * gh / (yMax - yMin)).clamp(0.0, gh);
 
-  final int blockSize = blockSizeFor(viewSpan, gw);
+  final int blockSize = _blockSizeFor(viewSpan, gw);
   final double blockPx = blockSize * gw / viewSpan;
 
   return cache.paint(
@@ -2145,7 +2205,7 @@ bool paintEnvelopeDataLayer(
       for (final ch in activeChannels) {
         if (data.channel(ch).data.isEmpty) continue;
 
-        drawChannelEnvelope(
+        _drawChannelEnvelope(
           cCanvas,
           color: getChannelColor(ch),
           graphW: gw,
@@ -2162,7 +2222,7 @@ bool paintEnvelopeDataLayer(
         );
       }
       if (clip != null) cCanvas.restore();
-      // drawChannelEnvelope maps sample s to (s - start) * gw / viewSpan.
+      // _drawChannelEnvelope maps sample s to (s - start) * gw / viewSpan.
       return (end - start) * gw / viewSpan;
     },
   );
@@ -2225,9 +2285,9 @@ _GraphLayout? _setupGraphFrame(
     ..color = frameColor
     ..style = PaintingStyle.stroke;
 
-  canvas.translate(kGraphLeftSpace, topSpace);
+  canvas.translate(_kGraphLeftSpace, topSpace);
   final graphSz = Size(
-    size.width - kGraphLeftSpace - kGraphRightSpace,
+    size.width - _kGraphLeftSpace - _kGraphRightSpace,
     size.height - bottomSpace - topSpace,
   );
 
@@ -2277,12 +2337,13 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
   final double dpr;
 
   /// Axis-label paragraph cache, owned (and disposed) by the host [State].
-  final LabelCache labels;
+  final _LabelCache labels;
 
-  /// Asks the host widget to schedule another frame; called when bake work
-  /// remains so the rolling bakes complete even for static sources whose
-  /// [GraphDataSource.repaint] never fires.
-  final VoidCallback _requestRepaint;
+  /// Drives the rolling segment bakes: a repaint listenable for this painter
+  /// and the scheduler for extra frames when bake work remains (rolling
+  /// bakes must complete even for static sources whose
+  /// [GraphDataSource.repaint] never fires).
+  final _BakePump bakePump;
 
   _TimeSeriesGraphPainter(
     this._data,
@@ -2293,10 +2354,8 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
     required this.colorScheme,
     required this.dpr,
     required this.labels,
-    required Listenable bakePump,
-    required VoidCallback requestRepaint,
+    required this.bakePump,
   }) : _activeChannels = activeChannels,
-       _requestRepaint = requestRepaint,
        super(repaint: Listenable.merge([_data.repaint, _ctrl, bakePump]));
 
   // --- Layout hooks --------------------------------------------------------
@@ -2343,7 +2402,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       _data,
       _ctrl,
       topSpace: topSpace,
-      bottomSpace: showXLabels ? kGraphBottomSpace : 4,
+      bottomSpace: showXLabels ? _kGraphBottomSpace : 4,
       minSamples: 1 + firstSampleOffset,
       frameColor: colorScheme.primary.withAlpha(150),
     );
@@ -2367,7 +2426,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
 
     // -- Grid and labels --
     final grid = Path();
-    drawTimeAxis(
+    _drawTimeAxis(
       canvas,
       grid,
       graphSz,
@@ -2379,7 +2438,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       drawMinor: drawMinorGrid,
       textColor: colorScheme.onSurface,
     );
-    drawValueAxis(
+    _drawValueAxis(
       canvas,
       grid,
       graphSz,
@@ -2396,7 +2455,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       ..strokeWidth = 0.2;
     canvas.drawPath(grid, gridPen);
 
-    drawZeroBaseline(
+    _drawZeroBaseline(
       canvas,
       graphSz,
       yRange,
@@ -2404,7 +2463,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       colorScheme.onSurface.withAlpha(130),
     );
 
-    drawMissingDataHatching(
+    _drawMissingDataHatching(
       canvas,
       graphSz,
       viewStart: viewStart,
@@ -2416,12 +2475,12 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
     drawOverlay(canvas, graphSz);
 
     // -- Data lines (segment-cached envelope) --
-    final workRemains = paintEnvelopeDataLayer(
+    final workRemains = _paintEnvelopeDataLayer(
       canvas,
       cache: cache,
       data: _data,
       activeChannels: activeIndices,
-      keyExtras: envelopeCacheKeyExtras(
+      keyExtras: _envelopeCacheKeyExtras(
         _data,
         cacheKeyTares(),
         _settings.displayUnit,
@@ -2436,7 +2495,7 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       firstUsableSample: oldestSample + firstSampleOffset,
       seriesFor: series,
     );
-    if (workRemains) _requestRepaint();
+    if (workRemains) bakePump.schedule();
   }
 
   @override
@@ -2444,11 +2503,11 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
 }
 
 /// Force graph: each channel's tared value in the selected display unit.
-class ForceGraphPainter extends _TimeSeriesGraphPainter {
+class _ForceGraphPainter extends _TimeSeriesGraphPainter {
   @override
   final bool showXLabels;
 
-  ForceGraphPainter(
+  _ForceGraphPainter(
     super.data,
     super.settings,
     super.ctrl, {
@@ -2459,7 +2518,6 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
     required super.dpr,
     required super.labels,
     required super.bakePump,
-    required super.requestRepaint,
   });
 
   @override
@@ -2474,7 +2532,7 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
 
   @override
   EnvelopeSeries series(int channel) =>
-      taredEnvelopeSeries(_data, channel, _settings.displayUnit);
+      _taredEnvelopeSeries(_data, channel, _settings.displayUnit);
 
   @override
   YAxisRange computeYRange(int viewStart, int viewEnd) {
@@ -2484,7 +2542,7 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
     // the precomputed aggregates (exact for min/max) and per-sample scans
     // only the partial head/tail, so the cost is O(window / bucketSize).
     final bufferCap = _data.bufferCapacity;
-    final ext = foldChannelExtremes(
+    final ext = _foldChannelExtremes(
       _activeChannels,
       math.max(viewStart, _data.oldestSample),
       math.min(viewEnd, _data.totalSamples),
@@ -2520,8 +2578,8 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
 
 /// Derivative graph: the first difference of each channel, scaled to display
 /// units per second.
-class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
-  DerivativeGraphPainter(
+class _DerivativeGraphPainter extends _TimeSeriesGraphPainter {
+  _DerivativeGraphPainter(
     super.data,
     super.settings,
     super.ctrl, {
@@ -2531,7 +2589,6 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
     required super.dpr,
     required super.labels,
     required super.bakePump,
-    required super.requestRepaint,
   });
 
   @override
@@ -2599,7 +2656,7 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
 
     // Channels with diff aggregates fold via the bucket fast path; folding
     // both scaled bounds keeps the range correct under a negative scale.
-    final ext = foldChannelExtremes(_activeChannels, startI, endI, (ch) {
+    final ext = _foldChannelExtremes(_activeChannels, startI, endI, (ch) {
       if (_data.channel(ch).data.isEmpty) return null;
       final buckets = _data.diffBucketsFor(ch);
       return buckets == null ? null : (buckets, _rawDiffAt(ch));

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -1073,7 +1073,7 @@ class _MinimapPainter extends CustomPainter {
       cache: _cache,
       data: _data,
       activeChannels: activeIndices,
-      keyExtras: [_data.dataGeneration, ...tares, unit, _data.calibrationSlope],
+      keyExtras: envelopeCacheKeyExtras(_data, tares, unit),
       gw: gw,
       gh: gh,
       dpr: _dpr,
@@ -1082,11 +1082,7 @@ class _MinimapPainter extends CustomPainter {
       yMin: yMin,
       yMax: yMax,
       firstUsableSample: oldestSample,
-      seriesFor: (ch) => EnvelopeSeries.bucketed(
-        sampleAt: taredDisplaySampleAt(_data, ch, unit),
-        buckets: _data.channel(ch).buckets,
-        rawToDisplay: taredDisplayFromRaw(_data, ch, unit),
-      ),
+      seriesFor: (ch) => taredEnvelopeSeries(_data, ch, unit),
       avgStrokeWidth: 1.0,
       avgAlpha: 180,
     );
@@ -2016,6 +2012,59 @@ double Function(double raw) taredDisplayFromRaw(
   return (raw) => (raw - tare) * slopeToUnit;
 }
 
+/// The tared-force rendering recipe for one channel (exact per-sample
+/// evaluator + bucket acceleration). Shared by the force graph and the
+/// minimap so both plot the identical series.
+EnvelopeSeries taredEnvelopeSeries(
+  GraphDataSource data,
+  int channel,
+  ForceUnit unit,
+) => EnvelopeSeries.bucketed(
+  sampleAt: taredDisplaySampleAt(data, channel, unit),
+  buckets: data.channel(channel).buckets,
+  rawToDisplay: taredDisplayFromRaw(data, channel, unit),
+);
+
+/// The envelope-layer cache-key extras identifying one data/configuration
+/// combination: stream identity, per-channel tares, display unit, and
+/// calibration. Shared by every surface rendering the envelope data layer.
+List<Object?> envelopeCacheKeyExtras(
+  GraphDataSource data,
+  List<double> tares,
+  ForceUnit unit,
+) => [data.dataGeneration, ...tares, unit, data.calibrationSlope];
+
+/// Fold the raw extremes of [channels] over `[start, end)` (already clamped
+/// to the source's usable range). [seriesFor] yields a channel's bucket
+/// aggregates and exact evaluator, or null when the channel has no data;
+/// [adjust] maps each folded bound per channel (tare offset, display scale).
+/// BOTH adjusted bounds feed each end of the range, so a negative display
+/// multiplier can't invert it. Returns null when no channel covers a sample.
+(double, double)? foldChannelExtremes(
+  Iterable<int> channels,
+  int start,
+  int end,
+  (BucketSeries buckets, double Function(int i) rawAt)? Function(int ch)
+  seriesFor,
+  double Function(double raw, int ch) adjust,
+) {
+  double? lo, hi;
+  for (final ch in channels) {
+    final series = seriesFor(ch);
+    if (series == null) continue;
+    // Gap samples hold a previous real value, so they can never extend
+    // the range: no exclusion needed.
+    final ext = windowedExtremes(series.$1, start, end, series.$2);
+    if (ext == null) continue;
+    for (final v in [adjust(ext.$1, ch), adjust(ext.$2, ch)]) {
+      if (lo == null || v < lo) lo = v;
+      if (hi == null || v > hi) hi = v;
+    }
+  }
+  // lo and hi are always assigned together; null means no channel folded.
+  return (lo == null) ? null : (lo, hi!);
+}
+
 /// Paint the segment-cached envelope data layer for the window
 /// [viewStart, viewStart + viewSpan) mapped to x in [0, gw): the pipeline
 /// shared by the force graph, derivative graph, and minimap. Handles the
@@ -2372,12 +2421,11 @@ abstract class _TimeSeriesGraphPainter extends CustomPainter {
       cache: cache,
       data: _data,
       activeChannels: activeIndices,
-      keyExtras: [
-        _data.dataGeneration,
-        ...cacheKeyTares(),
+      keyExtras: envelopeCacheKeyExtras(
+        _data,
+        cacheKeyTares(),
         _settings.displayUnit,
-        _data.calibrationSlope,
-      ],
+      ),
       gw: graphSz.width,
       gh: graphSz.height,
       dpr: dpr,
@@ -2425,11 +2473,8 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
       _activeChannels.map((ch) => _data.channel(ch).tare).toList();
 
   @override
-  EnvelopeSeries series(int channel) => EnvelopeSeries.bucketed(
-    sampleAt: taredDisplaySampleAt(_data, channel, _settings.displayUnit),
-    buckets: _data.channel(channel).buckets,
-    rawToDisplay: taredDisplayFromRaw(_data, channel, _settings.displayUnit),
-  );
+  EnvelopeSeries series(int channel) =>
+      taredEnvelopeSeries(_data, channel, _settings.displayUnit);
 
   @override
   YAxisRange computeYRange(int viewStart, int viewEnd) {
@@ -2438,36 +2483,20 @@ class ForceGraphPainter extends _TimeSeriesGraphPainter {
     // convert to display units. [windowedExtremes] folds full buckets from
     // the precomputed aggregates (exact for min/max) and per-sample scans
     // only the partial head/tail, so the cost is O(window / bucketSize).
-    final oldestSample = _data.oldestSample;
-    final totalSamples = _data.totalSamples;
     final bufferCap = _data.bufferCapacity;
-    double rawMax = 0;
-    double rawMin = 0;
-    bool hasData = false;
-
-    for (final ch in _activeChannels) {
-      final s = _data.channel(ch);
-      final line = s.data;
-      if (line.isEmpty) continue;
-      final sScanStart = math.max(viewStart, oldestSample);
-      final sScanEnd = math.min(viewEnd, totalSamples);
-      if (sScanStart >= sScanEnd) continue;
-
-      // Gap samples hold a previous real value, so they can never extend
-      // the range: no exclusion needed.
-      final ext = windowedExtremes(
-        s.buckets,
-        sScanStart,
-        sScanEnd,
-        (i) => line[i % bufferCap].toDouble(),
-      );
-      if (ext == null) continue;
-      final lo = ext.$1 - s.tare;
-      final hi = ext.$2 - s.tare;
-      if (!hasData || hi > rawMax) rawMax = hi;
-      if (!hasData || lo < rawMin) rawMin = lo;
-      hasData = true;
-    }
+    final ext = foldChannelExtremes(
+      _activeChannels,
+      math.max(viewStart, _data.oldestSample),
+      math.min(viewEnd, _data.totalSamples),
+      (ch) {
+        final s = _data.channel(ch);
+        if (s.data.isEmpty) return null;
+        return (s.buckets, (int i) => s.data[i % bufferCap].toDouble());
+      },
+      (raw, ch) => raw - _data.channel(ch).tare,
+    );
+    double rawMin = ext?.$1 ?? 0;
+    double rawMax = ext?.$2 ?? 0;
 
     // Enforce a minimum visible range (noise floor) so the graph isn't degenerate
     const double noiseFloor = 10000; // raw counts
@@ -2568,26 +2597,28 @@ class DerivativeGraphPainter extends _TimeSeriesGraphPainter {
       first = false;
     }
 
-    for (final ch in _activeChannels) {
-      if (_data.channel(ch).data.isEmpty) continue;
-      if (startI >= endI) continue;
-
+    // Channels with diff aggregates fold via the bucket fast path; folding
+    // both scaled bounds keeps the range correct under a negative scale.
+    final ext = foldChannelExtremes(_activeChannels, startI, endI, (ch) {
+      if (_data.channel(ch).data.isEmpty) return null;
       final buckets = _data.diffBucketsFor(ch);
-      if (buckets == null) {
-        // Exact-only fallback for sources without diff aggregates.
-        final valueAt = _sampleAt(ch);
-        for (int i = startI; i < endI; i++) {
-          final d = valueAt(i);
-          if (!d.isNaN) fold(d);
-        }
+      return buckets == null ? null : (buckets, _rawDiffAt(ch));
+    }, (raw, _) => raw * scale);
+    if (ext != null) {
+      fold(ext.$1);
+      fold(ext.$2);
+    }
+
+    // Exact-only fallback for channels without diff aggregates.
+    for (final ch in _activeChannels) {
+      if (_data.channel(ch).data.isEmpty || _data.diffBucketsFor(ch) != null) {
         continue;
       }
-
-      final ext = windowedExtremes(buckets, startI, endI, _rawDiffAt(ch));
-      if (ext == null) continue;
-      // Folding both scaled bounds keeps this correct under a negative scale.
-      fold(ext.$1 * scale);
-      fold(ext.$2 * scale);
+      final valueAt = _sampleAt(ch);
+      for (int i = startI; i < endI; i++) {
+        final d = valueAt(i);
+        if (!d.isNaN) fold(d);
+      }
     }
     return _computeYRange(dMin, dMax);
   }

--- a/test/ble_link_manager_test.dart
+++ b/test/ble_link_manager_test.dart
@@ -17,7 +17,8 @@ import 'package:dynamite_app/services/mockble.dart';
 /// Mock timing: hwDelay 200 ms (availability), netDelay 1 s (connect /
 /// discoverServices / calibration read). A full connect therefore takes ~3 s:
 /// connect(1s) -> MTU(immediate) -> discoverServices(1s) -> calibration(1s)
-/// -> subscribe. [BleLinkManager.disconnectTimeout] is 2500 ms.
+/// -> subscribe. [BleLinkManager.disconnectTimeout] is 2500 ms,
+/// [BleLinkManager.connectTimeout] is 15 s (the mock's slowConnect is 20 s).
 ///
 /// IMPORTANT: every test tears its link down INSIDE the [fakeAsync] scope
 /// (see [teardownLink]). A disconnect left running when the scope exits keeps
@@ -84,6 +85,10 @@ void main() {
       expect(link.link.state, BtLinkState.idle);
       expect(seen.whereType<BleConnectionFailed>(), hasLength(1));
       expect(seen.whereType<BleConnectionLost>(), isEmpty);
+      // The GATT link came up (connect succeeded) before setup failed — it
+      // must be released, not leaked.
+      expect(MockBlePlatform.instance.disconnectCalls, contains(deviceId));
+      expect(MockBlePlatform.instance.connectedDeviceId, isNull);
 
       teardownLink(async, link);
     });
@@ -196,6 +201,133 @@ void main() {
       expect(seen, isEmpty);
 
       teardownLink(async, link);
+    });
+  });
+
+  test('cancelling a hung connect releases the link and ignores the late '
+      'success', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+
+      unawaited(link.connectToDevice(deviceId));
+      // Mid-connect (the mock's connect takes 1 s): the attempt is in flight.
+      async.elapse(const Duration(milliseconds: 500));
+      expect(link.link.state, BtLinkState.connecting);
+
+      unawaited(link.disconnectSelectedDevice());
+      // The disconnect settles immediately; the mock's outstanding connect
+      // completes (late) at 1 s and must be released by the guard.
+      async.elapse(const Duration(seconds: 4));
+
+      expect(link.link.state, BtLinkState.idle);
+      expect(link.isStreaming, isFalse);
+      expect(MockBlePlatform.instance.connectedDeviceId, isNull);
+      // A user-initiated cancel surfaces no failure/lost/timeout notices…
+      expect(seen, isEmpty);
+      // …and exactly two platform disconnects went out: the cancel itself and
+      // the guard releasing the late success. The abandoned connect future
+      // resolving silently did NOT trigger a further teardown.
+      expect(MockBlePlatform.instance.disconnectCalls, [deviceId, deviceId]);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('a connect failing after user cancel does not re-tear-down', () {
+    fakeAsync((async) {
+      MockBlePlatform.instance.failConnect = true;
+      final (link, seen) = wire();
+
+      // A cancelled attempt fails quietly: no error reaches the caller.
+      Object? error;
+      unawaited(
+        link.connectToDevice(deviceId).catchError((Object e) => error = e),
+      );
+      async.elapse(const Duration(milliseconds: 500));
+      expect(link.link.state, BtLinkState.connecting);
+
+      unawaited(link.disconnectSelectedDevice());
+      // The mock's connect future throws at 1 s — after the cancel teardown.
+      async.elapse(const Duration(seconds: 4));
+
+      expect(error, isNull);
+      expect(link.link.state, BtLinkState.idle);
+      expect(seen, isEmpty);
+      // The cancel's disconnect is the only platform teardown; the late
+      // failure hit the abandoned-attempt guard and returned silently.
+      expect(MockBlePlatform.instance.disconnectCalls, [deviceId]);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('a connect that outlives its timeout is torn down and the late '
+      'success released', () {
+    fakeAsync((async) {
+      MockBlePlatform.instance.slowConnect = true;
+      final (link, seen) = wire();
+
+      Object? error;
+      unawaited(
+        link.connectToDevice(deviceId).catchError((Object e) => error = e),
+      );
+      // BleLinkManager.connectTimeout (15 s) fires before the mock's 20 s
+      // connect completes.
+      async.elapse(const Duration(seconds: 16));
+
+      expect(error, isNotNull);
+      expect(link.link.state, BtLinkState.idle);
+      expect(seen, isEmpty);
+      expect(MockBlePlatform.instance.disconnectCalls, [deviceId]);
+
+      // The platform connect completes late; the unwanted-link guard must
+      // release it without adopting it.
+      async.elapse(const Duration(seconds: 5));
+      expect(link.link.state, BtLinkState.idle);
+      expect(link.isStreaming, isFalse);
+      expect(MockBlePlatform.instance.connectedDeviceId, isNull);
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('a connect callback for an unknown device is released, not adopted', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+      unawaited(link.connectToDevice(deviceId));
+      async.elapse(const Duration(seconds: 4));
+      expect(link.isStreaming, isTrue);
+
+      // A platform-level connect completes for a device the app never asked
+      // for. (The mock is single-link: its disconnect of 'zzz' also severs
+      // its own '2' state — only the manager's behavior is asserted here.)
+      MockBlePlatform.instance.updateConnection('zzz', true);
+      async.elapse(const Duration(seconds: 3));
+
+      // The active link is untouched and the stranger's GATT link released.
+      expect(link.isStreaming, isTrue);
+      expect(MockBlePlatform.instance.disconnectCalls, contains('zzz'));
+      expect(seen, isEmpty);
+
+      teardownLink(async, link);
+    });
+  });
+
+  test('a connect callback arriving on an idle link is released, not '
+      'adopted', () {
+    fakeAsync((async) {
+      final (link, seen) = wire();
+      // Let the startup availability query resolve (hwDelay 200 ms).
+      async.elapse(const Duration(milliseconds: 300));
+
+      MockBlePlatform.instance.updateConnection(deviceId, true);
+      async.elapse(const Duration(seconds: 3));
+
+      expect(link.link.state, BtLinkState.idle);
+      expect(link.isStreaming, isFalse);
+      expect(MockBlePlatform.instance.disconnectCalls, contains(deviceId));
+      expect(seen, isEmpty);
     });
   });
 

--- a/test/bt_status_visual_test.dart
+++ b/test/bt_status_visual_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/universal_ble.dart' show AvailabilityState;
+
+import 'package:dynamite_app/services/ble_link_manager.dart' show BtLinkState;
+import 'package:dynamite_app/widgets/bt_icon.dart';
+import 'package:dynamite_app/widgets/status_colors.dart';
+
+/// Tests for [btStatusVisual], the pure link/adapter/scan -> indicator
+/// mapping behind [BluetoothIndicator].
+void main() {
+  const status = StatusColors.light;
+  final colors = ColorScheme.fromSeed(seedColor: Colors.blue);
+
+  BtStatusVisual visual({
+    BtLinkState linkState = BtLinkState.idle,
+    AvailabilityState availability = AvailabilityState.poweredOn,
+    bool isScanning = false,
+    bool hasDevices = false,
+  }) => btStatusVisual(
+    linkState: linkState,
+    availability: availability,
+    isScanning: isScanning,
+    hasDevices: hasDevices,
+    status: status,
+    colors: colors,
+  );
+
+  test('link states outrank scan and adapter status', () {
+    // Even while scanning with the radio on, a link transition wins.
+    final v = visual(
+      linkState: BtLinkState.connecting,
+      isScanning: true,
+      hasDevices: true,
+    );
+    expect(v.label, 'Connecting…');
+    expect(v.color, status.linkActive);
+    expect(v.showSpinner, isTrue);
+  });
+
+  test('streaming is the only non-spinner link state', () {
+    for (final s in BtLinkState.values) {
+      final v = visual(linkState: s);
+      expect(
+        v.showSpinner,
+        s == BtLinkState.idle || s == BtLinkState.streaming ? isFalse : isTrue,
+        reason: 'state $s',
+      );
+    }
+    expect(visual(linkState: BtLinkState.streaming).label, 'Connected');
+    expect(visual(linkState: BtLinkState.connected).label, 'Setting up…');
+    expect(
+      visual(linkState: BtLinkState.disconnecting).label,
+      'Disconnecting…',
+    );
+    expect(visual(linkState: BtLinkState.cooldown).label, 'Almost ready…');
+  });
+
+  test('idle + scanning outranks adapter status', () {
+    final v = visual(
+      isScanning: true,
+      availability: AvailabilityState.poweredOff,
+    );
+    expect(v.label, contains('Scanning'));
+    expect(v.showSpinner, isTrue);
+  });
+
+  test('idle powered-on hints reflect discovered devices', () {
+    expect(visual(hasDevices: true).label, 'Tap a device to connect');
+    expect(visual(hasDevices: false).label, 'Tap Scan to find devices');
+  });
+
+  test('adapter problems surface in the idle state', () {
+    expect(
+      visual(availability: AvailabilityState.poweredOff).label,
+      'Bluetooth is off',
+    );
+    expect(
+      visual(availability: AvailabilityState.poweredOff).color,
+      colors.outline,
+    );
+    expect(
+      visual(availability: AvailabilityState.unsupported).color,
+      colors.error,
+    );
+    expect(
+      visual(availability: AvailabilityState.unauthorized).color,
+      colors.tertiary,
+    );
+    expect(
+      visual(availability: AvailabilityState.unknown).label,
+      contains('Starting up'),
+    );
+  });
+}

--- a/test/data_hub_test.dart
+++ b/test/data_hub_test.dart
@@ -28,6 +28,23 @@ void main() {
       }
     });
 
+    test('cleared listeners fire on clear() only, not on sample appends', () {
+      final hub = DataHub();
+      var cleared = 0;
+      void listener() => cleared++;
+      hub.addClearedListener(listener);
+
+      feed(hub, frameOf(7), 10);
+      expect(cleared, 0);
+
+      hub.clear();
+      expect(cleared, 1);
+
+      hub.removeClearedListener(listener);
+      hub.clear();
+      expect(cleared, 1);
+    });
+
     test('a never-positive channel reports its true (negative) peak', () {
       final hub = DataHub();
       final frame = Int32List(channels);

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -161,6 +161,37 @@ void main() {
     });
   });
 
+  group('SessionChunkCodec', () {
+    test('pack/decode round-trips frames exactly', () {
+      const codec = SessionChunkCodec(channels);
+      final values = [
+        [1, 2, 3, 4],
+        [-5, 6, -7, 8],
+        [0x7FFFFFFF, -0x80000000, 0, 123456],
+      ];
+      final bytes = codec.pack(values.length, (s, ch) => values[s][ch]);
+      expect(codec.framesOf(bytes), values.length);
+      expect(bytes.lengthInBytes, values.length * channels * 4);
+
+      final decoded = <List<int>>[];
+      codec.decode(bytes, (s, ch, raw) {
+        while (decoded.length <= s) {
+          decoded.add(List.filled(channels, 0));
+        }
+        decoded[s][ch] = raw;
+      });
+      expect(decoded, values);
+    });
+
+    test('framesOf ignores trailing partial bytes', () {
+      const codec = SessionChunkCodec(channels);
+      expect(codec.framesOf(Uint8List(0)), 0);
+      expect(codec.framesOf(Uint8List(channels * 4 - 1)), 0);
+      expect(codec.framesOf(Uint8List(channels * 4)), 1);
+      expect(codec.framesOf(Uint8List(channels * 4 + 1)), 1);
+    });
+  });
+
   group('crash recovery', () {
     test('gaps persisted on flush survive recoverIncompleteSessions', () async {
       AppDatabase.instance = AppDatabase.forTesting(NativeDatabase.memory());

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -49,7 +49,11 @@ void main() {
         hub.addSampleFrame(frame);
       }
 
-      final writer = LiveSessionWriter(1, Float64List(channels));
+      final writer = LiveSessionWriter(
+        1,
+        Float64List(channels),
+        DataHub.samplesPerSec,
+      );
       await writer.appendData(hub, 0, n);
 
       expect(writer.totalSamplesRecorded, n);
@@ -72,6 +76,7 @@ void main() {
       final writer = LiveSessionWriter(
         1,
         Float64List(channels),
+        DataHub.samplesPerSec,
         chunkSink: (sessionId, chunkIndex, data, gapsJson) async =>
             saved.add(data),
       );
@@ -115,6 +120,7 @@ void main() {
       final writer = LiveSessionWriter(
         1,
         Float64List(channels),
+        DataHub.samplesPerSec,
         chunkSink: (sessionId, chunkIndex, data, gapsJson) async {
           sinkCalls++;
           if (!entered.isCompleted) entered.complete();
@@ -206,5 +212,37 @@ void main() {
       expect(loaded.gaps.contains(2119), isTrue);
       expect(loaded.gaps.contains(2120), isFalse);
     });
+
+    test(
+      'a session with only empty chunks completes with a zero peak',
+      () async {
+        AppDatabase.instance = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(AppDatabase.closeInstance);
+
+        // A chunk row exists, but it holds no complete frame (0 bytes), so the
+        // recovered aggregate scan finds no samples and peakRaw stays at
+        // -infinity — which must never reach the DB.
+        final sessionId = await AppDatabase.instance.createSession(
+          name: 'empty chunks',
+          sampleRate: DataHub.samplesPerSec,
+          channelCount: channels,
+          channelLabels: '["a","b","c","d"]',
+          tares: '[0,0,0,0]',
+          calibrationSlope: 1.0,
+          visibleChannels: '[true,true,true,true]',
+        );
+        await AppDatabase.instance.insertChunk(sessionId, 0, Uint8List(0));
+
+        await SessionStorage.recoverIncompleteSessions();
+
+        final row = await AppDatabase.instance.sessionById(sessionId);
+        expect(row, isNotNull);
+        expect(row!.isCompleted, isTrue);
+        expect(row.sampleCount, 0);
+        expect(row.durationMs, 0);
+        expect(row.peakForceRaw, 0.0);
+        expect(row.peakForceRaw.isFinite, isTrue);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Bug fixes

- **GATT leaks**: failed post-connect setup and abandoned/timed-out connects
  now release the platform GATT link (`_teardownLink(releaseGatt:)` +
  best-effort `_releaseGatt`) instead of leaving the OS/browser holding a
  connection the app considers dead.
- **Connect hangs**: explicit 15s timeout passed to `UniversalBle.connect`
  (it bypasses the package command queue, so the 5s command timeout never
  applied; default was 60s).
- **Late-connect race**: a platform connect completing after timeout/cancel
  (or for an unknown device) is released and ignored by the unwanted-link
  guard in `_onConnectionChange`, not adopted.
- **Cancel while connecting**: the Devices tab shows a Cancel button during
  connect; abandoned attempts fail quietly (no phantom cooldown, no toast).
- **Crash recovery**: shared `_completeSession` helper applies the isFinite
  peak guard and persisted sample rate on both finalize and recovery paths.
- **Smaller fixes**: pinch-zoom focal no longer ignores left plot padding;
  demo connect now cancels a pending cooldown timer; gap polylines break
  explicitly (`VertexBatcher.reset()`) instead of relying on the clip path;
  session delete errors are awaited and surfaced.

## Refactors (behavior-preserving)

- All link-ending paths unified through `_teardownLink`; setup-pass
  cancellation encapsulated in `_SetupToken` (replaces the raw generation
  int and its scattered bump sites); `_beginConnect` unifies the demo/real
  connect preamble with a synchronous busy-guard.
- Session detail screen is driven by `watchSessionById` — no mirrored row
  copy, local visibility list, or manual reloads.
- RSSI polling is gated to Devices-tab visibility (no 2s radio wakeups for
  an off-screen value); Live/Settings tabs use narrow `select()`s so RSSI
  polls stop rebuilding them; stall timer runs only while streaming;
  `sessionInProgress` is derived from the writer.
- Deduplication: `ChannelIngest` + `kBucketSize` (one ingest/grid for live
  and session data), `SessionChunkCodec` (one packed chunk format, was 3
  copies), `encodeAdcFrame`/`encodeAdcPacket` (one wire encoder for demo +
  mock), shared rename/delete flows, `EmptyPlaceholder`, tappable channel
  cell, `goToDevices()`.
- Graph internals: `_bakeOne` split, `GraphWorkspace.build` decomposed,
  gesture state collapsed to one nullable session record, ~15 symbols
  privatized, `btStatusVisual` extracted as a pure table-driven function.
- `logTrace()` (debug-only, lazy) replaces `debugPrint` on 50 Hz packet
  paths; scale/memory TODOs documented for long sessions.
- CSV export uses session channel labels and `ForceUnit` conversion instead
  of hard-coded `chN`/`kgf` headers.

## Testing

- 5 new `fakeAsync` BLE lifecycle tests: cancel mid-connect, fail-after-
  cancel, connect-outliving-timeout with late success, unknown-device and
  idle-link connection callbacks (mock gained `slowConnect` knob +
  `disconnectCalls` spy).
- New unit tests: `btStatusVisual` mapping, hub cleared-listeners, chunk
  codec round-trip.