### PR TITLE
Simplify calibration settings branching; fix DMM field focus loss

### DIFF
--- a/lib/models/calibration.dart
+++ b/lib/models/calibration.dart
@@ -39,6 +39,25 @@ const int kLadderResistorCount = 6;
 /// dead short — a true zero independent of resistor values.
 const int kCalPointCount = 5;
 
+/// Storage-order indices of the cal points by signal role: the outermost
+/// points bracket a load cell's full-scale range, the middle one is the
+/// dead-short zero.
+const int kCalIdxPosFs = 0;
+const int kCalIdxPosMid = 1;
+const int kCalIdxZero = 2;
+const int kCalIdxNegMid = 3;
+const int kCalIdxNegFs = 4;
+
+/// Display labels for the [kCalPointCount] configs — the tap pairs wired at
+/// factory calibration, in storage order.
+const List<String> calConfigLabels = [
+  '(t1, t5)',
+  '(t2, t4)',
+  '(t3, t3)',
+  '(t4, t2)',
+  '(t5, t1)',
+];
+
 /// Nominal resistor values used when a channel's characterized values are
 /// absent from flash.
 const List<double> nominalLadderResistors = <double>[
@@ -154,15 +173,15 @@ class ChannelBoardCalibration {
 
   /// ADC offset in counts: the dead-short (t3,t3) reading measures it
   /// directly. 0 for an uncalibrated channel.
-  double get offsetCounts => readings?[2] ?? 0;
+  double get offsetCounts => readings?[kCalIdxZero] ?? 0;
 
   /// Terminal slope in counts per mV/V: the end-to-end slope between the two
   /// outermost cal points (which bracket a load cell's full-scale range).
   /// Cached (see [setpoints]).
   late final double spanCountsPerMvV = switch (readings) {
     final r? =>
-      (r[0] - r[kCalPointCount - 1]) /
-          (setpoints[0] - setpoints[kCalPointCount - 1]),
+      (r[kCalIdxPosFs] - r[kCalIdxNegFs]) /
+          (setpoints[kCalIdxPosFs] - setpoints[kCalIdxNegFs]),
     null => nominalCountsPerMvV,
   };
 
@@ -182,12 +201,14 @@ class ChannelBoardCalibration {
     final r = readings;
     if (r == null) return 0;
     final sp = setpoints;
-    // Storage order: 0 = +FS, 1 = +mid, 2 = zero, 3 = -mid, 4 = -FS.
-    final iFs = positiveSide ? 0 : 4;
-    final iMid = positiveSide ? 1 : 3;
+    final iFs = positiveSide ? kCalIdxPosFs : kCalIdxNegFs;
+    final iMid = positiveSide ? kCalIdxPosMid : kCalIdxNegMid;
     final lineAtMid =
-        r[2] + (r[iFs] - r[2]) * (sp[iMid] - sp[2]) / (sp[iFs] - sp[2]);
-    return (r[iMid] - lineAtMid) / (r[iFs] - r[2]).abs() * 1e6;
+        r[kCalIdxZero] +
+        (r[iFs] - r[kCalIdxZero]) *
+            (sp[iMid] - sp[kCalIdxZero]) /
+            (sp[iFs] - sp[kCalIdxZero]);
+    return (r[iMid] - lineAtMid) / (r[iFs] - r[kCalIdxZero]).abs() * 1e6;
   }
 
   /// Session-snapshot serialization (recorded sessions carry the calibration

--- a/lib/screens/settings_tab.dart
+++ b/lib/screens/settings_tab.dart
@@ -85,9 +85,11 @@ class SettingsTab extends StatelessWidget {
           const SectionHeader('Device settings'),
           const SizedBox(height: 16),
 
-          // Device name — not editable yet. Keyed by the name so the field
-          // rebuilds with the new value on connect/disconnect. While no link
-          // is up, a blurb with a jump to the Devices tab takes its place.
+          // Everything from here down belongs to the connected device: its
+          // name, the load cell slots and the factory board calibration are
+          // read from ITS flash (and the DMM cross-check is per-device
+          // memory). With no link up, none of it exists — only a connect
+          // prompt with a jump to the Devices tab shows.
           if (deviceId.isEmpty)
             Card(
               child: ListTile(
@@ -110,7 +112,9 @@ class SettingsTab extends StatelessWidget {
                 ),
               ),
             )
-          else
+          else ...[
+            // Device name — not editable yet. Keyed by the name so the
+            // field rebuilds with the new value on connect/disconnect.
             TextFormField(
               key: ValueKey(deviceName),
               initialValue: deviceName,
@@ -120,13 +124,8 @@ class SettingsTab extends StatelessWidget {
                 border: OutlineInputBorder(),
               ),
             ),
-          const SizedBox(height: 16),
+            const SizedBox(height: 16),
 
-          // Everything below belongs to the connected device: the load cell
-          // slots and the factory board calibration are read from ITS flash
-          // (and the DMM cross-check is per-device memory). With no link up,
-          // none of it exists — only the connect prompt shows.
-          if (deviceId.isNotEmpty) ...[
             // The connected device's load cell slots (the rig). Read from
             // the device at connect time; edits go back via "Save to
             // device".

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -106,7 +106,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   /// convert through SOMETHING (the documented pre-calibration behavior).
   ///
   /// The UI never reads this: the settings page shows the flash-document
-  /// owner's copy (`RigState.deviceBoardCalibration`), which carries the
+  /// owner's copy (`RigState.boardCalibrationFor`), which carries the
   /// device identity. This field describes the samples the hub holds.
   BoardCalibration? get boardCalibration => _boardCalibration;
   BoardCalibration? _boardCalibration;

--- a/lib/services/rig_state.dart
+++ b/lib/services/rig_state.dart
@@ -158,14 +158,18 @@ class RigState extends ChangeNotifier {
   /// are gated on this (see [_lastFlash]).
   bool get hasDeviceDoc => _lastFlash != null;
 
-  /// The device the current flash document belongs to.
-  String get flashDeviceId => _flashDeviceId;
-
-  /// The board half of the flash document, or null before the first read.
-  /// The settings UI reads factory calibration from HERE — the document
-  /// owner — never from the hub's conversion-side snapshot, so what renders
+  /// The board half of the flash document, but only while the document
+  /// belongs to [deviceId]: null before the first read of this run, and
+  /// null while the document on file came from ANOTHER device (it is kept
+  /// across disconnects — see [_flashDeviceId]). The settings UI's single
+  /// ownership query, decided HERE by the document owner: the hub's
+  /// conversion-side snapshot is never the UI's source, so what renders
   /// always belongs to an identified device.
-  BoardCalibration? get deviceBoardCalibration => _lastFlash?.board;
+  BoardCalibration? boardCalibrationFor(String deviceId) {
+    final flash = _lastFlash;
+    if (flash == null || _flashDeviceId != deviceId) return null;
+    return flash.board;
+  }
 
   List<RigHistoryEntry> get history => List.unmodifiable(_history);
 

--- a/lib/widgets/board_calibration_section.dart
+++ b/lib/widgets/board_calibration_section.dart
@@ -13,25 +13,27 @@ import '../services/rig_state.dart';
 /// measurement chain.
 ///
 /// Everything here is per-board data, so it comes from the flash-document
-/// owner ([RigState]) — never from the data hub's conversion-side snapshot —
-/// and renders only while the document belongs to [deviceId], the connected
-/// device. No device / no document / another device's document: a
-/// placeholder card, never nominal or stale values presented as real ones.
+/// owner ([RigState.boardCalibrationFor]) — never from the data hub's
+/// conversion-side snapshot — and renders only while the document belongs
+/// to [deviceId], the connected device. No device / no document / another
+/// device's document: a placeholder card, never nominal or stale values
+/// presented as real ones.
 class BoardCalibrationSection extends StatelessWidget {
   const BoardCalibrationSection({super.key, required this.deviceId});
 
   /// The connected device this section renders for. Passed in by the
   /// settings tab (which only includes the section while a link is up), so
   /// the section needs no link-manager dependency — and a flash document
-  /// belonging to any OTHER device is refused.
+  /// belonging to any OTHER device is refused by the ownership query.
   final String deviceId;
 
   @override
   Widget build(BuildContext context) {
     final rig = context.watch<RigState>();
-    final board = rig.deviceBoardCalibration;
-    final owned = rig.hasDeviceDoc && rig.flashDeviceId == deviceId;
-    if (!owned || board == null) {
+    // One ownership query, decided by the document owner: null means no
+    // document this run, or a document belonging to another device.
+    final board = rig.boardCalibrationFor(deviceId);
+    if (board == null) {
       return const Card(
         child: ListTile(
           leading: Icon(Icons.phonelink_erase, color: Colors.grey),
@@ -80,8 +82,12 @@ class BoardCalibrationSection extends StatelessWidget {
           style: Theme.of(context).textTheme.bodySmall,
         ),
         const SizedBox(height: 8),
+        // Deliberately keyless: every device transition unmounts this field
+        // (the settings gate or the placeholder card takes its place), so
+        // the initial value always matches the device on screen. Keying it
+        // by the value would instead rebuild it per keystroke — a new field
+        // each time, focus lost mid-typing.
         TextFormField(
-          key: ValueKey('dmm$dmmMv'),
           initialValue: dmmMv?.toString() ?? '',
           keyboardType: const TextInputType.numberWithOptions(decimal: true),
           decoration: const InputDecoration(
@@ -103,12 +109,16 @@ class BoardCalibrationSection extends StatelessWidget {
         ),
         if (dmmMv != null) ...[
           const SizedBox(height: 8),
+          // Only factory-calibrated channels have a measured span to compare
+          // against the DMM. A nominal channel would just echo the nominal
+          // 4.53 V assumption back as a fake "gain error".
           for (int i = 0; i < board.channels.length; i++)
-            Text(
-              'Ch ${i + 1}: implied chain gain error '
-              '${_gainErrorPercent(board.channels[i], dmmMv)}',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
+            if (board.channels[i].isFactoryCalibrated)
+              Text(
+                'Ch ${i + 1}: implied chain gain error '
+                '${_gainErrorPercent(board.channels[i], dmmMv)}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
         ],
       ],
     );
@@ -131,14 +141,6 @@ class _ChannelCalTile extends StatelessWidget {
 
   final int index;
   final ChannelBoardCalibration channel;
-
-  static const _configLabels = [
-    '(t1, t5)',
-    '(t2, t4)',
-    '(t3, t3)',
-    '(t4, t2)',
-    '(t5, t1)',
-  ];
 
   @override
   Widget build(BuildContext context) {
@@ -192,7 +194,7 @@ class _ChannelCalTile extends StatelessWidget {
                       for (int k = 0; k < kCalPointCount; k++)
                         TableRow(
                           children: [
-                            _td(_configLabels[k]),
+                            _td(calConfigLabels[k]),
                             _td(channel.setpoints[k].toStringAsFixed(4)),
                             _td(channel.readings![k].toStringAsFixed(1)),
                           ],

--- a/test/board_calibration_section_test.dart
+++ b/test/board_calibration_section_test.dart
@@ -30,6 +30,7 @@ void main() {
     WidgetTester tester, {
     bool withFlash = true,
     String deviceId = 'dev1',
+    String? flashDoc,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final rig = RigState(transport: _FakeTransport());
@@ -37,7 +38,7 @@ void main() {
       rig.onFlashRead(
         'dev1',
         'Bench unit',
-        DeviceFlash.parse(demoBoardCalibrationDoc),
+        DeviceFlash.parse(flashDoc ?? demoBoardCalibrationDoc),
       );
     }
     await tester.pumpWidget(
@@ -149,17 +150,50 @@ void main() {
     tester,
   ) async {
     final rig = await pump(tester);
-    await rig.setMeasuredExcitationMv(4530.24);
-    await tester.pump();
 
     final field = find.widgetWithText(
       TextFormField,
       'Your DMM excitation reading (mV)',
     );
+    await tester.enterText(field, '4530.24');
+    await tester.pumpAndSettle();
+    expect(rig.measuredExcitationMv, closeTo(4530.24, 1e-9));
+    expect(find.textContaining('implied chain gain error'), findsNWidgets(4));
+
     await tester.enterText(field, '');
     await tester.pumpAndSettle();
 
     expect(rig.measuredExcitationMv, isNull);
     expect(find.textContaining('implied chain gain error'), findsNothing);
+  });
+
+  testWidgets('DMM gain error rows cover factory-calibrated channels only', (
+    tester,
+  ) async {
+    // Only CH1 of this document has factory data: the cross-check has a
+    // measured span to compare only there — a nominal channel would just
+    // echo the nominal 4.53 V assumption back as a fake "gain error".
+    const partialCalDoc = '''
+K3CAL1
+ch0.r=10000.8,10.0012,9.9991,10.0008,10.0003,9999.4
+ch0.raw=6386310.2,3193480.0,845.2,-3191769.6,-6384619.8
+END
+''';
+    await pump(tester, flashDoc: partialCalDoc);
+
+    // The header reflects the single calibrated channel.
+    expect(find.textContaining('1 of 4 channels'), findsOneWidget);
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Your DMM excitation reading (mV)'),
+      '4530.24',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('implied chain gain error'), findsOneWidget);
+    expect(
+      find.textContaining('Ch 1: implied chain gain error'),
+      findsOneWidget,
+    );
   });
 }

--- a/test/rig_state_test.dart
+++ b/test/rig_state_test.dart
@@ -76,6 +76,20 @@ void main() {
       expect(seen, isEmpty);
     });
 
+    test('boardCalibrationFor gates on document ownership', () async {
+      final rig = await settledRig();
+
+      // No flash document read yet.
+      expect(rig.boardCalibrationFor('dev1'), isNull);
+
+      rig.onFlashRead('dev1', 'Bench unit', fixture());
+      // The connected device gets its own document…
+      expect(rig.boardCalibrationFor('dev1'), isNotNull);
+      // …any other device is refused — a stale or foreign document never
+      // renders as the connected device's calibration.
+      expect(rig.boardCalibrationFor('dev2'), isNull);
+    });
+
     test('an identical re-read is quiet', () async {
       final rig = await settledRig();
       rig.onFlashRead('dev1', 'Bench unit', fixture());


### PR DESCRIPTION
## Summary

Shrinks the branch surface of the settings-page calibration view and fixes two bugs found along the way.

- **DMM field focus loss (bug)**: the field was keyed by its own value, so every valid keystroke rebuilt it — focus dropped mid-typing and the text reformatted as you typed. Now keyless: every device transition already unmounts the field (settings gate or placeholder card), so its initial value always matches the device on screen.
- **Misleading gain-error rows (bug)**: the DMM cross-check rendered a row for every channel; on uncalibrated ones that just echoed the nominal 4.53 V assumption back as a fake "error". Rows now cover only factory-calibrated channels.
- **Single ownership query**: RigState.boardCalibrationFor(deviceId) replaces the getter plus widget-side recombination (which included a dead `|| board == null` branch). The document owner decides what may render, and the rule is unit-tested. The flashDeviceId getter, now unused, is removed too.
- **One device gate**: the settings tab's two deviceId checks merged into one if/else — the device-owned region is a single block.
- **Ladder storage order, one owner**: role-named index constants (kCalIdxZero, kCalIdxPosFs, ...) and the config labels live in calibration.dart next to the format docs, replacing magic indices and the widget's private label copy.

## Testing

- 251 tests pass, flutter analyze clean.
- New: boardCalibrationFor ownership gating unit test; mixed-board widget test pinning that gain-error rows skip uncalibrated channels.
- Reworked the DMM-clearing widget test to drive the UI (type, then clear) instead of writing the model behind the field's back — that setup was coupled to the removed key.