### PR TITLE
Slim down settings/calibration: cut DMM cross-check and change notices, inject prefs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'models/app_settings.dart';
 import 'services/adc_packet_decoder.dart';
@@ -31,6 +32,9 @@ void main() async {
   // Repair any sessions left incomplete by a crash before the UI reads the
   // session list, so partial sessions are finalized (or pruned) first.
   await SessionStorage.recoverIncompleteSessions();
+  // Prefs are resolved here and injected into their owners, so their loads
+  // are synchronous constructor work and can never race a user edit.
+  final prefs = await SharedPreferences.getInstance();
 
   // Object graph, one layer per concern:
   //   BleLinkManager (link state machine) --raw bytes--> AdcPacketDecoder
@@ -45,13 +49,13 @@ void main() async {
   final linkManager = BleLinkManager(events: appEvents)
     ..onAdcData = decoder.onDataPacket
     ..onCalibrationData = decoder.onCalibrationPacket;
-  final rigState = RigState(transport: linkManager, events: appEvents);
+  final rigState = RigState(transport: linkManager, prefs: prefs);
   // Flash documents (board + slots) arrive via the decoder: the hub takes
   // the board, RigState takes the whole document. The device id/name are
   // read off the link at delivery time (the read only ever runs against the
   // active link).
   decoder.onDeviceFlash = (flash) => rigState.onFlashRead(
-    linkManager.selectedDeviceId,
+    linkManager.connectedDeviceId,
     linkManager.connectedDeviceName,
     flash,
   );
@@ -61,7 +65,7 @@ void main() async {
     decoder: decoder,
     events: appEvents,
   );
-  final appSettings = AppSettings();
+  final appSettings = AppSettings(prefs: prefs);
   // Push the effective per-channel load cells (device slots, including
   // unsaved edits) into the data layer now and on every rig change.
   // Content-equal pushes are a no-op inside the hub.

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -9,12 +9,34 @@ import 'force_unit.dart';
 /// Application-wide settings, persisted via SharedPreferences.
 ///
 /// Deliberately NOT here: channel labels (gone — row titles come from the
-/// rig's load cell slots), everything load cell (device slots, history —
-/// owned by `RigState`), and the DMM excitation cross-check (a measurement
-/// OF one board — per-device memory in `RigState`, never app-global).
-/// Legacy keys from the pre-slot model are erased on load; there are no
-/// field devices, so no migration is performed.
+/// rig's load cell slots) and everything load cell (device slots, history —
+/// owned by `RigState`). Legacy keys from the pre-slot model are erased on
+/// load; there are no field devices, so no migration is performed.
 class AppSettings extends ChangeNotifier {
+  /// [prefs] is injected (see `main`): the instance is available
+  /// synchronously, so the load happens right here in the constructor and
+  /// can never race a later setter.
+  AppSettings({required SharedPreferences prefs}) : _prefs = prefs {
+    for (final key in _legacyKeys) {
+      unawaited(_prefs.remove(key));
+    }
+
+    final unitName = _prefs.getString(_keyUnit);
+    if (unitName != null) {
+      _displayUnit = ForceUnit.values.firstWhere(
+        (u) => u.name == unitName,
+        orElse: () => ForceUnit.mVv,
+      );
+    }
+
+    final active = _prefs.getStringList(_keyActiveChannels);
+    if (active != null && active.length == nwNumAdcChan) {
+      _activeChannels = active.map((s) => s == 'true').toList();
+    }
+
+    _wakelockEnabled = _prefs.getBool(_keyWakelock) ?? false;
+  }
+
   static const String _keyUnit = 'display_unit';
   static const String _keyActiveChannels = 'active_channels';
   static const String _keyWakelock = 'wakelock_enabled';
@@ -27,6 +49,8 @@ class AppSettings extends ChangeNotifier {
     'channel_load_cells',
     'measured_excitation_mv',
   ];
+
+  final SharedPreferences _prefs;
 
   // mV/V is the default: it converts with board calibration alone, so a
   // fresh install shows meaningful numbers before any load cell is assigned
@@ -48,69 +72,24 @@ class AppSettings extends ChangeNotifier {
   bool _wakelockEnabled = false;
   bool get wakelockEnabled => _wakelockEnabled;
 
-  /// Preference keys the user has explicitly set through a setter. [_load]'s
-  /// async read resolves AFTER the constructor returns, so a setter that ran
-  /// in the meantime owns the in-memory value — [_load] must not overwrite it
-  /// with the (older) persisted one.
-  final Set<String> _modifiedKeys = {};
-
-  AppSettings() {
-    unawaited(_load());
-  }
-
-  Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
-
-    for (final key in _legacyKeys) {
-      await prefs.remove(key);
-    }
-
-    final unitName = prefs.getString(_keyUnit);
-    if (unitName != null && !_modifiedKeys.contains(_keyUnit)) {
-      _displayUnit = ForceUnit.values.firstWhere(
-        (u) => u.name == unitName,
-        orElse: () => ForceUnit.mVv,
-      );
-    }
-
-    final active = prefs.getStringList(_keyActiveChannels);
-    if (active != null &&
-        active.length == nwNumAdcChan &&
-        !_modifiedKeys.contains(_keyActiveChannels)) {
-      _activeChannels = active.map((s) => s == 'true').toList();
-    }
-
-    if (!_modifiedKeys.contains(_keyWakelock)) {
-      _wakelockEnabled = prefs.getBool(_keyWakelock) ?? false;
-    }
-
-    notifyListeners();
-  }
-
   Future<void> setDisplayUnit(ForceUnit unit) async {
-    _modifiedKeys.add(_keyUnit);
     _displayUnit = unit;
     notifyListeners();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_keyUnit, unit.name);
+    await _prefs.setString(_keyUnit, unit.name);
   }
 
   Future<void> setChannelActive(int index, bool active) async {
-    _modifiedKeys.add(_keyActiveChannels);
     _activeChannels[index] = active;
     notifyListeners();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(
+    await _prefs.setStringList(
       _keyActiveChannels,
       _activeChannels.map((b) => b.toString()).toList(),
     );
   }
 
   Future<void> setWakelockEnabled(bool enabled) async {
-    _modifiedKeys.add(_keyWakelock);
     _wakelockEnabled = enabled;
     notifyListeners();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_keyWakelock, enabled);
+    await _prefs.setBool(_keyWakelock, enabled);
   }
 }

--- a/lib/models/calibration.dart
+++ b/lib/models/calibration.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import '../services/adc_protocol.dart';
 
 /// Analog front-end constants (fixed by hardware): the load cell signal
@@ -107,9 +105,8 @@ List<double> ladderSetpointsMvV(List<double> resistors) {
 /// behavior.
 class ChannelBoardCalibration {
   ChannelBoardCalibration({List<double>? resistors, List<double>? readings})
-    : resistors = List.unmodifiable(resistors ?? nominalLadderResistors),
+    : resistors = _validatedResistors(resistors),
       readings = _validatedReadings(readings) {
-    assert(this.resistors.length == kLadderResistorCount);
     final r = this.readings;
     if (r != null) {
       // Sort the five points ascending by raw reading for interpolation.
@@ -121,12 +118,39 @@ class ChannelBoardCalibration {
     }
   }
 
-  /// Reject degenerate readings (duplicate points would divide by zero
-  /// during interpolation) by treating the channel as uncalibrated.
+  /// Corrupt resistor values degrade to the nominal ladder: a real ladder
+  /// resistor is ~10k/~10 ohms, and a zero or negative value would produce
+  /// nonsense setpoints (or a zero ladder total → NaN).
+  static List<double> _validatedResistors(List<double>? r) {
+    if (r == null) return nominalLadderResistors;
+    assert(r.length == kLadderResistorCount);
+    for (final v in r) {
+      if (v <= 0) return nominalLadderResistors;
+    }
+    return List.unmodifiable(r);
+  }
+
+  /// Reject unusable readings by treating the channel as uncalibrated:
+  /// values beyond the ADC's bipolar range can't have come from hardware,
+  /// and duplicates (exact or near) would divide by ~zero during
+  /// interpolation — a real ladder spread is millions of counts, so a
+  /// sub-thousand-count gap can only be corrupt flash.
   static List<double>? _validatedReadings(List<double>? r) {
     if (r == null) return null;
     assert(r.length == kCalPointCount);
-    if (r.toSet().length != r.length) return null;
+    final sorted = [...r]..sort();
+    for (final v in sorted) {
+      // 'NaN'/'Infinity' parse fine with double.tryParse — reject them and
+      // anything beyond the ADC's bipolar range: neither came from hardware.
+      if (!v.isFinite ||
+          v >= adcCountsPerPolarity ||
+          v < -adcCountsPerPolarity) {
+        return null;
+      }
+    }
+    for (int i = 1; i < sorted.length; ++i) {
+      if (sorted[i] - sorted[i - 1] < 1000) return null;
+    }
     return List.unmodifiable(r);
   }
 
@@ -150,23 +174,20 @@ class ChannelBoardCalibration {
   /// Map an absolute raw ADC reading to mV/V of excitation via the piecewise
   /// map. Out-of-range readings extend the outermost segment. Readings are
   /// absolute (offset included): net values come from subtracting the map at
-  /// the tare point — see [ChannelCalibration.netMvV].
+  /// the tare point — see `ForceUnit.converterFor`.
   double mvVFromRaw(double raw) {
     final r = readings;
     if (r == null) return raw / nominalCountsPerMvV;
     final xs = _sortedRaw;
     final ys = _sortedSetpoints;
-    if (raw <= xs[0]) {
-      return ys[0] + (raw - xs[0]) * (ys[1] - ys[0]) / (xs[1] - xs[0]);
+    // Right endpoint of the segment containing raw, clamped to the outer
+    // segments: below/above the cal range extrapolates along them.
+    var i = 1;
+    while (i < xs.length - 1 && raw > xs[i]) {
+      ++i;
     }
-    for (int i = 1; i < xs.length; ++i) {
-      if (raw <= xs[i]) {
-        return ys[i - 1] +
-            (raw - xs[i - 1]) * (ys[i] - ys[i - 1]) / (xs[i] - xs[i - 1]);
-      }
-    }
-    final n = xs.length - 1;
-    return ys[n] + (raw - xs[n]) * (ys[n] - ys[n - 1]) / (xs[n] - xs[n - 1]);
+    return ys[i - 1] +
+        (raw - xs[i - 1]) * (ys[i] - ys[i - 1]) / (xs[i] - xs[i - 1]);
   }
 
   // -- Diagnostics ----------------------------------------------------------
@@ -252,13 +273,6 @@ class BoardCalibration {
   /// Factory DMM reading of the excitation (`cal.exc.mv`), if any.
   final double? excitationMv;
 
-  /// Every channel on the nominal chain (no factory data anywhere).
-  factory BoardCalibration.nominal() => BoardCalibration(
-    channels: [
-      for (int i = 0; i < nwNumAdcChan; ++i) ChannelBoardCalibration(),
-    ],
-  );
-
   /// Parse the board-calibration keys of a `key=value` flash document.
   /// Slot (`lcN.*`) and other unknown keys are ignored. Never throws — see
   /// [DeviceFlash.parse].
@@ -287,11 +301,6 @@ class BoardCalibration {
       excitationMv: double.tryParse(kv['cal.exc.mv'] ?? ''),
     );
   }
-
-  /// Serialize the board-calibration keys as a full flash document (no
-  /// slots). Convenience wrapper over [DeviceFlash.serialize].
-  String serialize() =>
-      DeviceFlash(board: this, slots: RigSlots.empty()).serialize();
 }
 
 /// Split a `key=value` flash document into a map. Lines without `key=value`
@@ -317,6 +326,11 @@ Map<String, String> parseFlashKv(String text) {
 /// the channels (the plugged-in rig); the rest are spares carried on the
 /// device. Constant for the first prototype.
 const int kRigSlotCount = 10;
+
+/// Display label for slot [i]: the first [nwNumAdcChan] slots are the
+/// channels ('CH 1'…), the rest numbered spares ('Slot 5'…).
+String rigSlotTitle(int i) =>
+    i < nwNumAdcChan ? 'CH ${i + 1}' : 'Slot ${i + 1}';
 
 /// One populated device slot: the cell plus the write timestamp from flash
 /// (display metadata only — never a sync arbiter).
@@ -367,14 +381,7 @@ class RigSlots {
 
   /// Channel row titles: the cell's title, or the bare channel name.
   List<String> get channelTitles => [
-    for (int i = 0; i < nwNumAdcChan; ++i) cellAt(i)?.title ?? 'CH ${i + 1}',
-  ];
-
-  /// Per-slot content signatures (cell JSON, null for empty). Compared
-  /// against a stored copy to detect "changed since your last visit"; mtime
-  /// is deliberately excluded (a pure rewrite is not a change).
-  List<String?> get signatures => [
-    for (final s in slots) s == null ? null : jsonEncode(s.cell.toJson()),
+    for (int i = 0; i < nwNumAdcChan; ++i) cellAt(i)?.title ?? rigSlotTitle(i),
   ];
 
   RigSlots withSlot(int i, RigSlot? slot) => RigSlots([
@@ -563,9 +570,9 @@ class LoadCellProfile {
 // ---------------------------------------------------------------------------
 
 /// Everything needed to convert one channel's raw ADC counts into display
-/// units: the board piecewise map plus the assigned load cell (if any).
-/// Net values are differences of the board map between a reading and the
-/// tare point, so piecewise nonlinearity is applied on both sides.
+/// units: the board piecewise map plus the assigned load cell (if any). Net
+/// values are differences of the board map between a reading and the tare
+/// point, so piecewise nonlinearity is applied on both sides.
 class ChannelCalibration {
   const ChannelCalibration({required this.board, this.loadCell});
 
@@ -574,29 +581,6 @@ class ChannelCalibration {
   /// Assigned load cell; null means "electrical units only" — force
   /// conversions report unavailable and the UI shows '—'.
   final LoadCellProfile? loadCell;
-
-  double netMvV(double raw, double tare) =>
-      board.mvVFromRaw(raw) - board.mvVFromRaw(tare);
-
-  /// Net mV at the load cell output, via the board's effective excitation.
-  double netMv(double raw, double tare) =>
-      netMvV(raw, tare) * board.effectiveExcitationV;
-
-  double netRaw(double raw, double tare) => raw - tare;
-
-  /// Net force in kgf, or null when no load cell is assigned.
-  double? netKgf(double raw, double tare) {
-    final lc = loadCell;
-    if (lc == null) return null;
-    return netMvV(raw, tare) * lc.kgfPerMvV;
-  }
-
-  /// Local piecewise slope (mV/V per count) at [raw] — for derivative
-  /// display, where differencing the map would need two evaluations anyway.
-  double mvVPerCountAt(double raw) {
-    const h = 0.5;
-    return (board.mvVFromRaw(raw + h) - board.mvVFromRaw(raw - h)) / (2 * h);
-  }
 
   /// Session-snapshot serialization.
   Map<String, dynamic> toJson() => {

--- a/lib/models/force_unit.dart
+++ b/lib/models/force_unit.dart
@@ -35,6 +35,20 @@ enum ForceUnit {
   /// board calibration. Drives the Settings picker's grouping.
   bool get isForce => kgfFactor != null;
 
+  /// The multiplier applied to net mV/V for this unit on [channel]: force
+  /// units fold in the cell's kgf-per-mV/V, mV folds in the board's
+  /// effective excitation, mV/V is unity. Null when the unit is unavailable
+  /// on the channel (a force unit with no load cell assigned). Raw counts
+  /// bypass the board map entirely and never consult this.
+  double? _scalePerMvV(ChannelCalibration channel) {
+    final f = kgfFactor;
+    if (f != null) {
+      final cell = channel.loadCell;
+      return cell == null ? null : f * cell.kgfPerMvV;
+    }
+    return this == ForceUnit.mV ? channel.board.effectiveExcitationV : 1.0;
+  }
+
   /// Build the absolute-raw -> display-unit converter for one channel, net of
   /// [tare] (the board map is evaluated at both points and differenced, so
   /// piecewise nonlinearity applies on both sides). Monotone nondecreasing.
@@ -48,22 +62,12 @@ enum ForceUnit {
     ChannelCalibration channel,
     double tare,
   ) {
+    if (this == ForceUnit.raw) return (raw) => raw - tare;
+    final scale = _scalePerMvV(channel);
+    if (scale == null) return null;
     final board = channel.board;
     final tareMvV = board.mvVFromRaw(tare);
-    final f = kgfFactor;
-    if (f != null) {
-      final cell = channel.loadCell;
-      if (cell == null) return null;
-      final scale = f * cell.kgfPerMvV;
-      return (raw) => (board.mvVFromRaw(raw) - tareMvV) * scale;
-    }
-    return switch (this) {
-      ForceUnit.mVv => (raw) => board.mvVFromRaw(raw) - tareMvV,
-      ForceUnit.mV =>
-        (raw) => (board.mvVFromRaw(raw) - tareMvV) * board.effectiveExcitationV,
-      ForceUnit.raw => (raw) => raw - tare,
-      _ => throw StateError('$this is a force unit'),
-    };
+    return (raw) => (board.mvVFromRaw(raw) - tareMvV) * scale;
   }
 
   /// Build the raw-diff -> display-unit converter for one channel (no tare:
@@ -74,21 +78,11 @@ enum ForceUnit {
   double Function(double rawDiff)? diffConverterFor(
     ChannelCalibration channel,
   ) {
-    final span = channel.board.spanCountsPerMvV;
-    final f = kgfFactor;
-    if (f != null) {
-      final cell = channel.loadCell;
-      if (cell == null) return null;
-      final scale = f * cell.kgfPerMvV / span;
-      return (diff) => diff * scale;
-    }
-    return switch (this) {
-      ForceUnit.mVv => (diff) => diff / span,
-      ForceUnit.mV =>
-        (diff) => diff / span * channel.board.effectiveExcitationV,
-      ForceUnit.raw => (diff) => diff,
-      _ => throw StateError('$this is a force unit'),
-    };
+    if (this == ForceUnit.raw) return (diff) => diff;
+    final scale = _scalePerMvV(channel);
+    if (scale == null) return null;
+    final perCount = scale / channel.board.spanCountsPerMvV;
+    return (diff) => diff * perCount;
   }
 
   /// Format a [value] (already in this unit) with an explicit sign, and a

--- a/lib/screens/app_shell.dart
+++ b/lib/screens/app_shell.dart
@@ -99,17 +99,6 @@ class AppShellState extends State<AppShell> {
             showCloseIcon: true,
           ),
         );
-      case RigChangedSinceLastVisit(:final deviceName, :final changes):
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text(
-              'Load cells on $deviceName changed since your last visit:\n'
-              '${changes.join('\n')}',
-            ),
-            duration: const Duration(seconds: 8),
-            showCloseIcon: true,
-          ),
-        );
       case CalibrationUnreadable(:final deviceName):
         messenger.showSnackBar(
           SnackBar(

--- a/lib/screens/settings_tab.dart
+++ b/lib/screens/settings_tab.dart
@@ -16,13 +16,16 @@ import 'app_shell.dart';
 class SettingsTab extends StatelessWidget {
   const SettingsTab({super.key});
 
+  /// Fetched once per process, not per rebuild of the tab.
+  static final Future<PackageInfo> _packageInfo = PackageInfo.fromPlatform();
+
   @override
   Widget build(BuildContext context) {
     final settings = context.watch<AppSettings>();
     // Narrow selects: the link manager notifies on every RSSI poll, but the
     // device section only cares about identity changes.
     final deviceId = context.select<BleLinkManager, String>(
-      (l) => l.selectedDeviceId,
+      (l) => l.connectedDeviceId,
     );
     final deviceName = context.select<BleLinkManager, String>(
       (l) => l.connectedDeviceName,
@@ -43,30 +46,20 @@ class SettingsTab extends StatelessWidget {
           // Display units
           Text('Display Units', style: Theme.of(context).textTheme.titleSmall),
           const SizedBox(height: 8),
-          for (final (label, units) in [
-            ('Force', ForceUnit.values.where((u) => u.isForce)),
-            ('Electrical', ForceUnit.values.where((u) => !u.isForce)),
-          ]) ...[
-            Text(label, style: Theme.of(context).textTheme.labelMedium),
-            const SizedBox(height: 4),
-            SegmentedButton<ForceUnit>(
-              segments: [
-                for (final u in units)
-                  ButtonSegment(value: u, label: Text(u.symbol)),
-              ],
-              selected: {settings.displayUnit},
-              // The default selected checkmark steals width from the labels
-              // and makes the segments wrap on narrow (mobile) screens.
-              showSelectedIcon: false,
-              emptySelectionAllowed: true,
-              onSelectionChanged: (set) {
-                if (set.isNotEmpty) {
-                  unawaited(settings.setDisplayUnit(set.first));
-                }
-              },
-            ),
-            const SizedBox(height: 8),
-          ],
+          _UnitGroup(
+            label: 'Force',
+            units: [
+              for (final u in ForceUnit.values)
+                if (u.isForce) u,
+            ],
+          ),
+          _UnitGroup(
+            label: 'Electrical',
+            units: [
+              for (final u in ForceUnit.values)
+                if (!u.isForce) u,
+            ],
+          ),
           const SizedBox(height: 16),
 
           // Wakelock
@@ -87,9 +80,8 @@ class SettingsTab extends StatelessWidget {
 
           // Everything from here down belongs to the connected device: its
           // name, the load cell slots and the factory board calibration are
-          // read from ITS flash (and the DMM cross-check is per-device
-          // memory). With no link up, none of it exists — only a connect
-          // prompt with a jump to the Devices tab shows.
+          // read from ITS flash. With no link up, none of it exists — only
+          // a connect prompt with a jump to the Devices tab shows.
           if (deviceId.isEmpty)
             Card(
               child: ListTile(
@@ -149,7 +141,7 @@ class SettingsTab extends StatelessWidget {
           const SectionHeader('About'),
           const SizedBox(height: 16),
           FutureBuilder<PackageInfo>(
-            future: PackageInfo.fromPlatform(),
+            future: _packageInfo,
             builder: (context, snapshot) {
               if (snapshot.hasData) {
                 final packageInfo = snapshot.data!;
@@ -178,6 +170,40 @@ class SettingsTab extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// One row of the display-units picker: a label above a segmented button
+/// covering one unit family (force or electrical).
+class _UnitGroup extends StatelessWidget {
+  const _UnitGroup({required this.label, required this.units});
+
+  final String label;
+  final List<ForceUnit> units;
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = context.watch<AppSettings>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: Theme.of(context).textTheme.labelMedium),
+        const SizedBox(height: 4),
+        SegmentedButton<ForceUnit>(
+          segments: [
+            for (final u in units)
+              ButtonSegment(value: u, label: Text(u.symbol)),
+          ],
+          selected: {settings.displayUnit},
+          // The default selected checkmark steals width from the labels
+          // and makes the segments wrap on narrow (mobile) screens.
+          showSelectedIcon: false,
+          onSelectionChanged: (set) =>
+              unawaited(settings.setDisplayUnit(set.first)),
+        ),
+        const SizedBox(height: 8),
+      ],
     );
   }
 }

--- a/lib/services/app_events.dart
+++ b/lib/services/app_events.dart
@@ -47,17 +47,6 @@ class RecordingStorageError extends AppEvent {
   final Object error;
 }
 
-/// The connected device's load cell slots differ from what this app last saw
-/// on it (another host wrote, or cells were swapped). Informational only —
-/// the device is the rig's truth, so there is nothing to resolve. [changes]
-/// holds one human-readable line per changed slot.
-class RigChangedSinceLastVisit extends AppEvent {
-  const RigChangedSinceLastVisit(this.deviceName, this.changes);
-
-  final String deviceName;
-  final List<String> changes;
-}
-
 /// The device's calibration characteristic could not be read; the app runs
 /// on nominal values (no factory calibration) until a read succeeds.
 class CalibrationUnreadable extends AppEvent {

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -337,7 +337,8 @@ class BleLinkManager extends ChangeNotifier implements RigFlashTransport {
 
   /// Device id of the active link whenever the GATT link is up (during setup or
   /// while streaming); empty otherwise.
-  String get selectedDeviceId => _link.isLinkUp ? _link.deviceId : '';
+  @override
+  String get connectedDeviceId => _link.isLinkUp ? _link.deviceId : '';
 
   /// Name of the currently connected device.
   @override
@@ -430,9 +431,6 @@ class BleLinkManager extends ChangeNotifier implements RigFlashTransport {
   String _demoFlashDoc = demoBoardCalibrationDoc;
 
   // -- RigFlashTransport ------------------------------------------------------
-
-  @override
-  String get connectedDeviceId => selectedDeviceId;
 
   /// Write a serialized `DeviceFlash` document to the connected device.
   /// Called only by `RigState.saveToDevice`, which has already composed the

--- a/lib/services/rig_state.dart
+++ b/lib/services/rig_state.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/calibration.dart';
-import 'app_events.dart';
 
 /// The piece of the BLE stack [RigState] needs: which device is connected,
 /// and a way to write the whole flash document back to it. Implemented by
@@ -70,7 +69,6 @@ class PendingRigEdits {
     required this.deviceId,
     required this.base,
     required this.edited,
-    required this.startedAt,
   });
 
   final String deviceId;
@@ -81,35 +79,44 @@ class PendingRigEdits {
 
   /// The edited slot list (what the app's readings already use).
   RigSlots edited;
-
-  final DateTime startedAt;
 }
 
 /// Owns the rig: the slot list read from the connected device, unsaved
-/// edits, the cross-device cell history, per-device change detection, and
-/// per-device user memory (the DMM excitation cross-check).
+/// edits, and the cross-device cell history.
 ///
 /// The model is deliberately low-state: the device flash is the ONLY rig
 /// truth; this class adds (a) pending edits the user hasn't saved yet and
-/// (b) advisory memory (history, last-seen signatures, DMM readings) that
-/// can inform and warn but never competes with the device.
+/// (b) advisory history that can inform but never competes with the device.
 class RigState extends ChangeNotifier {
-  RigState({required RigFlashTransport transport, AppEvents? events})
-    : _transport = transport,
-      _events = events {
-    unawaited(_load());
+  /// [prefs] is injected (see `main`): the instance is available
+  /// synchronously, so the history load happens right here in the
+  /// constructor and can never race a later setter.
+  RigState({
+    required RigFlashTransport transport,
+    required SharedPreferences prefs,
+  }) : _transport = transport,
+       _prefs = prefs {
+    // Keys of removed subsystems (per-device change detection, the DMM
+    // cross-check), erased on load; there are no field devices, so no
+    // migration is performed.
+    for (final key in _legacyKeys) {
+      unawaited(_prefs.remove(key));
+    }
+    _loadHistory();
   }
 
   static const String _keyHistory = 'rig_history';
-  static const String _keyLastSeen = 'rig_lastseen';
-  static const String _keyDmm = 'rig_dmm_excitation_mv';
+  static const List<String> _legacyKeys = [
+    'rig_lastseen',
+    'rig_dmm_excitation_mv',
+  ];
 
   /// History is a suggestion list, not an archive — cap it so it stays
   /// scannable (least-recently-seen evicted).
   static const int historyCap = 50;
 
   final RigFlashTransport _transport;
-  final AppEvents? _events;
+  final SharedPreferences _prefs;
 
   /// The flash document as last read from the connected device (board +
   /// slots). Null before the first successful read of this run — and save is
@@ -126,17 +133,6 @@ class RigState extends ChangeNotifier {
   PendingRigEdits? _pending;
 
   List<RigHistoryEntry> _history = [];
-  Map<String, List<String?>> _lastSeenByDevice = {};
-
-  /// The user's own DMM excitation readings (mV), keyed by device id. A DMM
-  /// reading measures ONE board's hardware, so it is per-device memory —
-  /// never an app-global value (that would compare one device against
-  /// another's calibration).
-  Map<String, double> _dmmByDevice = {};
-
-  /// Preference keys written since construction (the async [_load] must not
-  /// clobber them — same race as in AppSettings).
-  final Set<String> _modifiedKeys = {};
 
   // -- Reads -----------------------------------------------------------------
 
@@ -173,79 +169,32 @@ class RigState extends ChangeNotifier {
 
   List<RigHistoryEntry> get history => List.unmodifiable(_history);
 
-  /// The user's DMM excitation reading (mV) for the device the flash doc
-  /// belongs to, or null. Cross-check diagnostics only — the ratiometric
-  /// factory calibration stays authoritative regardless.
-  double? get measuredExcitationMv => _dmmByDevice[_flashDeviceId];
-
-  /// Set (or clear, with null) the DMM reading for the flash doc's device.
-  /// No-op without a flash doc: there is no identified device to hang the
-  /// value on.
-  Future<void> setMeasuredExcitationMv(double? mv) async {
-    final id = _flashDeviceId;
-    if (id.isEmpty) return;
-    _modifiedKeys.add(_keyDmm);
-    if (mv == null) {
-      _dmmByDevice.remove(id);
-    } else {
-      _dmmByDevice[id] = mv;
-    }
-    notifyListeners();
-    await _persistDmm();
-  }
-
   // -- Flash reads (connect time) ---------------------------------------------
 
   /// A flash document just arrived from device [deviceId] (named
   /// [deviceName]): adopt it as the rig truth, restore or discard matching
-  /// pending edits, update history and change-detection, and emit a "changed
-  /// since your last visit" notice when the rig differs from what this app
-  /// last saw on this device.
+  /// pending edits, and record every populated slot in the cell history.
   void onFlashRead(String deviceId, String deviceName, DeviceFlash flash) {
-    final now = DateTime.now();
-    final notices = <String>[];
-
-    // Change detection against the stored signatures (positional: a swap of
-    // two cells correctly reports both channel slots as changed).
-    final previous = _lastSeenByDevice[deviceId];
-    if (previous != null) {
-      final current = flash.slots.signatures;
-      for (int i = 0; i < kRigSlotCount; ++i) {
-        if (previous[i] == current[i]) continue;
-        notices.add(_describeChange(i, previous[i], current[i]));
-      }
-    }
-    _lastSeenByDevice[deviceId] = flash.slots.signatures;
-    unawaited(_persistLastSeen());
+    // A link that dropped mid-read delivers with no identity — without an
+    // owning device id the document can't be attributed to anything.
+    if (deviceId.isEmpty) return;
 
     // Pending edits: restore only when they belong to this device AND the
     // device still matches their base. A changed device makes them stale —
-    // discard (the notice below says so) rather than resurrect a edit based
-    // on a rig that no longer exists.
+    // discard rather than resurrect an edit based on a rig that no longer
+    // exists.
     final pending = _pending;
-    if (pending != null) {
-      final sameDevice = pending.deviceId == deviceId;
-      final baseMatches = _signaturesEqual(
-        pending.base.signatures,
-        flash.slots.signatures,
-      );
-      if (sameDevice && baseMatches) {
-        // Restored: readings keep using the edited slots; the dirty banner
-        // comes back on its own via notifyListeners.
-      } else {
-        _pending = null;
-        if (sameDevice) {
-          notices.add(
-            'Your unsaved changes were discarded — the device changed.',
-          );
-        }
-      }
+    if (pending != null &&
+        !(pending.deviceId == deviceId &&
+            _sameCells(pending.base, flash.slots))) {
+      _pending = null;
     }
 
     _lastFlash = flash;
     _flashDeviceId = deviceId;
 
     // History: every populated slot on the device was "seen" now.
+    final now = DateTime.now();
     for (int i = 0; i < kRigSlotCount; ++i) {
       final cell = flash.slots.cellAt(i);
       if (cell != null) {
@@ -253,32 +202,14 @@ class RigState extends ChangeNotifier {
       }
     }
 
-    if (notices.isNotEmpty) {
-      _events?.emit(RigChangedSinceLastVisit(deviceName, notices));
-    }
     notifyListeners();
   }
 
-  static String _slotLabel(int i) => i < 4 ? 'CH${i + 1}' : 'Slot ${i + 1}';
-
-  static String _describeChange(int i, String? oldSig, String? newSig) {
-    final label = _slotLabel(i);
-    LoadCellProfile? parse(String? s) => s == null
-        ? null
-        : LoadCellProfile.fromJson(Map<String, dynamic>.from(jsonDecode(s)));
-    final oldCell = parse(oldSig);
-    final newCell = parse(newSig);
-    return switch ((oldCell, newCell)) {
-      (null, final n?) => '$label: added ${n.title}',
-      (final o?, null) => '$label: removed ${o.title}',
-      (final o?, final n?) => '$label: ${o.title} → ${n.title}',
-      _ => '',
-    };
-  }
-
-  static bool _signaturesEqual(List<String?> a, List<String?> b) {
-    for (int i = 0; i < a.length; ++i) {
-      if (a[i] != b[i]) return false;
+  /// Content comparison for the pending-restore check: a pure rewrite with
+  /// fresh mtimes is NOT a change, so compare the cells, not the slots.
+  static bool _sameCells(RigSlots a, RigSlots b) {
+    for (int i = 0; i < kRigSlotCount; ++i) {
+      if (a.cellAt(i) != b.cellAt(i)) return false;
     }
     return true;
   }
@@ -295,7 +226,6 @@ class RigState extends ChangeNotifier {
       deviceId: _flashDeviceId,
       base: flash!.slots,
       edited: flash.slots,
-      startedAt: DateTime.now(),
     );
   }
 
@@ -356,17 +286,14 @@ class RigState extends ChangeNotifier {
       return false;
     }
     // The device now holds exactly what we wrote: adopt it as the new flash
-    // truth, clear the pending session, and re-anchor change detection so
-    // our own write doesn't come back as a "changed elsewhere" notice.
+    // truth and clear the pending session.
     _lastFlash = DeviceFlash(board: flash.board, slots: stamped);
     _pending = null;
-    _lastSeenByDevice[pending.deviceId] = stamped.signatures;
-    unawaited(_persistLastSeen());
     notifyListeners();
     return true;
   }
 
-  // -- History + change-detection persistence -----------------------------------
+  // -- History persistence ------------------------------------------------------
 
   void _upsertHistory(
     LoadCellProfile cell,
@@ -399,79 +326,29 @@ class RigState extends ChangeNotifier {
     unawaited(_persistHistory());
   }
 
-  Future<void> _persistHistory() async {
-    _modifiedKeys.add(_keyHistory);
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(
-      _keyHistory,
-      jsonEncode([for (final e in _history) e.toJson()]),
-    );
+  Future<void> _persistHistory() => _prefs.setString(
+    _keyHistory,
+    jsonEncode([for (final e in _history) e.toJson()]),
+  );
+
+  void _loadHistory() {
+    final raw = _prefs.getString(_keyHistory);
+    if (raw == null || raw.isEmpty) return;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return;
+      _history = [for (final e in decoded) ?_tryParseHistoryEntry(e)];
+    } catch (e) {
+      debugPrint('Failed to parse rig history: $e');
+    }
   }
 
-  Future<void> _persistLastSeen() async {
-    _modifiedKeys.add(_keyLastSeen);
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_keyLastSeen, jsonEncode(_lastSeenByDevice));
-  }
-
-  Future<void> _persistDmm() async {
-    _modifiedKeys.add(_keyDmm);
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_keyDmm, jsonEncode(_dmmByDevice));
-  }
-
-  Future<void> _load() async {
-    final prefs = await SharedPreferences.getInstance();
-
-    if (!_modifiedKeys.contains(_keyHistory)) {
-      try {
-        final raw = prefs.getString(_keyHistory);
-        final decoded = raw == null || raw.isEmpty ? null : jsonDecode(raw);
-        if (decoded is List) {
-          _history = [
-            for (final e in decoded)
-              if (e is Map)
-                RigHistoryEntry.fromJson(Map<String, dynamic>.from(e)),
-          ];
-        }
-      } catch (e) {
-        debugPrint('Failed to parse rig history: $e');
-      }
+  /// One malformed entry drops just that entry, not the whole history.
+  static RigHistoryEntry? _tryParseHistoryEntry(Object? e) {
+    try {
+      return RigHistoryEntry.fromJson(Map<String, dynamic>.from(e as Map));
+    } catch (_) {
+      return null;
     }
-
-    if (!_modifiedKeys.contains(_keyLastSeen)) {
-      try {
-        final raw = prefs.getString(_keyLastSeen);
-        final decoded = raw == null || raw.isEmpty ? null : jsonDecode(raw);
-        if (decoded is Map) {
-          _lastSeenByDevice = {
-            for (final entry in decoded.entries)
-              entry.key as String: [
-                for (final s in entry.value as List) s is String ? s : null,
-              ],
-          };
-        }
-      } catch (e) {
-        debugPrint('Failed to parse rig last-seen: $e');
-      }
-    }
-
-    if (!_modifiedKeys.contains(_keyDmm)) {
-      try {
-        final raw = prefs.getString(_keyDmm);
-        final decoded = raw == null || raw.isEmpty ? null : jsonDecode(raw);
-        if (decoded is Map) {
-          _dmmByDevice = {
-            for (final entry in decoded.entries)
-              if (entry.value is num)
-                entry.key as String: (entry.value as num).toDouble(),
-          };
-        }
-      } catch (e) {
-        debugPrint('Failed to parse rig DMM readings: $e');
-      }
-    }
-
-    notifyListeners();
   }
 }

--- a/lib/widgets/board_calibration_section.dart
+++ b/lib/widgets/board_calibration_section.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -8,9 +6,7 @@ import '../services/rig_state.dart';
 
 /// Settings → Device settings → Board calibration: a read-only view of the
 /// CONNECTED device's factory calibration (the 5-point ladder fit per
-/// channel), plus the DMM excitation cross-check. The ratiometric
-/// calibration is always authoritative — the DMM reading only verifies the
-/// measurement chain.
+/// channel).
 ///
 /// Everything here is per-board data, so it comes from the flash-document
 /// owner ([RigState.boardCalibrationFor]) — never from the data hub's
@@ -29,10 +25,13 @@ class BoardCalibrationSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final rig = context.watch<RigState>();
     // One ownership query, decided by the document owner: null means no
-    // document this run, or a document belonging to another device.
-    final board = rig.boardCalibrationFor(deviceId);
+    // document this run, or a document belonging to another device. Narrow
+    // select: slot edits notify RigState too, but the board instance only
+    // changes with a fresh flash read.
+    final board = context.select<RigState, BoardCalibration?>(
+      (r) => r.boardCalibrationFor(deviceId),
+    );
     if (board == null) {
       return const Card(
         child: ListTile(
@@ -47,7 +46,6 @@ class BoardCalibrationSection extends StatelessWidget {
     final calibrated = board.channels
         .where((c) => c.isFactoryCalibrated)
         .length;
-    final dmmMv = rig.measuredExcitationMv;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -68,69 +66,8 @@ class BoardCalibrationSection extends StatelessWidget {
         const SizedBox(height: 8),
         for (int i = 0; i < board.channels.length; i++)
           _ChannelCalTile(index: i, channel: board.channels[i]),
-        const SizedBox(height: 16),
-        Text(
-          'Excitation cross-check',
-          style: Theme.of(context).textTheme.titleSmall,
-        ),
-        const SizedBox(height: 4),
-        Text(
-          'The ratiometric calibration is authoritative: a load cell and the '
-          'calibration ladder share the same excitation, so it cancels. '
-          'Measuring the excitation with a DMM can only verify the chain, '
-          'not improve the calibration.',
-          style: Theme.of(context).textTheme.bodySmall,
-        ),
-        const SizedBox(height: 8),
-        // Deliberately keyless: every device transition unmounts this field
-        // (the settings gate or the placeholder card takes its place), so
-        // the initial value always matches the device on screen. Keying it
-        // by the value would instead rebuild it per keystroke — a new field
-        // each time, focus lost mid-typing.
-        TextFormField(
-          initialValue: dmmMv?.toString() ?? '',
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          decoration: const InputDecoration(
-            labelText: 'Your DMM excitation reading (mV)',
-            border: OutlineInputBorder(),
-            isDense: true,
-          ),
-          onChanged: (s) {
-            final trimmed = s.trim();
-            if (trimmed.isEmpty) {
-              unawaited(rig.setMeasuredExcitationMv(null));
-            } else {
-              final v = double.tryParse(trimmed);
-              if (v != null && v > 0) {
-                unawaited(rig.setMeasuredExcitationMv(v));
-              }
-            }
-          },
-        ),
-        if (dmmMv != null) ...[
-          const SizedBox(height: 8),
-          // Only factory-calibrated channels have a measured span to compare
-          // against the DMM. A nominal channel would just echo the nominal
-          // 4.53 V assumption back as a fake "gain error".
-          for (int i = 0; i < board.channels.length; i++)
-            if (board.channels[i].isFactoryCalibrated)
-              Text(
-                'Ch ${i + 1}: implied chain gain error '
-                '${_gainErrorPercent(board.channels[i], dmmMv)}',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-        ],
       ],
     );
-  }
-
-  /// (measured span) vs (DMM excitation × nominal chain): the combined AFE
-  /// gain + ADC reference error the factory calibration absorbed.
-  static String _gainErrorPercent(ChannelBoardCalibration ch, double dmmMv) {
-    final expected = countsPerMvAtCellOutput * dmmMv / 1000.0;
-    final err = ch.spanCountsPerMvV / expected - 1;
-    final pct = err * 100;
-    return '${pct >= 0 ? '+' : ''}${pct.toStringAsFixed(3)} %';
   }
 }
 

--- a/lib/widgets/rig_slots_section.dart
+++ b/lib/widgets/rig_slots_section.dart
@@ -41,11 +41,6 @@ const double _kRowHeight = 72;
 /// Width of the static gutter holding the channel rail + CH tags.
 const double _kGutterWidth = 28;
 
-/// Height of the always-present status bar (fits the two buttons of the
-/// dirty state with room to spare, so clean and dirty states are the same
-/// height and the list never shifts).
-const double _kBarHeight = 56;
-
 class _RigSlotsSectionState extends State<RigSlotsSection> {
   bool _saving = false;
 
@@ -70,14 +65,10 @@ class _RigSlotsSectionState extends State<RigSlotsSection> {
 
   @override
   Widget build(BuildContext context) {
-    final rig = context.watch<RigState>();
-    // The section reads the link only to gate the Save button: saving needs
-    // the very device the flash doc came from to be connected.
-    final connectedId = context.select<BleLinkManager, String>(
-      (l) => l.connectedDeviceId,
-    );
-
-    if (!rig.hasDeviceDoc) {
+    // Narrow selects: the section renders three slices of the rig (doc
+    // presence, the slots, the dirty state), not every RigState notify.
+    final hasDoc = context.select<RigState, bool>((r) => r.hasDeviceDoc);
+    if (!hasDoc) {
       return const Card(
         child: ListTile(
           leading: Icon(Icons.phonelink_erase, color: Colors.grey),
@@ -88,9 +79,17 @@ class _RigSlotsSectionState extends State<RigSlotsSection> {
         ),
       );
     }
+    final slots = context.select<RigState, RigSlots>((r) => r.effectiveSlots);
+    final pending = context.select<RigState, PendingRigEdits?>(
+      (r) => r.pending,
+    );
+    final rig = context.read<RigState>();
+    // The section reads the link only to gate the Save button: saving needs
+    // the very device the flash doc came from to be connected.
+    final connectedId = context.select<BleLinkManager, String>(
+      (l) => l.connectedDeviceId,
+    );
 
-    final slots = rig.effectiveSlots;
-    final pending = rig.pending;
     final canSave =
         pending != null &&
         connectedId.isNotEmpty &&
@@ -302,8 +301,9 @@ class _ChannelGutter extends StatelessWidget {
 
 /// The always-present save-state bar. Dirty: the red of the Live tab's
 /// "Not connected" header (errorContainer), with content in the matching
-/// on-color so it stays readable. Clean: a quiet confirmation. Both states
-/// are exactly [_kBarHeight] tall, so toggling never moves the slot list.
+/// on-color so it stays readable. Clean: a quiet confirmation. One layout
+/// for both states — the buttons keep their space while hidden, so the bar
+/// (and the slot list below) never moves when the dirty state flips.
 class _StatusBar extends StatelessWidget {
   const _StatusBar({
     required this.dirty,
@@ -323,73 +323,52 @@ class _StatusBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-
-    if (!dirty) {
-      return Card(
-        child: SizedBox(
-          height: _kBarHeight,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                Icon(
-                  Icons.check_circle_outline,
-                  size: 18,
-                  color: colors.outline,
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'All settings saved to device.',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: colors.outline,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
+    final fg = dirty ? colors.onErrorContainer : colors.outline;
 
     return Card(
-      color: colors.errorContainer,
-      child: SizedBox(
-        height: _kBarHeight,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 8, 0),
-          child: Row(
-            children: [
-              Icon(
-                Icons.warning_amber,
-                size: 18,
-                color: colors.onErrorContainer,
+      color: dirty ? colors.errorContainer : null,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 6, 8, 6),
+        child: Row(
+          children: [
+            Icon(
+              dirty ? Icons.warning_amber : Icons.check_circle_outline,
+              size: 18,
+              color: fg,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                dirty
+                    ? 'Changes not saved to device — readings in this app '
+                          'already use them.'
+                    : 'All settings saved to device.',
+                style: theme.textTheme.bodySmall?.copyWith(color: fg),
               ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  'Changes not saved to device — readings in this app '
-                  'already use them.',
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: colors.onErrorContainer,
+            ),
+            Visibility(
+              visible: dirty,
+              maintainSize: true,
+              maintainAnimation: true,
+              maintainState: true,
+              child: Row(
+                children: [
+                  TextButton(
+                    onPressed: saving ? null : onRevert,
+                    style: TextButton.styleFrom(
+                      foregroundColor: colors.onErrorContainer,
+                    ),
+                    child: const Text('Revert'),
                   ),
-                ),
+                  const SizedBox(width: 4),
+                  FilledButton(
+                    onPressed: canSave ? onSave : null,
+                    child: Text(saving ? 'Saving…' : 'Save to device'),
+                  ),
+                ],
               ),
-              TextButton(
-                onPressed: saving ? null : onRevert,
-                style: TextButton.styleFrom(
-                  foregroundColor: colors.onErrorContainer,
-                ),
-                child: const Text('Revert'),
-              ),
-              const SizedBox(width: 4),
-              FilledButton(
-                onPressed: canSave ? onSave : null,
-                child: Text(saving ? 'Saving…' : 'Save to device'),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
@@ -407,7 +386,7 @@ Future<void> showAddToSlot(BuildContext context, RigState rig, int slot) {
   return showDialog<void>(
     context: context,
     builder: (ctx) => AlertDialog(
-      title: Text('Add load cell — ${_slotTitle(slot)}'),
+      title: Text('Add load cell — ${rigSlotTitle(slot)}'),
       content: SizedBox(
         width: 380,
         child: SingleChildScrollView(
@@ -471,8 +450,6 @@ Future<void> showAddToSlot(BuildContext context, RigState rig, int slot) {
   );
 }
 
-String _slotTitle(int i) => i < 4 ? 'CH ${i + 1}' : 'Slot ${i + 1}';
-
 // ---------------------------------------------------------------------------
 // Slot editor dialog (edit a populated slot, or custom entry for an empty one)
 // ---------------------------------------------------------------------------
@@ -533,16 +510,20 @@ class _SlotEditorDialogState extends State<_SlotEditorDialog> {
   }
 
   bool _valid() =>
-      (double.tryParse(capCtrl.text.trim()) ?? 0) > 0 &&
-      (double.tryParse(sensCtrl.text.trim()) ?? 0) > 0;
+      (_typedNumber(capCtrl.text) ?? 0) > 0 &&
+      (_typedNumber(sensCtrl.text) ?? 0) > 0;
 
   void _save() {
+    final cap = _typedNumber(capCtrl.text);
+    final sens = _typedNumber(sensCtrl.text);
+    // The Save button is gated on [_valid], so both parse positive here.
+    if (cap == null || sens == null || cap <= 0 || sens <= 0) return;
     rig.setSlot(
       slot,
       LoadCellProfile(
         name: nameCtrl.text.trim(),
-        capacityKg: double.parse(capCtrl.text.trim()),
-        sensitivityMvV: double.parse(sensCtrl.text.trim()),
+        capacityKg: cap,
+        sensitivityMvV: sens,
       ),
     );
     Navigator.of(context).pop();
@@ -558,7 +539,7 @@ class _SlotEditorDialogState extends State<_SlotEditorDialog> {
     final editing = initial != null;
     return AlertDialog(
       title: Text(
-        '${editing ? 'Edit' : 'New'} load cell — ${_slotTitle(slot)}',
+        '${editing ? 'Edit' : 'New'} load cell — ${rigSlotTitle(slot)}',
       ),
       content: SizedBox(
         width: 380,
@@ -646,3 +627,15 @@ class _SlotEditorDialogState extends State<_SlotEditorDialog> {
 /// Render a double without a trailing '.0' for whole numbers.
 String _num(double v) =>
     v == v.roundToDouble() ? v.toInt().toString() : v.toString();
+
+/// Parse a typed-in number, tolerating a comma decimal separator (some
+/// locales' decimal key inserts one). Input that already has a '.', or has
+/// several commas, is parsed as-is — thousands-grouped text fails to parse
+/// rather than silently misparsing.
+double? _typedNumber(String s) {
+  final t = s.trim();
+  if (!t.contains('.') && t.indexOf(',') == t.lastIndexOf(',')) {
+    return double.tryParse(t.replaceFirst(',', '.'));
+  }
+  return double.tryParse(t);
+}

--- a/test/app_settings_test.dart
+++ b/test/app_settings_test.dart
@@ -5,30 +5,27 @@ import 'package:dynamite_app/models/app_settings.dart';
 import 'package:dynamite_app/models/force_unit.dart';
 
 /// Tests for [AppSettings] persistence (SharedPreferences backed by the
-/// in-memory mock).
+/// in-memory mock). The constructor loads synchronously from the injected
+/// prefs instance, so no settle is needed.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<AppSettings> settledSettings() async {
-    final settings = AppSettings();
-    // Let the constructor's async prefs load resolve (a few microtask turns).
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-    return settings;
-  }
+  Future<AppSettings> newSettings() async =>
+      AppSettings(prefs: await SharedPreferences.getInstance());
 
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
   test('defaults: mV/V unit, all channels active', () async {
-    final s = await settledSettings();
+    final s = await newSettings();
     expect(s.displayUnit, ForceUnit.mVv);
     expect(s.activeChannels, everyElement(isTrue));
   });
 
   test('display unit persists across instances', () async {
-    final s = await settledSettings();
+    final s = await newSettings();
     await s.setDisplayUnit(ForceUnit.kgf);
 
-    final s2 = await settledSettings();
+    final s2 = await newSettings();
     expect(s2.displayUnit, ForceUnit.kgf);
   });
 
@@ -38,7 +35,8 @@ void main() {
       'load_cell_bank': '[{"id":"x"}]',
       'channel_load_cells': '["x",null,null,null]',
     });
-    await settledSettings();
+    await newSettings();
+    await pumpEventQueue(); // the constructor's erases are fire-and-forget
 
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getString('channel_labels'), isNull);

--- a/test/board_calibration_section_test.dart
+++ b/test/board_calibration_section_test.dart
@@ -33,7 +33,10 @@ void main() {
     String? flashDoc,
   }) async {
     SharedPreferences.setMockInitialValues({});
-    final rig = RigState(transport: _FakeTransport());
+    final rig = RigState(
+      transport: _FakeTransport(),
+      prefs: await SharedPreferences.getInstance(),
+    );
     if (withFlash) {
       rig.onFlashRead(
         'dev1',
@@ -115,64 +118,10 @@ void main() {
     expect(find.textContaining('Factory calibration'), findsNothing);
   });
 
-  testWidgets('a DMM reading shows per-channel implied gain error', (
+  testWidgets('the header counts the factory-calibrated channels', (
     tester,
   ) async {
-    final rig = await pump(tester);
-
-    expect(find.textContaining('implied chain gain error'), findsNothing);
-
-    await tester.enterText(
-      find.widgetWithText(TextFormField, 'Your DMM excitation reading (mV)'),
-      '4530.24',
-    );
-    await tester.pumpAndSettle();
-
-    expect(rig.measuredExcitationMv, closeTo(4530.24, 1e-9));
-    expect(find.textContaining('implied chain gain error'), findsNWidgets(4));
-    // ch0 span vs the DMM: span/(countsPerMv * 4.53024) - 1.
-    final board = BoardCalibration.parse(demoBoardCalibrationDoc);
-    final err =
-        (board.channels[0].spanCountsPerMvV /
-                (countsPerMvAtCellOutput * 4.53024) -
-            1) *
-        100;
-    final sign = err >= 0 ? '+' : '';
-    expect(
-      find.textContaining(
-        'Ch 1: implied chain gain error $sign${err.toStringAsFixed(3)} %',
-      ),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('clearing the DMM field removes the gain error rows', (
-    tester,
-  ) async {
-    final rig = await pump(tester);
-
-    final field = find.widgetWithText(
-      TextFormField,
-      'Your DMM excitation reading (mV)',
-    );
-    await tester.enterText(field, '4530.24');
-    await tester.pumpAndSettle();
-    expect(rig.measuredExcitationMv, closeTo(4530.24, 1e-9));
-    expect(find.textContaining('implied chain gain error'), findsNWidgets(4));
-
-    await tester.enterText(field, '');
-    await tester.pumpAndSettle();
-
-    expect(rig.measuredExcitationMv, isNull);
-    expect(find.textContaining('implied chain gain error'), findsNothing);
-  });
-
-  testWidgets('DMM gain error rows cover factory-calibrated channels only', (
-    tester,
-  ) async {
-    // Only CH1 of this document has factory data: the cross-check has a
-    // measured span to compare only there — a nominal channel would just
-    // echo the nominal 4.53 V assumption back as a fake "gain error".
+    // Only CH1 of this document has factory data.
     const partialCalDoc = '''
 K3CAL1
 ch0.r=10000.8,10.0012,9.9991,10.0008,10.0003,9999.4
@@ -181,19 +130,6 @@ END
 ''';
     await pump(tester, flashDoc: partialCalDoc);
 
-    // The header reflects the single calibrated channel.
     expect(find.textContaining('1 of 4 channels'), findsOneWidget);
-
-    await tester.enterText(
-      find.widgetWithText(TextFormField, 'Your DMM excitation reading (mV)'),
-      '4530.24',
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.textContaining('implied chain gain error'), findsOneWidget);
-    expect(
-      find.textContaining('Ch 1: implied chain gain error'),
-      findsOneWidget,
-    );
   });
 }

--- a/test/calibration_test.dart
+++ b/test/calibration_test.dart
@@ -195,21 +195,28 @@ ch2.raw=6401205.6,3201448.2,1502.8,-3196441.9
       expect(board.channels[1].isFactoryCalibrated, isTrue);
     });
 
-    test('serialize round-trips through parse', () {
-      final original = BoardCalibration.parse(doc);
-      final reparsed = BoardCalibration.parse(original.serialize());
-      expect(reparsed.factoryDate, original.factoryDate);
-      expect(reparsed.excitationMv, original.excitationMv);
-      for (int i = 0; i < original.channels.length; ++i) {
-        final a = original.channels[i];
-        final b = reparsed.channels[i];
-        for (int k = 0; k < kLadderResistorCount; ++k) {
-          expect(b.resistors[k], closeTo(a.resistors[k], 1e-9));
-        }
-        for (int k = 0; k < kCalPointCount; ++k) {
-          expect(b.readings![k], closeTo(a.readings![k], 1e-6));
-        }
-      }
+    test('out-of-range or near-duplicate readings are rejected', () {
+      final board = BoardCalibration.parse(
+        // Beyond the ADC's 24-bit bipolar range: can't be hardware.
+        'ch0.raw=9000000,3200621.9,845.2,-3199374.1,-6397331.0\n'
+        // A sub-thousand-count gap between points: interpolation would
+        // divide by ~zero (a real ladder spread is millions of counts).
+        'ch1.raw=6399057.3,6399057.4,845.2,-3199374.1,-6397331.0\n'
+        'ch2.raw=6399057.3,3200621.9,845.2,-3199374.1,-6397331.0\n',
+      );
+      expect(board.channels[0].isFactoryCalibrated, isFalse);
+      expect(board.channels[1].isFactoryCalibrated, isFalse);
+      expect(board.channels[2].isFactoryCalibrated, isTrue);
+    });
+
+    test('non-positive resistors degrade to the nominal ladder', () {
+      final board = BoardCalibration.parse(
+        'ch0.r=10000,10,10,0,10,10000\n'
+        'ch0.raw=6399057.3,3200621.9,845.2,-3199374.1,-6397331.0\n',
+      );
+      expect(board.channels[0].resistors, nominalLadderResistors);
+      // The readings were fine, so the channel stays factory-calibrated.
+      expect(board.channels[0].isFactoryCalibrated, isTrue);
     });
   });
 
@@ -246,52 +253,6 @@ ch2.raw=6401205.6,3201448.2,1502.8,-3196441.9
       expect(plain.valuesLine, '200 kg · 2 mV/V');
       final cert = LoadCellProfile(capacityKg: 200, sensitivityMvV: 2.007);
       expect(cert.valuesLine, '200 kg · 2.007 mV/V');
-    });
-  });
-
-  group('ChannelCalibration', () {
-    const alpha = 412.7;
-    const beta = 3198500.0;
-    final sp = ladderSetpointsMvV(nominalLadderResistors);
-    final board = ChannelBoardCalibration(
-      readings: [for (final d in sp) alpha + beta * d],
-    );
-
-    test('net values are map differences between raw and tare', () {
-      final cal = ChannelCalibration(board: board);
-      final rawFs = board.readings![0];
-      expect(cal.netMvV(rawFs, alpha), closeTo(sp[0], 1e-9));
-      expect(cal.netMvV(rawFs, rawFs), 0.0);
-      expect(cal.netRaw(rawFs, alpha), closeTo(rawFs - alpha, 1e-9));
-      expect(
-        cal.netMv(rawFs, alpha),
-        closeTo(sp[0] * board.effectiveExcitationV, 1e-9),
-      );
-    });
-
-    test('force conversion needs an assigned load cell', () {
-      final bare = ChannelCalibration(board: board);
-      expect(bare.netKgf(board.readings![0], alpha), isNull);
-
-      final cell = LoadCellProfile(capacityKg: 200, sensitivityMvV: 2);
-      final assigned = ChannelCalibration(board: board, loadCell: cell);
-      final rawFs = board.readings![0];
-      expect(
-        assigned.netKgf(rawFs, alpha),
-        closeTo(sp[0] * 100, 1e-9), // 200 kg / 2 mV/V = 100 kgf per mV/V
-      );
-      final corrected = ChannelCalibration(
-        board: board,
-        // The cal-cert sensitivity below the nominal 2 mV/V reads higher.
-        loadCell: cell.copyWith(sensitivityMvV: 2 / 1.02),
-      );
-      expect(corrected.netKgf(rawFs, alpha), closeTo(sp[0] * 102, 1e-9));
-    });
-
-    test('local slope tracks the piecewise segment', () {
-      final cal = ChannelCalibration(board: board);
-      // Affine device: the local slope is beta everywhere.
-      expect(cal.mvVPerCountAt(board.readings![1]), closeTo(1 / beta, 1e-15));
     });
   });
 }

--- a/test/data_hub_test.dart
+++ b/test/data_hub_test.dart
@@ -237,12 +237,12 @@ void main() {
     test('board calibration replaces the nominal chain and bumps version', () {
       final hub = DataHub();
       final v0 = hub.calibrationVersion;
-      // ch0 measures at twice the nominal span; other channels stay nominal.
+      // ch0 measures at half the nominal span; other channels stay nominal.
       final sp = ladderSetpointsMvV(nominalLadderResistors);
       final board = BoardCalibration(
         channels: [
           ChannelBoardCalibration(
-            readings: [for (final d in sp) 500 + 2 * nominalCountsPerMvV * d],
+            readings: [for (final d in sp) 500 + 0.5 * nominalCountsPerMvV * d],
           ),
           ChannelBoardCalibration(),
           ChannelBoardCalibration(),
@@ -256,7 +256,7 @@ void main() {
       feed(hub, frameOf(1000), 5);
       expect(
         hub.currentValue(0, ForceUnit.mVv),
-        closeTo(1000 / (2 * nominalCountsPerMvV), 1e-12),
+        closeTo(1000 / (0.5 * nominalCountsPerMvV), 1e-12),
       );
       expect(
         hub.currentValue(1, ForceUnit.mVv),

--- a/test/device_action_buttons_test.dart
+++ b/test/device_action_buttons_test.dart
@@ -40,9 +40,10 @@ void main() {
     final linkManager = BleLinkManager(events: appEvents)
       ..onAdcData = decoder.onDataPacket
       ..onCalibrationData = decoder.onCalibrationPacket;
-    final rigState = RigState(transport: linkManager, events: appEvents);
+    final prefs = await SharedPreferences.getInstance();
+    final rigState = RigState(transport: linkManager, prefs: prefs);
     decoder.onDeviceFlash = (flash) => rigState.onFlashRead(
-      linkManager.selectedDeviceId,
+      linkManager.connectedDeviceId,
       linkManager.connectedDeviceName,
       flash,
     );
@@ -56,7 +57,7 @@ void main() {
     await tester.pumpWidget(
       MultiProvider(
         providers: [
-          ChangeNotifierProvider(create: (_) => AppSettings()),
+          ChangeNotifierProvider.value(value: AppSettings(prefs: prefs)),
           Provider.value(value: appEvents),
           ChangeNotifierProvider.value(value: dataHub),
           ChangeNotifierProvider.value(value: linkManager),

--- a/test/rig_slots_section_test.dart
+++ b/test/rig_slots_section_test.dart
@@ -39,11 +39,12 @@ void main() {
     UniversalBle.setInstance(MockBlePlatform.instance);
     final events = AppEvents();
     final link = BleLinkManager(events: events);
-    // NOTE: no async settle delay here — inside testWidgets the clock is
-    // FakeAsync and a Future.delayed would never fire. The rig's async
-    // prefs load is harmless (empty prefs) and race-free (modified-keys
-    // guard), so reading the flash right after construction is fine.
-    final rig = RigState(transport: _FakeTransport(), events: events);
+    final rig = RigState(
+      transport: _FakeTransport(),
+      // The rig's prefs load is synchronous in the constructor, so reading
+      // the flash right after construction is fine.
+      prefs: await SharedPreferences.getInstance(),
+    );
     if (withFlash) {
       rig.onFlashRead(
         'dev1',

--- a/test/rig_slots_test.dart
+++ b/test/rig_slots_test.dart
@@ -72,7 +72,9 @@ void main() {
         slots: RigSlots.empty(),
       );
       final reparsed = DeviceFlash.parse(boardOnly.serialize());
-      expect(reparsed.slots.signatures, everyElement(isNull));
+      for (int i = 0; i < kRigSlotCount; ++i) {
+        expect(reparsed.slots[i], isNull, reason: 'slot $i');
+      }
       // And the board keys survive untouched.
       expect(reparsed.board.channels[0].isFactoryCalibrated, isTrue);
     });
@@ -89,7 +91,7 @@ void main() {
         ),
       );
       final doc = DeviceFlash(
-        board: BoardCalibration.nominal(),
+        board: DeviceFlash.parse(demoBoardCalibrationDoc).board,
         slots: slots,
       ).serialize();
       expect(doc.contains('lc0.name=a=b c'), isTrue);
@@ -142,23 +144,6 @@ void main() {
       final moved = slots.withSwap(0, 5);
       expect(moved.cellAt(0), isNull);
       expect(moved.cellAt(5)?.name, 'A');
-    });
-
-    test('signatures track content and ignore mtime', () {
-      final cell = LoadCellProfile(
-        name: 'A',
-        capacityKg: 100,
-        sensitivityMvV: 2,
-      );
-      final a = RigSlots.empty().withSlot(0, RigSlot(cell: cell));
-      final b = RigSlots.empty().withSlot(
-        0,
-        RigSlot(cell: cell, mtime: DateTime.utc(2026, 1, 1)),
-      );
-      expect(a.signatures, b.signatures);
-
-      final c = b.withSlot(0, RigSlot(cell: cell.copyWith(sensitivityMvV: 2.02)));
-      expect(c.signatures, isNot(b.signatures));
     });
   });
 }

--- a/test/rig_state_test.dart
+++ b/test/rig_state_test.dart
@@ -2,13 +2,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dynamite_app/models/calibration.dart';
-import 'package:dynamite_app/services/app_events.dart';
 import 'package:dynamite_app/services/demo_calibration.dart';
 import 'package:dynamite_app/services/rig_state.dart';
 
 /// Tests for [RigState]: flash reads, pending edits (restore/discard across
-/// reconnects), save/revert, history, and change detection. Transport is a
-/// fake capturing the written document; SharedPreferences is mocked.
+/// reconnects), save/revert, and history. Transport is a fake capturing the
+/// written document; SharedPreferences is mocked.
 class _FakeTransport implements RigFlashTransport {
   String deviceId = 'dev1';
   String deviceName = 'Bench unit';
@@ -32,14 +31,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late _FakeTransport transport;
-  late AppEvents events;
-  late List<AppEvent> seen;
 
-  Future<RigState> settledRig() async {
-    final rig = RigState(transport: transport, events: events);
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-    return rig;
-  }
+  Future<RigState> newRig() async => RigState(
+    transport: transport,
+    prefs: await SharedPreferences.getInstance(),
+  );
 
   DeviceFlash fixture() => DeviceFlash.parse(demoBoardCalibrationDoc);
 
@@ -52,14 +48,11 @@ void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
     transport = _FakeTransport();
-    events = AppEvents();
-    seen = [];
-    events.stream.listen(seen.add);
   });
 
   group('flash reads', () {
-    test('first read populates slots, titles and history; no event', () async {
-      final rig = await settledRig();
+    test('first read populates slots, titles and history', () async {
+      final rig = await newRig();
       rig.onFlashRead('dev1', 'Bench unit', fixture());
 
       expect(rig.hasDeviceDoc, isTrue);
@@ -73,11 +66,19 @@ void main() {
       expect(rig.hasPending, isFalse);
       // 3 channel cells + 1 spare were seen.
       expect(rig.history, hasLength(4));
-      expect(seen, isEmpty);
+    });
+
+    test('a flash read with an empty device id is ignored', () async {
+      final rig = await newRig();
+      // A link that dropped mid-read delivers with no identity; the
+      // document can't be attributed to anything.
+      rig.onFlashRead('', '', fixture());
+      expect(rig.hasDeviceDoc, isFalse);
+      expect(rig.history, isEmpty);
     });
 
     test('boardCalibrationFor gates on document ownership', () async {
-      final rig = await settledRig();
+      final rig = await newRig();
 
       // No flash document read yet.
       expect(rig.boardCalibrationFor('dev1'), isNull);
@@ -90,27 +91,15 @@ void main() {
       expect(rig.boardCalibrationFor('dev2'), isNull);
     });
 
-    test('an identical re-read is quiet', () async {
-      final rig = await settledRig();
-      rig.onFlashRead('dev1', 'Bench unit', fixture());
-      rig.onFlashRead('dev1', 'Bench unit', fixture());
-      expect(seen, isEmpty);
-    });
-
-    test('a changed device wins and raises the FYI event', () async {
-      final rig = await settledRig();
+    test('a changed device wins: readings use the new values', () async {
+      final rig = await newRig();
       rig.onFlashRead('dev1', 'Bench unit', fixture());
       rig.onFlashRead(
         'dev1',
         'Bench unit',
         DeviceFlash.parse(recalibratedDoc()),
       );
-      await pumpEventQueue(); // AppEvents delivers asynchronously
 
-      final notices = seen.whereType<RigChangedSinceLastVisit>();
-      expect(notices, hasLength(1));
-      expect(notices.single.changes.single, contains('CH1'));
-      expect(notices.single.changes.single, contains('Thrust cell'));
       // The device is the truth: readings use the new values immediately.
       expect(rig.channelCells[0]?.sensitivityMvV, closeTo(1.9985, 1e-12));
     });
@@ -120,7 +109,7 @@ void main() {
     test(
       'edits take effect immediately; revert restores the flash state',
       () async {
-        final rig = await settledRig();
+        final rig = await newRig();
         rig.onFlashRead('dev1', 'Bench unit', fixture());
 
         rig.setSlot(
@@ -140,7 +129,7 @@ void main() {
     test(
       'swap exchanges slots (assign/unassign across the boundary)',
       () async {
-        final rig = await settledRig();
+        final rig = await newRig();
         rig.onFlashRead('dev1', 'Bench unit', fixture());
 
         // Drag the spare (slot 4) onto CH2 (slot 1): the two exchange.
@@ -165,23 +154,32 @@ void main() {
     test(
       'pending survives a disconnect+reconnect to the same device',
       () async {
-        final rig = await settledRig();
+        final rig = await newRig();
         rig.onFlashRead('dev1', 'Bench unit', fixture());
         rig.setSlot(
           3,
           LoadCellProfile(name: 'New', capacityKg: 50, sensitivityMvV: 1),
         );
 
-        // Reconnect: the device re-reads with unchanged content.
-        rig.onFlashRead('dev1', 'Bench unit', fixture());
+        // Reconnect: the device re-reads with unchanged content — fresh
+        // mtimes (a pure rewrite elsewhere) do NOT count as a change.
+        rig.onFlashRead(
+          'dev1',
+          'Bench unit',
+          DeviceFlash.parse(
+            demoBoardCalibrationDoc.replaceFirst(
+              '2026-07-20T10:15:00.000Z',
+              '2026-07-21T08:00:00.000Z',
+            ),
+          ),
+        );
         expect(rig.hasPending, isTrue);
         expect(rig.channelTitles[3], 'New');
-        expect(seen, isEmpty); // no FYI: nothing changed on the device
       },
     );
 
     test('pending is discarded when the device changed while away', () async {
-      final rig = await settledRig();
+      final rig = await newRig();
       rig.onFlashRead('dev1', 'Bench unit', fixture());
       rig.setSlot(
         3,
@@ -193,20 +191,12 @@ void main() {
         'Bench unit',
         DeviceFlash.parse(recalibratedDoc()),
       );
-      await pumpEventQueue();
       expect(rig.hasPending, isFalse);
       expect(rig.channelTitles[3], 'CH 4'); // edited slot is gone
-      final notices = seen.whereType<RigChangedSinceLastVisit>();
-      expect(
-        notices.single.changes.where(
-          (c) => c.contains('unsaved changes were discarded'),
-        ),
-        hasLength(1),
-      );
     });
 
     test('pending for another device is discarded on connect', () async {
-      final rig = await settledRig();
+      final rig = await newRig();
       rig.onFlashRead('dev1', 'Bench unit', fixture());
       rig.setSlot(
         3,
@@ -222,7 +212,7 @@ void main() {
     test(
       'writes edited slots with fresh mtimes and verbatim board keys',
       () async {
-        final rig = await settledRig();
+        final rig = await newRig();
         rig.onFlashRead('dev1', 'Bench unit', fixture());
         rig.setSlot(
           3,
@@ -245,16 +235,11 @@ void main() {
           fixture().board.channels[0].readings,
         );
         expect(written.board.factoryDate, '2026-07-20');
-
-        // Our own write must not come back as a "changed elsewhere" notice on
-        // the next connect (change detection was re-anchored).
-        rig.onFlashRead('dev1', 'Bench unit', written);
-        expect(seen.whereType<RigChangedSinceLastVisit>(), isEmpty);
       },
     );
 
     test('a failed write keeps the pending edits', () async {
-      final rig = await settledRig();
+      final rig = await newRig();
       rig.onFlashRead('dev1', 'Bench unit', fixture());
       rig.setSlot(
         3,
@@ -272,76 +257,26 @@ void main() {
     test(
       'history survives a restart (new RigState on the same prefs)',
       () async {
-        final rig = await settledRig();
+        final rig = await newRig();
         rig.onFlashRead('dev1', 'Bench unit', fixture());
         expect(rig.history, hasLength(4));
 
-        final rig2 = await settledRig();
+        final rig2 = await newRig();
         expect(rig2.history, hasLength(4));
         expect(rig2.history.map((e) => e.cell.name), contains('Thrust cell'));
       },
     );
 
-    test('a change on a KNOWN device fires once, then re-anchors', () async {
-      final rig = await settledRig();
-      rig.onFlashRead('dev1', 'Bench unit', fixture());
-      rig.onFlashRead(
-        'dev1',
-        'Bench unit',
-        DeviceFlash.parse(recalibratedDoc()),
-      );
-      await pumpEventQueue();
-      expect(seen.whereType<RigChangedSinceLastVisit>(), hasLength(1));
-
-      // A third read of the same (new) content is quiet again.
-      rig.onFlashRead(
-        'dev1',
-        'Bench unit',
-        DeviceFlash.parse(recalibratedDoc()),
-      );
-      await pumpEventQueue();
-      expect(seen.whereType<RigChangedSinceLastVisit>(), hasLength(1));
+    test('a malformed history entry is dropped, the rest survives', () async {
+      SharedPreferences.setMockInitialValues({
+        'rig_history':
+            '[{"cell":{"name":"Good","capacityKg":100,"sensitivityMvV":2},'
+            '"lastSeen":1753000000000,"deviceName":"d","origin":"device"},'
+            '{"bogus":true}]',
+      });
+      final rig = await newRig();
+      expect(rig.history, hasLength(1));
+      expect(rig.history.single.cell.name, 'Good');
     });
-  });
-
-  group('DMM excitation cross-check (per-device)', () {
-    test('no flash doc: nowhere to hang the value, set is a no-op', () async {
-      final rig = await settledRig();
-      await rig.setMeasuredExcitationMv(4530.2);
-      expect(rig.measuredExcitationMv, isNull);
-    });
-
-    test('the value attaches to the flash doc\'s device only', () async {
-      final rig = await settledRig();
-      rig.onFlashRead('dev1', 'Bench unit', fixture());
-      await rig.setMeasuredExcitationMv(4530.2);
-      expect(rig.measuredExcitationMv, 4530.2);
-
-      // Another device has no reading of its own…
-      rig.onFlashRead('dev2', 'Other unit', fixture());
-      expect(rig.measuredExcitationMv, isNull);
-
-      // …and dev1's reading is still there when dev1 comes back.
-      rig.onFlashRead('dev1', 'Bench unit', fixture());
-      expect(rig.measuredExcitationMv, 4530.2);
-
-      // Clearing works.
-      await rig.setMeasuredExcitationMv(null);
-      expect(rig.measuredExcitationMv, isNull);
-    });
-
-    test(
-      'the value survives a restart (new RigState on the same prefs)',
-      () async {
-        final rig = await settledRig();
-        rig.onFlashRead('dev1', 'Bench unit', fixture());
-        await rig.setMeasuredExcitationMv(4530.2);
-
-        final rig2 = await settledRig();
-        expect(rig2.measuredExcitationMv, isNull); // no doc read yet
-        rig2.onFlashRead('dev1', 'Bench unit', fixture());
-        expect(rig2.measuredExcitationMv, 4530.2);
-      },
-    );
   });
 }

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -294,13 +294,13 @@ void main() {
 
         final hub = DataHub();
         final sp = ladderSetpointsMvV(nominalLadderResistors);
-        // ch0 measures at twice the nominal span; other channels nominal.
+        // ch0 measures at half the nominal span; other channels nominal.
         hub.updateBoardCalibration(
           BoardCalibration(
             channels: [
               ChannelBoardCalibration(
                 readings: [
-                  for (final d in sp) 500 + 2 * nominalCountsPerMvV * d,
+                  for (final d in sp) 500 + 0.5 * nominalCountsPerMvV * d,
                 ],
               ),
               ChannelBoardCalibration(),
@@ -333,10 +333,10 @@ void main() {
         final row = await AppDatabase.instance.sessionById(writer.sessionId);
         final loaded = (await SessionStorage.loadSession(row!))!;
 
-        // Board snapshot: ch0 at 2x nominal span.
+        // Board snapshot: ch0 at 0.5x nominal span.
         expect(
           loaded.calibrationFor(0).board.spanCountsPerMvV,
-          closeTo(2 * nominalCountsPerMvV, 1e-3),
+          closeTo(0.5 * nominalCountsPerMvV, 1e-3),
         );
         expect(loaded.calibrationFor(0).board.isFactoryCalibrated, isTrue);
         // Load cell snapshot round-trips with its exact sensitivity.
@@ -347,7 +347,7 @@ void main() {
         final kgf = ForceUnit.kgf.converterFor(loaded.calibrationFor(0), 0)!;
         expect(
           kgf(1000),
-          closeTo(1000 / (2 * nominalCountsPerMvV) * (100 / 2.02), 1e-9),
+          closeTo(1000 / (0.5 * nominalCountsPerMvV) * (100 / 2.02), 1e-9),
         );
         // ch1 had no load cell assigned at recording time.
         expect(ForceUnit.kgf.converterFor(loaded.calibrationFor(1), 0), isNull);

--- a/test/settings_tab_test.dart
+++ b/test/settings_tab_test.dart
@@ -23,10 +23,13 @@ void main() {
     UniversalBle.setInstance(MockBlePlatform.instance);
     final events = AppEvents();
     final link = BleLinkManager(events: events);
+    final prefs = await SharedPreferences.getInstance();
     await tester.pumpWidget(
       MultiProvider(
         providers: [
-          ChangeNotifierProvider<AppSettings>(create: (_) => AppSettings()),
+          ChangeNotifierProvider<AppSettings>.value(
+            value: AppSettings(prefs: prefs),
+          ),
           ChangeNotifierProvider<BleLinkManager>.value(value: link),
         ],
         child: const MaterialApp(home: Scaffold(body: SettingsTab())),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -41,9 +41,10 @@ void main() {
     final linkManager = BleLinkManager(events: appEvents)
       ..onAdcData = decoder.onDataPacket
       ..onCalibrationData = decoder.onCalibrationPacket;
-    final rigState = RigState(transport: linkManager, events: appEvents);
+    final prefs = await SharedPreferences.getInstance();
+    final rigState = RigState(transport: linkManager, prefs: prefs);
     decoder.onDeviceFlash = (flash) => rigState.onFlashRead(
-      linkManager.selectedDeviceId,
+      linkManager.connectedDeviceId,
       linkManager.connectedDeviceName,
       flash,
     );
@@ -57,7 +58,7 @@ void main() {
     await tester.pumpWidget(
       MultiProvider(
         providers: [
-          ChangeNotifierProvider(create: (_) => AppSettings()),
+          ChangeNotifierProvider.value(value: AppSettings(prefs: prefs)),
           Provider.value(value: appEvents),
           ChangeNotifierProvider.value(value: dataHub),
           ChangeNotifierProvider.value(value: linkManager),


### PR DESCRIPTION
## Summary

Implements the settings/calibration code review: reduces branching, state,
and bug surface while keeping the architecture (device flash as sole rig
truth, pending edits, history quick-pick, ownership gating) intact.
Net **−408 lines** across 22 files; analyzer clean; all 243 tests pass.

## Functionality removed (with rationale)

- **DMM excitation cross-check** — the codebase's own docs state the
  ratiometric calibration is authoritative and a DMM reading "can only
  verify the chain, not improve it." Removes a persisted map, a settings
  field with a fragile focus contract, and a rebuild-per-keystroke path.
- **"Changed since your last visit" snackbar** — informational only; the
  slots UI shows the device's truth at every connect. Pending-edit stale
  detection is unaffected (it now compares slot cells directly instead of
  JSON signatures).

## State reduced

- `SharedPreferences` is injected via constructors (awaited in `main`), so
  loads are synchronous — `_modifiedKeys` and the "async load clobbers a
  user edit" race are gone from both `AppSettings` and `RigState`.
- Dead code deleted: `ChannelCalibration.net*`, `mvVPerCountAt`,
  `BoardCalibration.nominal()`/`serialize()`, `PendingRigEdits.startedAt`.
- Settings sections use narrow `select`s instead of watching all of
  `RigState`; `selectedDeviceId`/`connectedDeviceId` unified to one name.

## Branching reduced

- `mvVFromRaw`: clamped segment search, single interpolation expression.
- `ForceUnit` converters: one shared scale helper; unreachable `throw`s gone.
- Save-state bar: one layout with `Visibility(maintainSize: …)` instead of
  two scaffolds held equal by a hand-maintained height constant.
- Slot labels ('CH 1'/'Slot 5') unified in one helper (fixes 'CH1' vs
  'CH 1' inconsistency).

## Bugs fixed

- `onFlashRead` could adopt a flash doc under an empty device id when the
  link dropped mid-read — now ignored.
- Malformed persisted history entries no longer discard the whole history.
- Flash readings validated: non-finite (`double.tryParse` accepts
  'NaN'/'Infinity'), beyond the 24-bit ADC range, or near-duplicate points
  (÷~0 in interpolation) all degrade the channel to nominal; non-positive
  resistors degrade to the nominal ladder. (Two pre-existing test fixtures
  used physically impossible readings and were corrected.)
- Slot editor accepts comma decimal separators without misparsing
  thousands-grouped input.

## Test plan

- `flutter analyze` clean, `flutter test` 243/243 pass.
- Coverage adjusted, not just deleted: empty-id flash read, malformed
  history entry, out-of-range/near-duplicate/non-positive flash values,
  mtime-insensitive pending restore.