### PR TITLE
Fix link-drop race at recording start; drop session-card peak, harden settings and gap parsing

### DIFF
--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -36,6 +36,12 @@ class AppSettings extends ChangeNotifier {
   bool _wakelockEnabled = false;
   bool get wakelockEnabled => _wakelockEnabled;
 
+  /// Preference keys the user has explicitly set through a setter. [_load]'s
+  /// async read resolves AFTER the constructor returns, so a setter that ran
+  /// in the meantime owns the in-memory value — [_load] must not overwrite it
+  /// with the (older) persisted one.
+  final Set<String> _modifiedKeys = {};
+
   AppSettings() {
     unawaited(_load());
   }
@@ -44,7 +50,7 @@ class AppSettings extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
 
     final unitName = prefs.getString(_keyUnit);
-    if (unitName != null) {
+    if (unitName != null && !_modifiedKeys.contains(_keyUnit)) {
       _displayUnit = ForceUnit.values.firstWhere(
         (u) => u.name == unitName,
         orElse: () => ForceUnit.kN,
@@ -52,21 +58,28 @@ class AppSettings extends ChangeNotifier {
     }
 
     final labels = prefs.getStringList(_keyChannelLabels);
-    if (labels != null && labels.length == nwNumAdcChan) {
+    if (labels != null &&
+        labels.length == nwNumAdcChan &&
+        !_modifiedKeys.contains(_keyChannelLabels)) {
       _channelLabels = labels;
     }
 
     final active = prefs.getStringList(_keyActiveChannels);
-    if (active != null && active.length == nwNumAdcChan) {
+    if (active != null &&
+        active.length == nwNumAdcChan &&
+        !_modifiedKeys.contains(_keyActiveChannels)) {
       _activeChannels = active.map((s) => s == 'true').toList();
     }
 
-    _wakelockEnabled = prefs.getBool(_keyWakelock) ?? false;
+    if (!_modifiedKeys.contains(_keyWakelock)) {
+      _wakelockEnabled = prefs.getBool(_keyWakelock) ?? false;
+    }
 
     notifyListeners();
   }
 
   Future<void> setDisplayUnit(ForceUnit unit) async {
+    _modifiedKeys.add(_keyUnit);
     _displayUnit = unit;
     notifyListeners();
     final prefs = await SharedPreferences.getInstance();
@@ -74,6 +87,7 @@ class AppSettings extends ChangeNotifier {
   }
 
   Future<void> setChannelLabel(int index, String label) async {
+    _modifiedKeys.add(_keyChannelLabels);
     _channelLabels[index] = label;
     notifyListeners();
     final prefs = await SharedPreferences.getInstance();
@@ -81,6 +95,7 @@ class AppSettings extends ChangeNotifier {
   }
 
   Future<void> setChannelActive(int index, bool active) async {
+    _modifiedKeys.add(_keyActiveChannels);
     _activeChannels[index] = active;
     notifyListeners();
     final prefs = await SharedPreferences.getInstance();
@@ -91,6 +106,7 @@ class AppSettings extends ChangeNotifier {
   }
 
   Future<void> setWakelockEnabled(bool enabled) async {
+    _modifiedKeys.add(_keyWakelock);
     _wakelockEnabled = enabled;
     notifyListeners();
     final prefs = await SharedPreferences.getInstance();

--- a/lib/models/gap_list.dart
+++ b/lib/models/gap_list.dart
@@ -82,13 +82,24 @@ class GapList {
     for (int k = 0; k < _bounds.length; k += 2) [_bounds[k], _bounds[k + 1]],
   ]);
 
-  /// Parse the [toJson] format. Malformed input yields an empty list.
+  /// Parse the [toJson] format. Malformed input yields an empty list —
+  /// including ranges that are empty, inverted, overlapping or out of order:
+  /// those violate the sorted-disjoint invariant [contains] binary-searches
+  /// on, so a corrupt document degrades to "no gaps" rather than a corrupt
+  /// list. (Adjacent ranges are valid and merge on [append].)
   factory GapList.fromJson(String json) {
     final gaps = GapList();
     try {
       final List<dynamic> parsed = jsonDecode(json);
+      var lastEnd = -1;
       for (final pair in parsed) {
-        gaps.append((pair[0] as num).toInt(), (pair[1] as num).toInt());
+        final start = (pair[0] as num).toInt();
+        final end = (pair[1] as num).toInt();
+        if (end <= start || start < lastEnd) {
+          throw const FormatException('gap ranges must be increasing');
+        }
+        gaps.append(start, end);
+        lastEnd = end;
       }
     } catch (_) {
       gaps.clear();

--- a/lib/screens/live_tab.dart
+++ b/lib/screens/live_tab.dart
@@ -175,6 +175,16 @@ class _LiveTabState extends State<LiveTab> {
               behavior: SnackBarBehavior.floating,
             ),
           );
+        case StartSessionLinkLost():
+          // The link drop itself is announced by the shell's
+          // BleConnectionLost notice; this just confirms the REC tap didn't
+          // start anything.
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Connection lost — recording not started'),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
         case StartSessionFailed(:final error):
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/lib/screens/sessions_tab.dart
+++ b/lib/screens/sessions_tab.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
-import '../models/app_settings.dart';
-import '../models/force_unit.dart';
 import '../services/database.dart';
 import '../utils/format.dart';
 import '../widgets/dialogs.dart';
@@ -25,8 +22,6 @@ class _SessionsTabState extends State<SessionsTab> {
 
   @override
   Widget build(BuildContext context) {
-    final settings = context.watch<AppSettings>();
-
     return SafeArea(
       child: Column(
         children: [
@@ -92,7 +87,6 @@ class _SessionsTabState extends State<SessionsTab> {
                   itemCount: sessions.length,
                   itemBuilder: (context, index) => _SessionCard(
                     session: sessions[index],
-                    unit: settings.displayUnit,
                     onTap: () => _openDetail(sessions[index]),
                     onDelete: () => _deleteSession(sessions[index]),
                   ),
@@ -129,13 +123,11 @@ class _SessionsTabState extends State<SessionsTab> {
 class _SessionCard extends StatelessWidget {
   const _SessionCard({
     required this.session,
-    required this.unit,
     required this.onTap,
     required this.onDelete,
   });
 
   final Session session;
-  final ForceUnit unit;
   final VoidCallback onTap;
   final Future<void> Function() onDelete;
 
@@ -143,9 +135,6 @@ class _SessionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final duration = Duration(milliseconds: session.durationMs);
     final durationStr = formatDuration(duration);
-    final peakDisplay = unit.format(
-      unit.fromRaw(session.peakForceRaw.toDouble(), session.calibrationSlope),
-    );
 
     return Dismissible(
       key: ValueKey(session.id),
@@ -168,11 +157,13 @@ class _SessionCard extends StatelessWidget {
             session.name.isEmpty ? 'Untitled' : session.name,
             style: const TextStyle(fontWeight: FontWeight.w500),
           ),
+          // No peak value here: peaks are per-channel (see the detail view);
+          // the stored row-wide peak is a max over all channels and reads
+          // inconsistent next to them.
           subtitle: Text(
-            '${formatDate(session.createdAt)} · $durationStr\n'
-            'Peak: $peakDisplay · ${session.channelCount} ch',
+            '${formatDate(session.createdAt)} · $durationStr · '
+            '${session.channelCount} ch',
           ),
-          isThreeLine: true,
           trailing: const Icon(Icons.chevron_right),
         ),
       ),

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -13,13 +13,6 @@ import '../utils/log.dart';
 ///
 /// This is intentionally a *per-device* concept even though, today, the app
 /// only tracks one link at a time (see [DeviceLink] / [BleLinkManager]).
-///
-/// MULTI-DEVICE (Path A): when we support N simultaneous devices, this enum
-/// stays exactly as-is. The only change is that [BleLinkManager] will hold a
-/// `Map<String /*deviceId*/, DeviceLink>` instead of the single [_link] below,
-/// and the UI will read each row's state from its own [DeviceLink]. The
-/// adapter-availability and scanning state remain *global* (one radio), so they
-/// do NOT move into [DeviceLink].
 enum BtLinkState {
   /// No connection to this device; it may or may not be in the discovered list.
   idle,
@@ -53,13 +46,9 @@ enum BtLinkState {
   cooldown,
 }
 
-/// All per-device link state for a single BLE device.
-///
-/// MULTI-DEVICE (Path A): promote the single [BleLinkManager._link] to a
-/// `Map<String, DeviceLink>` keyed by [deviceId]. Each map entry owns its own
-/// state/name/services/subscription. The migration is mechanical because
-/// every field that is logically per-device already lives here rather than as a
-/// loose field on [BleLinkManager].
+/// All per-device link state for a single BLE device. Everything logically
+/// per-device lives here rather than as loose fields on [BleLinkManager] —
+/// see the multi-device roadmap on [BleLinkManager].
 class DeviceLink {
   DeviceLink({this.deviceId = ''});
 
@@ -134,6 +123,16 @@ class _SetupToken {
 /// via [onAdcData] / [onCalibrationData] (wired to [AdcPacketDecoder] at app
 /// startup), and recording observes this notifier's state changes (see
 /// [RecordingController]).
+///
+/// MULTI-DEVICE ROADMAP: today exactly one link is tracked ([_link]), and
+/// [QueueType.perDevice] already isolates per-device command queues. To
+/// support N simultaneous devices, promote [_link] to a
+/// `Map<String /*deviceId*/, DeviceLink>`: [DeviceLink] holds every logically
+/// per-device field (state, name, rssi), so the migration is mechanical —
+/// per-device lookup in [_onConnectionChange] and [_onValueChange] (route by
+/// deviceId instead of dropping), per-device busy guards in [_beginConnect]
+/// and [disconnectSelectedDevice]. Adapter availability and scanning stay
+/// *global* (one radio) and do NOT move into [DeviceLink].
 class BleLinkManager extends ChangeNotifier {
   /// Upper bound we pass to [UniversalBle.disconnect] so a silent stack can't
   /// strand the UI on "Disconnecting…". The package's own `disconnect()` sets
@@ -196,13 +195,9 @@ class BleLinkManager extends ChangeNotifier {
   bool _isScanning = false;
   bool get isScanning => _isScanning;
 
-  /// The single active device link.
-  ///
-  /// MULTI-DEVICE (Path A): replace with
-  /// `final Map<String, DeviceLink> _links = {};` and add per-device accessors.
-  /// The getters below currently project this single link into the flat API the
-  /// UI consumes today; in the multi-device world the UI will read each
-  /// [DeviceLink] directly instead of via these singular getters.
+  /// The single active device link (see the multi-device roadmap on the
+  /// class). The getters below project it into the flat API the UI consumes
+  /// today.
   final DeviceLink _link = DeviceLink();
   DeviceLink get link => _link;
 
@@ -292,7 +287,7 @@ class BleLinkManager extends ChangeNotifier {
     // web when the user rapidly connects/disconnects) blocks and serially times
     // out every later command — producing a storm of 10s "Future not completed"
     // failures. `perDevice` isolates a dead device's stuck commands from a fresh
-    // attempt, and aligns with the multi-device roadmap (Path A).
+    // attempt (and is the shape the multi-device roadmap needs).
     UniversalBle.queueType = QueueType.perDevice;
     // Fail stuck commands faster than the 10s default so a hung web GATT promise
     // surfaces (and our generation guard / teardown proceeds) without a long
@@ -370,9 +365,6 @@ class BleLinkManager extends ChangeNotifier {
     // Guard before any destructive clears: if we can't/shouldn't start a scan,
     // don't wipe the existing device list (which would leave the UI showing an
     // empty list with no picker having opened).
-    //
-    // MULTI-DEVICE (Path A): this becomes "if any link is mid-transition"
-    // (connecting/disconnecting) rather than a single flag.
     if (_link.state != BtLinkState.idle && !_link.isStreaming) {
       return;
     }
@@ -538,9 +530,6 @@ class BleLinkManager extends ChangeNotifier {
     // we gave up on it (connect timeout, user cancel); the GATT link is then
     // live at the platform level with nothing tracking it. Release such links
     // so they can't leak, then ignore the event.
-    //
-    // MULTI-DEVICE (Path A): look up `_links[deviceId]` instead of assuming
-    // the event is for the single active link.
     final bool isActiveDevice =
         _link.deviceId.isNotEmpty && _link.deviceId == deviceId;
     if (!isActiveDevice ||
@@ -675,9 +664,6 @@ class BleLinkManager extends ChangeNotifier {
   /// The latter is a one-shot async *query*, not an event source — it can't
   /// push updates, so it can't replace callback-driven state without polling
   /// (just a different timer).
-  ///
-  /// MULTI-DEVICE (Path A): the idle guard becomes per-device — a different,
-  /// idle device can connect while another is mid-transition.
   bool _beginConnect() {
     if (_link.state != BtLinkState.idle) {
       return false;
@@ -789,9 +775,6 @@ class BleLinkManager extends ChangeNotifier {
     // reconciliation: if the link is still stuck in `disconnecting` on this
     // device, the callback never landed within the window — force it idle and
     // surface the "didn't disconnect cleanly" notice ourselves.
-    //
-    // MULTI-DEVICE (Path A): operate on `_links[deviceId]` so each device
-    // settles independently and the notice can name that specific device.
     await UniversalBle.disconnect(deviceId, timeout: disconnectTimeout);
     await UniversalBle.getBluetoothAvailabilityState(); // fix for a bug in UBle
 
@@ -858,7 +841,7 @@ class BleLinkManager extends ChangeNotifier {
     // parsed as ADC packets. universal_ble normalizes characteristicId to
     // lowercase before invoking this callback, and btChrAdcFeedId is already
     // lowercase, so an exact match is safe.
-    // MULTI-DEVICE (Path A): route by deviceId instead of dropping.
+    // Multi-device: route by deviceId instead of dropping.
     if (deviceId != _link.deviceId || characteristicId != btChrAdcFeedId) {
       logTrace(
         () =>

--- a/lib/services/recording_controller.dart
+++ b/lib/services/recording_controller.dart
@@ -27,6 +27,14 @@ final class StartSessionTareInProgress extends StartSessionResult {
   const StartSessionTareInProgress();
 }
 
+/// Refused: the link dropped while the session row was being created. The
+/// orphan row was discarded; nothing is recording (and a later reconnect can
+/// never splice a different device's stream into this session — see
+/// [RecordingController.startSession]). Transient — retry once reconnected.
+final class StartSessionLinkLost extends StartSessionResult {
+  const StartSessionLinkLost();
+}
+
 /// Session creation (the DB row / writer) threw; nothing was latched, so the
 /// controller is still idle.
 final class StartSessionFailed extends StartSessionResult {
@@ -127,6 +135,16 @@ class RecordingController extends ChangeNotifier {
       return StartSessionFailed(e);
     }
 
+    // Re-check the link after the await: if it dropped while the row was
+    // being created, [_onLinkChanged] saw no writer latched and did nothing.
+    // Latching now would leave a live session on a dead link — and a later
+    // reconnect would splice the NEW device's stream (post-clear, indices
+    // restarted) into it. Discard the empty row and refuse instead.
+    if (!_linkManager.isStreaming) {
+      await SessionStorage.discardSession(writer);
+      return const StartSessionLinkLost();
+    }
+
     _sessionWriter = writer;
     _sessionName = sessionName;
     _decoder.resetContinuity();
@@ -158,8 +176,16 @@ class RecordingController extends ChangeNotifier {
       notifyListeners();
 
       // finalizeSession flushes through the writer's serialized queue, which
-      // drains any in-flight (unawaited) appends first.
-      final error = await SessionStorage.finalizeSession(writer: writer);
+      // drains any in-flight (unawaited) appends first. A failure there (e.g.
+      // the DB itself is gone) is folded into the returned error rather than
+      // thrown: stopSession also runs on unawaited auto-stop paths (link
+      // drop, writer error), where a throw would be an unhandled async error.
+      Object? error;
+      try {
+        error = await SessionStorage.finalizeSession(writer: writer);
+      } catch (e) {
+        error = e;
+      }
       if (error != null) {
         _events.emit(RecordingStorageError(error));
       }

--- a/lib/services/session_storage.dart
+++ b/lib/services/session_storage.dart
@@ -50,6 +50,13 @@ class SessionStorage {
     return LiveSessionWriter(sessionId, tare, DataHub.samplesPerSec);
   }
 
+  /// Discard a session that was created but never latched by its caller
+  /// (e.g. the link dropped while its row was being inserted — see
+  /// `RecordingController.startSession`). The writer has written no chunks,
+  /// so this is a plain row delete, not a recovery case.
+  static Future<void> discardSession(LiveSessionWriter writer) =>
+      AppDatabase.instance.deleteSession(writer.sessionId);
+
   /// Finalize a streaming session: flush any buffered samples, then record the
   /// aggregates the writer accumulated and mark the session completed.
   ///

--- a/test/gap_list_test.dart
+++ b/test/gap_list_test.dart
@@ -86,5 +86,22 @@ void main() {
       expect(GapList.fromJson('[]').isEmpty, isTrue);
       expect(GapList.fromJson('garbage').isEmpty, isTrue);
     });
+
+    test('fromJson rejects empty, inverted, and non-monotonic ranges', () {
+      // contains() binary-searches the sorted-disjoint invariant; corrupt
+      // documents must degrade to an empty list, not a corrupt one.
+      expect(GapList.fromJson('[[10,10]]').isEmpty, isTrue); // empty
+      expect(GapList.fromJson('[[10,5]]').isEmpty, isTrue); // inverted
+      expect(GapList.fromJson('[[30,40],[10,20]]').isEmpty, isTrue); // order
+      expect(GapList.fromJson('[[10,30],[20,40]]').isEmpty, isTrue); // overlap
+      expect(GapList.fromJson('[1,2]').isEmpty, isTrue); // wrong shape
+      expect(GapList.fromJson('[["a","b"]]').isEmpty, isTrue); // wrong types
+    });
+
+    test('fromJson accepts adjacent ranges (they merge on append)', () {
+      expect(GapList.fromJson('[[10,20],[20,30]]').rangesIn(0, 100).toList(), [
+        (10, 30),
+      ]);
+    });
   });
 }

--- a/test/recording_controller_test.dart
+++ b/test/recording_controller_test.dart
@@ -28,22 +28,23 @@ void main() {
     MockBlePlatform.instance.dropEveryNPackets = 0;
   });
 
-  (RecordingController, DataHub) wire() {
+  (RecordingController, DataHub, _StreamingLink) wire() {
     final events = AppEvents();
     final hub = DataHub();
     final decoder = AdcPacketDecoder(hub);
+    final link = _StreamingLink(events: events);
     final recording = RecordingController(
       dataHub: hub,
-      linkManager: _StreamingLink(events: events),
+      linkManager: link,
       decoder: decoder,
       events: events,
     );
     addTearDown(recording.dispose);
-    return (recording, hub);
+    return (recording, hub, link);
   }
 
   test('startSession refuses while a tare is averaging', () async {
-    final (recording, hub) = wire();
+    final (recording, hub, _) = wire();
 
     hub.requestTare();
     expect(hub.taring, isTrue);
@@ -63,7 +64,7 @@ void main() {
       AppDatabase.instance = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(AppDatabase.closeInstance);
 
-      final (recording, hub) = wire();
+      final (recording, hub, _) = wire();
 
       final start = await recording.startSession(
         channelLabels: const ['Load Cell 1', 'Load Cell 2', 'Ch 3', 'Ch 4'],
@@ -102,14 +103,75 @@ void main() {
       );
     },
   );
+
+  test(
+    'a link drop during session creation refuses and discards the row',
+    () async {
+      AppDatabase.instance = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(AppDatabase.closeInstance);
+
+      final (recording, _, link) = wire();
+
+      // Flip the flag synchronously, before the event loop can resume the
+      // creation future: this is the drop landing mid-insert. Without the
+      // post-await link re-check, the writer would latch onto the dead link —
+      // and a later reconnect would splice the new device's stream into it.
+      final future = recording.startSession(
+        channelLabels: const ['a', 'b', 'c', 'd'],
+        visibleChannels: const [true, true, true, true],
+      );
+      link.streaming = false;
+      final result = await future;
+
+      expect(result, isA<StartSessionLinkLost>());
+      expect(recording.sessionInProgress, isFalse);
+      // The orphan row was discarded, not left behind for crash recovery.
+      expect(await AppDatabase.instance.incompleteSessions(), isEmpty);
+    },
+  );
+
+  test(
+    'stopSession folds a finalization failure into the returned error',
+    () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.instance = db;
+      // Don't closeInstance() in teardown: this test closes the db itself.
+      addTearDown(() => AppDatabase.instance = null);
+
+      final (recording, hub, _) = wire();
+
+      final start = await recording.startSession(
+        channelLabels: const ['a', 'b', 'c', 'd'],
+        visibleChannels: const [true, true, true, true],
+      );
+      expect(start, isA<StartSessionOk>());
+
+      final frame = Int32List(DataHub.numAdcChannels);
+      hub.addSampleFrame(frame);
+      hub.commitBatch(0);
+
+      // Close the DB out from under the session: the finalizing completion
+      // write then throws. The failure must surface as the returned error —
+      // stopSession also runs on unawaited auto-stop paths, so it must never
+      // throw itself.
+      await db.close();
+
+      final stop = await recording.stopSession();
+      expect(recording.sessionInProgress, isFalse);
+      expect(stop.sessionId, isNotNull);
+      expect(stop.error, isNotNull);
+    },
+  );
 }
 
-/// A [BleLinkManager] that reports a streaming link, so
+/// A [BleLinkManager] whose streaming state is a plain settable flag, so
 /// [RecordingController.startSession]'s streaming precondition holds without
-/// driving a mock connection.
+/// driving a mock connection (and can be flipped mid-test to simulate a drop).
 class _StreamingLink extends BleLinkManager {
   _StreamingLink({required super.events});
 
+  bool streaming = true;
+
   @override
-  bool get isStreaming => true;
+  bool get isStreaming => streaming;
 }


### PR DESCRIPTION
## Bug fixes

- **Cross-device session splice**: `RecordingController.startSession` now
  re-checks the link after the session-row insert. Previously a link drop
  mid-insert left `_onLinkChanged` with no latched writer, so the session
  latched onto a dead link — and a later reconnect would stream the NEW
  device's data (post-clear, indices restarted) into the old session,
  including negative session-relative gap indices. The orphan row is
  discarded via the new `SessionStorage.discardSession`, and the caller gets
  a new `StartSessionLinkLost` outcome (snackbar in the live tab).
- **Unhandled async errors from auto-stops**: `stopSession` folds a
  `finalizeSession` throw (e.g. the DB is gone) into its returned error
  instead of throwing — it also runs on unawaited auto-stop paths (link
  drop, writer-error latch), where a throw is an unhandled async error.
- **Settings clobber on startup**: `AppSettings` setters record
  `_modifiedKeys`; the async `_load()` no longer overwrites a value the user
  changed while the SharedPreferences read was still in flight.
- **Corrupt gap metadata**: `GapList.fromJson` validates sorted, disjoint,
  non-empty ranges; empty, inverted, overlapping, or out-of-order documents
  degrade to an empty list instead of breaking the binary-search invariant.

## UI

- Session cards no longer show a peak: the row-wide value is a max over all
  channels and read inconsistently next to the detail view's per-channel
  peaks. Subtitle is now `date · duration · N ch`; the card's
  unit/calibration plumbing and the tab's `AppSettings` dependency went with
  it.

## Refactors (comment-only)

- The eight scattered "MULTI-DEVICE (Path A)" essays in
  `ble_link_manager.dart` are consolidated into one roadmap note on the
  class doc; individual sites keep at most a one-line pointer. No behavior
  change.

## Testing

- Regression: a link drop mid-`startSession` refuses and discards the row
  (deterministic — the flag flips synchronously before the drift future
  resumes).
- `stopSession` with the DB closed underneath returns the error, never
  throws.
- `GapList.fromJson` rejects empty/inverted/overlapping/out-of-order ranges
  and accepts adjacent (merging) ranges.

`flutter analyze` clean; 129/129 tests pass.