### PR TITLE
Harden the rig save path: verify writes by read-back, preserve unknown flash keys

### DIFF
--- a/lib/models/calibration.dart
+++ b/lib/models/calibration.dart
@@ -451,28 +451,66 @@ class RigSlots {
   }
 }
 
+/// Every key the model parses: board keys for the [nwNumAdcChan] channels
+/// it has, slot keys for the [kRigSlotCount] slots it has, and the two
+/// `cal.*` metadata keys. Anything else in a flash document (a newer
+/// firmware's keys, another tool's metadata) is NOT ours — it is kept
+/// verbatim in [DeviceFlash.extraLines] so a save can't erase it.
+final Set<String> _knownFlashKeys = {
+  'cal.date',
+  'cal.exc.mv',
+  for (int i = 0; i < nwNumAdcChan; ++i) ...['ch$i.r', 'ch$i.raw'],
+  for (int i = 0; i < kRigSlotCount; ++i) ...[
+    'lc$i.name',
+    'lc$i.cap',
+    'lc$i.sens',
+    'lc$i.mtime',
+  ],
+};
+
 /// The full device flash document: the factory board calibration (read-only
 /// to the app) plus the app-writable load cell slots. This is the unit the
 /// calibration characteristic reads and writes.
 class DeviceFlash {
-  const DeviceFlash({required this.board, required this.slots});
+  DeviceFlash({
+    required this.board,
+    required this.slots,
+    List<String>? extraLines,
+  }) : extraLines = List.unmodifiable(extraLines ?? const []);
 
   final BoardCalibration board;
   final RigSlots slots;
 
+  /// Lines from the parsed document whose keys the model doesn't know, in
+  /// original order, re-emitted verbatim by [serialize]. The app is the
+  /// courier of the whole document, not just the keys it understands: a
+  /// save must never silently erase flash content written by newer firmware
+  /// or other tools.
+  final List<String> extraLines;
+
   /// Parse a whole flash document. Never throws: structural problems degrade
-  /// only the affected piece (channel → nominal, slot → empty).
+  /// only the affected piece (channel → nominal, slot → empty). Unknown
+  /// `key=value` lines are preserved in [extraLines].
   factory DeviceFlash.parse(String text) {
     final kv = parseFlashKv(text);
     return DeviceFlash(
       board: BoardCalibration.fromKv(kv),
       slots: RigSlots.fromKv(kv),
+      extraLines: [
+        for (final rawLine in text.split(RegExp(r'\r?\n')))
+          if (rawLine.trim().contains('='))
+            if (!_knownFlashKeys.contains(
+              rawLine.trim().substring(0, rawLine.trim().indexOf('=')).trim(),
+            ))
+              rawLine.trim(),
+      ],
     );
   }
 
   /// Serialize the whole document. The app only ever writes with [slots] it
   /// intends to persist and [board] exactly as read — board keys round-trip
-  /// verbatim (the app is not their owner, just their courier).
+  /// verbatim (the app is not their owner, just their courier), and unknown
+  /// keys ride along in [extraLines].
   String serialize() {
     final b = StringBuffer('K3CAL1\n');
     if (board.factoryDate != null) b.writeln('cal.date=${board.factoryDate}');
@@ -481,14 +519,32 @@ class DeviceFlash {
     }
     for (int i = 0; i < board.channels.length; ++i) {
       final ch = board.channels[i];
-      b.writeln('ch$i.r=${ch.resistors.join(',')}');
+      // Only write the resistor key when it carries real information:
+      // characterized values, or factory readings present. Stamping the
+      // nominal ladder onto a blank flash would write values no hardware
+      // ever produced, presented as characterization.
+      if (ch.readings != null || !_isNominalLadder(ch.resistors)) {
+        b.writeln('ch$i.r=${ch.resistors.join(',')}');
+      }
       final r = ch.readings;
       if (r != null) b.writeln('ch$i.raw=${r.join(',')}');
+    }
+    for (final line in extraLines) {
+      b.writeln(line);
     }
     slots.serializeInto(b);
     b.write('END');
     return b.toString();
   }
+}
+
+/// Whether [r] is exactly the nominal ladder (i.e. carries no characterized
+/// information worth persisting).
+bool _isNominalLadder(List<double> r) {
+  for (int i = 0; i < kLadderResistorCount; ++i) {
+    if (r[i] != nominalLadderResistors[i]) return false;
+  }
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/services/ble_link_manager.dart
+++ b/lib/services/ble_link_manager.dart
@@ -457,6 +457,27 @@ class BleLinkManager extends ChangeNotifier implements RigFlashTransport {
     );
   }
 
+  /// Read the flash document back from the connected device (save
+  /// verification in `RigState.saveToDevice`). Null when nothing is
+  /// connected or the read fails — a failed verification must fail the save,
+  /// never crash it.
+  @override
+  Future<String?> readFlashDoc() async {
+    final deviceId = _link.deviceId;
+    if (deviceId.isEmpty) return null;
+    if (deviceId == DeviceLink.demoDeviceId) return _demoFlashDoc;
+    try {
+      final bytes = await UniversalBle.read(
+        deviceId,
+        btServiceId,
+        btChrCalibration,
+      );
+      return utf8.decode(bytes, allowMalformed: true);
+    } catch (_) {
+      return null;
+    }
+  }
+
   BleLinkManager({required AppEvents events}) : _events = events {
     if (useMockBt) {
       UniversalBle.setInstance(MockBlePlatform.instance);

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -218,11 +218,22 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
 
   bool get taring => (_tareCount > 0);
 
-  /// Request a new tare operation (zeros readings using next N samples).
+  /// Wall-clock deadline for an in-progress tare: a window that stops
+  /// filling (device gone silent) would otherwise leave the hub "taring"
+  /// forever — recording stays refused and the user gets no completion.
+  /// Generous (several window lengths) so a lossy link pausing the average
+  /// doesn't abort a legitimate tare. Checked in [commitBatch].
+  static const Duration _tareTimeout = Duration(milliseconds: _tareWindow * 5);
+  DateTime _tareDeadline = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// Request a new tare operation (zeros readings using the next N real
+  /// samples). The previous offsets stay in effect while the window fills —
+  /// zeroing them up front would make live values jump to absolute
+  /// (offset-inclusive) readings for a second, then snap back.
   void requestTare() {
     _tareCount = _tareWindow;
+    _tareDeadline = DateTime.now().add(_tareTimeout);
     for (int i = 0; i < numAdcChannels; ++i) {
-      tare[i] = 0;
       _runningTotal[i] = 0;
     }
   }
@@ -290,16 +301,52 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
         listener(startIdx, count);
       }
     }
+    // Abandon a tare whose window stopped filling (device gone silent
+    // mid-tare): the pre-tare offsets are still in effect — nothing was
+    // zeroed up front — and the user can simply tare again.
+    if (taring && DateTime.now().isAfter(_tareDeadline)) {
+      _tareCount = 0;
+      for (int i = 0; i < numAdcChannels; ++i) {
+        _runningTotal[i] = 0;
+      }
+    }
     lastDataAt = DateTime.now();
     gaps.pruneBefore(totalSamples - maxDataSz); // ring-wrap hygiene
     notifyListeners();
   }
 
   /// Replace the board calibration (a freshly-parsed factory read arrived).
+  /// Content-equal updates are a no-op (same rule as [updateLoadCells]): a
+  /// reconnect re-reading an identical document must not invalidate the
+  /// graph segment caches.
   void updateBoardCalibration(BoardCalibration calibration) {
+    final prev = _boardCalibration;
+    if (prev != null && _sameBoardCalibration(prev, calibration)) return;
     _boardCalibration = calibration;
     _calibrationVersion++;
     notifyListeners();
+  }
+
+  /// Content equality for cache invalidation: the channels' resistors and
+  /// readings (the conversion inputs). factoryDate/excitationMv are display
+  /// metadata — they change nothing the graphs render.
+  static bool _sameBoardCalibration(BoardCalibration a, BoardCalibration b) {
+    for (int i = 0; i < a.channels.length; ++i) {
+      final x = a.channels[i];
+      final y = b.channels[i];
+      for (int k = 0; k < x.resistors.length; ++k) {
+        if (x.resistors[k] != y.resistors[k]) return false;
+      }
+      final xr = x.readings;
+      final yr = y.readings;
+      if ((xr == null) != (yr == null)) return false;
+      if (xr != null && yr != null) {
+        for (int k = 0; k < xr.length; ++k) {
+          if (xr[k] != yr[k]) return false;
+        }
+      }
+    }
+    return true;
   }
 
   /// Replace the per-channel load-cell assignments (the rig's slots changed:

--- a/lib/services/rig_state.dart
+++ b/lib/services/rig_state.dart
@@ -20,6 +20,10 @@ abstract interface class RigFlashTransport {
   /// Write a serialized [DeviceFlash] document to the connected device.
   /// Throws on failure — the caller keeps its pending edits.
   Future<void> writeFlashDoc(String doc);
+
+  /// Read the flash document back from the connected device (save
+  /// verification). Null on failure or when no device is connected.
+  Future<String?> readFlashDoc();
 }
 
 /// A "last seen values" entry: a cell this app has met (on a device flash
@@ -30,7 +34,6 @@ class RigHistoryEntry {
     required this.cell,
     required this.lastSeen,
     required this.deviceName,
-    required this.origin,
   });
 
   final LoadCellProfile cell;
@@ -39,16 +42,13 @@ class RigHistoryEntry {
   /// Device the entry was last seen on (or added on), for display.
   String deviceName;
 
-  /// 'device' (read from flash) or 'manual' (typed by the user).
-  String origin;
-
   Map<String, dynamic> toJson() => {
     'cell': cell.toJson(),
     'lastSeen': lastSeen.millisecondsSinceEpoch,
     'deviceName': deviceName,
-    'origin': origin,
   };
 
+  /// Tolerant of extra keys (older versions persisted an 'origin' field).
   factory RigHistoryEntry.fromJson(Map<String, dynamic> json) =>
       RigHistoryEntry(
         cell: LoadCellProfile.fromJson(
@@ -56,7 +56,6 @@ class RigHistoryEntry {
         ),
         lastSeen: DateTime.fromMillisecondsSinceEpoch(json['lastSeen'] as int),
         deviceName: json['deviceName'] as String? ?? '',
-        origin: json['origin'] as String? ?? 'device',
       );
 }
 
@@ -193,14 +192,18 @@ class RigState extends ChangeNotifier {
     _lastFlash = flash;
     _flashDeviceId = deviceId;
 
-    // History: every populated slot on the device was "seen" now.
+    // History: every populated slot on the device was "seen" now. One
+    // persist for the batch, not one per cell.
     final now = DateTime.now();
+    var seenAny = false;
     for (int i = 0; i < kRigSlotCount; ++i) {
       final cell = flash.slots.cellAt(i);
       if (cell != null) {
-        _upsertHistory(cell, deviceName, 'device', now);
+        _upsertHistory(cell, deviceName, now, persist: false);
+        seenAny = true;
       }
     }
+    if (seenAny) unawaited(_persistHistory());
 
     notifyListeners();
   }
@@ -234,12 +237,7 @@ class RigState extends ChangeNotifier {
   void setSlot(int i, LoadCellProfile cell) {
     final p = _ensurePending();
     p.edited = p.edited.withSlot(i, RigSlot(cell: cell));
-    _upsertHistory(
-      cell,
-      _transport.connectedDeviceName,
-      'manual',
-      DateTime.now(),
-    );
+    _upsertHistory(cell, _transport.connectedDeviceName, DateTime.now());
     notifyListeners();
   }
 
@@ -268,26 +266,60 @@ class RigState extends ChangeNotifier {
   }
 
   /// Write the edited slots (with fresh mtimes) to the device, alongside the
-  /// board keys exactly as read. Returns false when the transport fails —
-  /// pending edits are kept so the user can retry or revert.
+  /// board keys exactly as read, then verify with a read-back. Returns false
+  /// when the write or the verification fails — pending edits are kept so
+  /// the user can retry or revert.
   Future<bool> saveToDevice() async {
     final pending = _pending;
     final flash = _lastFlash;
     if (pending == null || flash == null) return true;
+    // The write must go to the device the edits belong to — anything else
+    // would stamp this document's factory board keys onto another device's
+    // flash. The UI gates the Save button on this; the check belongs here
+    // too, next to the write.
+    if (pending.deviceId != _transport.connectedDeviceId) return false;
+    final edited = pending.edited;
     final now = DateTime.now().toUtc();
     final stamped = RigSlots([
       for (int i = 0; i < kRigSlotCount; ++i)
-        pending.edited.slots[i]?.copyWith(mtime: now),
+        edited.slots[i]?.copyWith(mtime: now),
     ]);
-    final doc = DeviceFlash(board: flash.board, slots: stamped).serialize();
+    final doc = DeviceFlash(
+      board: flash.board,
+      slots: stamped,
+      extraLines: flash.extraLines,
+    ).serialize();
     try {
       await _transport.writeFlashDoc(doc);
     } catch (_) {
       return false;
     }
-    // The device now holds exactly what we wrote: adopt it as the new flash
-    // truth and clear the pending session.
-    _lastFlash = DeviceFlash(board: flash.board, slots: stamped);
+    // Verify: "the device holds exactly what we wrote" is an assumption,
+    // not a fact (firmware may reject, truncate or normalize the write).
+    // Adopting the composed document as truth without checking would let
+    // app state diverge from the device silently — and there is no later
+    // change detection to catch it.
+    final String? readBack;
+    try {
+      readBack = await _transport.readFlashDoc();
+    } catch (_) {
+      return false;
+    }
+    if (readBack == null) return false;
+    final verified = DeviceFlash.parse(readBack);
+    if (!_sameCells(verified.slots, stamped)) return false;
+    // Commit only if nothing moved under the in-flight write: a revert, a
+    // fresh edit, or a reconnect's flash read means the newer state wins.
+    // (The UI also blocks edits while saving; this is the model-side guard.)
+    if (!identical(_pending, pending) ||
+        !identical(pending.edited, edited) ||
+        !identical(_lastFlash, flash)) {
+      return false;
+    }
+    // The device provably holds this document — adopt the READ-BACK version
+    // as the new flash truth (not the composed one), so any normalization
+    // the device applied is reflected in app state too.
+    _lastFlash = verified;
     _pending = null;
     notifyListeners();
     return true;
@@ -298,32 +330,26 @@ class RigState extends ChangeNotifier {
   void _upsertHistory(
     LoadCellProfile cell,
     String deviceName,
-    String origin,
-    DateTime now,
-  ) {
+    DateTime now, {
+    bool persist = true,
+  }) {
     for (final e in _history) {
       if (e.cell == cell) {
         e.lastSeen = now;
         e.deviceName = deviceName;
-        e.origin = origin;
         _history.sort((a, b) => b.lastSeen.compareTo(a.lastSeen));
-        unawaited(_persistHistory());
+        if (persist) unawaited(_persistHistory());
         return;
       }
     }
     _history.add(
-      RigHistoryEntry(
-        cell: cell,
-        lastSeen: now,
-        deviceName: deviceName,
-        origin: origin,
-      ),
+      RigHistoryEntry(cell: cell, lastSeen: now, deviceName: deviceName),
     );
     _history.sort((a, b) => b.lastSeen.compareTo(a.lastSeen));
     if (_history.length > historyCap) {
       _history = _history.sublist(0, historyCap);
     }
-    unawaited(_persistHistory());
+    if (persist) unawaited(_persistHistory());
   }
 
   Future<void> _persistHistory() => _prefs.setString(

--- a/lib/widgets/rig_slots_section.dart
+++ b/lib/widgets/rig_slots_section.dart
@@ -23,9 +23,9 @@ const quickSensitivitiesMvV = <double>[1, 2, 3];
 /// Edits and swaps take effect in this app immediately and raise the dirty
 /// state of the status bar; nothing reaches the device until "Save to
 /// device" (the flash doc is the rig's single truth — reads are automatic,
-/// writes are explicit). The bar is ALWAYS present — clean state reads
-/// "All settings saved to device." — so the list below never jumps when
-/// the dirty state flips.
+/// writes are explicit). The bar is ALWAYS present — the clean state reads
+/// "Settings shown are read from the device." — so the list below never
+/// jumps when the dirty state flips.
 class RigSlotsSection extends StatefulWidget {
   const RigSlotsSection({super.key});
 
@@ -154,6 +154,10 @@ class _RigSlotsSectionState extends State<RigSlotsSection> {
   /// — to the row's X for the whole drag, so it slides straight up and
   /// down the list instead of following the pointer sideways.
   ///
+  /// All edit affordances (tap, drag start, drop) close while a save is in
+  /// flight: an edit landing mid-write would mutate the pending session the
+  /// save already snapshotted (see RigState.saveToDevice's state guard).
+  ///
   /// TODO: also start the drag on a long-press anywhere on the row — the
   /// touch-platform pattern in ReorderableListView — while keeping the
   /// handle for immediate dragging on desktop.
@@ -169,7 +173,7 @@ class _RigSlotsSectionState extends State<RigSlotsSection> {
 
     return DragTarget<int>(
       // Dropping a row onto itself is not offered (and not highlighted).
-      onWillAcceptWithDetails: (details) => details.data != i,
+      onWillAcceptWithDetails: (details) => !_saving && details.data != i,
       onAcceptWithDetails: (details) => rig.swapSlots(details.data, i),
       // The tile is built inside the builder so the drag feedback can be
       // anchored to this row's render box (rowContext).
@@ -190,7 +194,7 @@ class _RigSlotsSectionState extends State<RigSlotsSection> {
               Icons.add_circle_outline,
               color: theme.colorScheme.outline,
             ),
-            onTap: () => showAddToSlot(context, rig, i),
+            onTap: _saving ? null : () => showAddToSlot(context, rig, i),
           );
         } else {
           final cell = slot.cell;
@@ -204,6 +208,7 @@ class _RigSlotsSectionState extends State<RigSlotsSection> {
             trailing: Draggable<int>(
               data: i,
               axis: Axis.vertical,
+              maxSimultaneousDrags: _saving ? 0 : 1,
               // Anchor the feedback to the row, not the handle: the
               // default childDragAnchorStrategy would pin the feedback's
               // X to the handle's left edge, hanging the full-width row
@@ -234,7 +239,7 @@ class _RigSlotsSectionState extends State<RigSlotsSection> {
                 ),
               ),
             ),
-            onTap: () => showSlotEditor(context, rig, i),
+            onTap: _saving ? null : () => showSlotEditor(context, rig, i),
           );
         }
 
@@ -342,7 +347,10 @@ class _StatusBar extends StatelessWidget {
                 dirty
                     ? 'Changes not saved to device — readings in this app '
                           'already use them.'
-                    : 'All settings saved to device.',
+                    // Provenance, not a success claim: the clean state also
+                    // covers a revert and a stale-edit discard, where "saved"
+                    // would be a lie.
+                    : 'Settings shown are read from the device.',
                 style: theme.textTheme.bodySmall?.copyWith(color: fg),
               ),
             ),
@@ -629,9 +637,11 @@ String _num(double v) =>
     v == v.roundToDouble() ? v.toInt().toString() : v.toString();
 
 /// Parse a typed-in number, tolerating a comma decimal separator (some
-/// locales' decimal key inserts one). Input that already has a '.', or has
-/// several commas, is parsed as-is — thousands-grouped text fails to parse
-/// rather than silently misparsing.
+/// locales' decimal key inserts one). A single comma with no '.' is treated
+/// as a decimal separator — that reads the cal-cert example "2,007"
+/// correctly as 2.007, at the cost of reading thousands-grouped "1,000" as
+/// 1.0 (an accepted ambiguity in the decimal-comma direction; inputs with
+/// several commas, or both separators, fail to parse rather than misparse).
 double? _typedNumber(String s) {
   final t = s.trim();
   if (!t.contains('.') && t.indexOf(',') == t.lastIndexOf(',')) {

--- a/test/board_calibration_section_test.dart
+++ b/test/board_calibration_section_test.dart
@@ -21,6 +21,9 @@ class _FakeTransport implements RigFlashTransport {
 
   @override
   Future<void> writeFlashDoc(String doc) async {}
+
+  @override
+  Future<String?> readFlashDoc() async => null;
 }
 
 void main() {

--- a/test/data_hub_test.dart
+++ b/test/data_hub_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:dynamite_app/models/calibration.dart';
 import 'package:dynamite_app/models/force_unit.dart';
 import 'package:dynamite_app/services/data_hub.dart';
+import 'package:dynamite_app/services/demo_calibration.dart';
 
 /// Unit tests for the hub's per-stream lifecycle (peaks, tare, reset). Uses
 /// [ForceUnit.raw] throughout so forces equal tare-adjusted raw counts.
@@ -197,6 +198,28 @@ void main() {
         expect(hub.rawData[0][110], 1000); // held value inside the gap
       },
     );
+
+    test('a re-tare holds the old offsets until the new average lands', () {
+      final hub = DataHub();
+      feed(hub, frameOf(1000), 1024);
+      hub.requestTare();
+      feed(hub, frameOf(1000), 1024);
+      expect(hub.tare[0], 1000); // established
+
+      // Re-tare at a new level: during the window the display must NOT
+      // jump to absolute (offset-inclusive) readings — the old offsets
+      // stay in effect until the new average lands.
+      hub.requestTare();
+      feed(hub, frameOf(1500), 100);
+      expect(hub.taring, isTrue);
+      expect(hub.tare[0], 1000);
+      expect(hub.currentValue(0, ForceUnit.raw), 500); // 1500 - 1000
+
+      feed(hub, frameOf(1500), 1024 - 100);
+      expect(hub.taring, isFalse);
+      expect(hub.tare[0], 1500);
+      expect(hub.currentValue(0, ForceUnit.raw), 0);
+    });
   });
 
   group('calibration', () {
@@ -273,6 +296,32 @@ void main() {
         hub.currentDerivative(0, ForceUnit.raw),
         1000.0 * DataHub.samplesPerSec,
       );
+    });
+
+    test('content-equal board calibration does not bump the version', () {
+      final hub = DataHub();
+      hub.updateBoardCalibration(
+        BoardCalibration.parse(demoBoardCalibrationDoc),
+      );
+      final v1 = hub.calibrationVersion;
+
+      // A reconnect re-reading the identical document (new instances, same
+      // content) must not invalidate the graph caches.
+      hub.updateBoardCalibration(
+        BoardCalibration.parse(demoBoardCalibrationDoc),
+      );
+      expect(hub.calibrationVersion, v1);
+
+      // A genuinely changed document bumps the version again.
+      hub.updateBoardCalibration(
+        BoardCalibration.parse(
+          demoBoardCalibrationDoc.replaceFirst(
+            'ch0.raw=6386310.2',
+            'ch0.raw=6386310.3',
+          ),
+        ),
+      );
+      expect(hub.calibrationVersion, greaterThan(v1));
     });
 
     test('content-equal load cell updates do not bump the version', () {

--- a/test/rig_slots_section_test.dart
+++ b/test/rig_slots_section_test.dart
@@ -29,6 +29,9 @@ class _FakeTransport implements RigFlashTransport {
   Future<void> writeFlashDoc(String doc) async {
     lastWrittenDoc = doc;
   }
+
+  @override
+  Future<String?> readFlashDoc() async => lastWrittenDoc;
 }
 
 void main() {
@@ -93,7 +96,10 @@ void main() {
       expect(find.text('CH $i'), findsOneWidget);
     }
     // Nothing dirty yet: the status bar shows its clean state.
-    expect(find.text('All settings saved to device.'), findsOneWidget);
+    expect(
+      find.text('Settings shown are read from the device.'),
+      findsOneWidget,
+    );
     expect(find.textContaining('Changes not saved to device'), findsNothing);
   });
 
@@ -125,7 +131,10 @@ void main() {
     expect(rig.hasPending, isFalse);
     expect(rig.channelCells[3], isNull);
     expect(find.textContaining('Changes not saved to device'), findsNothing);
-    expect(find.text('All settings saved to device.'), findsOneWidget);
+    expect(
+      find.text('Settings shown are read from the device.'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('dragging a slot onto another swaps them', (tester) async {

--- a/test/rig_slots_test.dart
+++ b/test/rig_slots_test.dart
@@ -97,6 +97,42 @@ void main() {
       expect(doc.contains('lc0.name=a=b c'), isTrue);
       expect(DeviceFlash.parse(doc).slots.cellAt(0)?.name, 'a=b c');
     });
+
+    test('unknown keys are preserved verbatim through parse + serialize', () {
+      const withExtras =
+          'K3CAL1\n'
+          'cal.date=2026-07-20\n'
+          'hw.rev=3\n'
+          'future.tooling=keep me\n'
+          'ch4.raw=1,2,3,4,5\n' // a future 8-channel device's key
+          'lc0.cap=100\n'
+          'lc0.sens=2\n'
+          'END\n';
+      final flash = DeviceFlash.parse(withExtras);
+      expect(flash.extraLines, [
+        'hw.rev=3',
+        'future.tooling=keep me',
+        'ch4.raw=1,2,3,4,5',
+      ]);
+
+      final roundTripped = DeviceFlash.parse(flash.serialize());
+      expect(roundTripped.extraLines, flash.extraLines);
+      expect(roundTripped.slots.cellAt(0)?.capacityKg, 100);
+      expect(roundTripped.board.factoryDate, '2026-07-20');
+    });
+
+    test('a blank-flash board does not get nominal resistors stamped', () {
+      // No ch* keys in the source: serializing must not invent them —
+      // nominal values written as 'chN.r' would pose as characterization.
+      final flash = DeviceFlash.parse('K3CAL1\nlc0.cap=100\nlc0.sens=2\nEND\n');
+      final doc = flash.serialize();
+      expect(doc.contains('ch'), isFalse, reason: doc);
+
+      // Characterized values DO round-trip (the fixture's real board).
+      final realDoc = DeviceFlash.parse(demoBoardCalibrationDoc).serialize();
+      expect(realDoc.contains('ch0.r='), isTrue);
+      expect(realDoc.contains('ch3.raw='), isTrue);
+    });
   });
 
   group('RigSlots', () {

--- a/test/rig_state_test.dart
+++ b/test/rig_state_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -14,6 +16,14 @@ class _FakeTransport implements RigFlashTransport {
   String? lastWrittenDoc;
   bool failWrite = false;
 
+  /// Served on read-back instead of the last written doc, to simulate a
+  /// device that ignores or rewrites what it received.
+  String? readBackDoc;
+
+  /// When set, the write completes only once this gate does — lets a test
+  /// land an edit while a save is in flight.
+  Completer<void>? writeGate;
+
   @override
   String get connectedDeviceId => deviceId;
 
@@ -23,8 +33,14 @@ class _FakeTransport implements RigFlashTransport {
   @override
   Future<void> writeFlashDoc(String doc) async {
     if (failWrite) throw StateError('write failed');
+    final gate = writeGate;
+    if (gate != null) await gate.future;
     lastWrittenDoc = doc;
   }
+
+  /// A faithful device serves back exactly what was last written.
+  @override
+  Future<String?> readFlashDoc() async => readBackDoc ?? lastWrittenDoc;
 }
 
 void main() {
@@ -250,6 +266,86 @@ void main() {
       expect(await rig.saveToDevice(), isFalse);
       expect(rig.hasPending, isTrue);
       expect(rig.channelTitles[3], 'New');
+    });
+
+    test('refuses to write while a different device is connected', () async {
+      final rig = await newRig();
+      rig.onFlashRead('dev1', 'Bench unit', fixture());
+      rig.setSlot(
+        3,
+        LoadCellProfile(name: 'New', capacityKg: 50, sensitivityMvV: 1),
+      );
+      // The pending edits belong to dev1, but dev2 is on the link now:
+      // writing would stamp dev1's factory board keys onto dev2's flash.
+      transport.deviceId = 'dev2';
+
+      expect(await rig.saveToDevice(), isFalse);
+      expect(transport.lastWrittenDoc, isNull); // nothing was sent
+      expect(rig.hasPending, isTrue);
+      expect(rig.channelTitles[3], 'New');
+    });
+
+    test('a read-back mismatch fails the save and keeps the edits', () async {
+      final rig = await newRig();
+      rig.onFlashRead('dev1', 'Bench unit', fixture());
+      rig.setSlot(
+        3,
+        LoadCellProfile(name: 'New', capacityKg: 50, sensitivityMvV: 1),
+      );
+      // The device silently ignored the write: it serves the OLD document.
+      transport.readBackDoc = demoBoardCalibrationDoc;
+
+      expect(await rig.saveToDevice(), isFalse);
+      expect(rig.hasPending, isTrue);
+      expect(rig.channelTitles[3], 'New');
+      // The flash truth was NOT advanced to the unverified write.
+      expect(rig.pending?.edited.cellAt(3)?.name, 'New');
+    });
+
+    test('an edit landing mid-write is kept, not silently discarded', () async {
+      final rig = await newRig();
+      rig.onFlashRead('dev1', 'Bench unit', fixture());
+      rig.setSlot(
+        3,
+        LoadCellProfile(name: 'New', capacityKg: 50, sensitivityMvV: 1),
+      );
+
+      transport.writeGate = Completer<void>();
+      final saveFuture = rig.saveToDevice();
+      // The save has snapshotted its document; this edit lands in the same
+      // pending session while the write is in flight.
+      rig.setSlot(
+        4,
+        LoadCellProfile(name: 'Other', capacityKg: 10, sensitivityMvV: 2),
+      );
+      transport.writeGate!.complete();
+
+      // The save refuses to commit: the pending session moved under it.
+      expect(await saveFuture, isFalse);
+      expect(rig.hasPending, isTrue);
+      expect(rig.channelTitles[3], 'New');
+      expect(rig.effectiveSlots.cellAt(4)?.name, 'Other');
+      // The flash truth was not advanced past the real read.
+      expect(rig.pending?.edited.cellAt(4)?.name, 'Other');
+    });
+
+    test('unknown flash keys ride through the save verbatim', () async {
+      final rig = await newRig();
+      const withExtras =
+          'K3CAL1\n'
+          'cal.date=2026-07-20\n'
+          'hw.rev=3\n'
+          'future.tooling=keep me\n'
+          'END\n';
+      rig.onFlashRead('dev1', 'Bench unit', DeviceFlash.parse(withExtras));
+      rig.setSlot(
+        3,
+        LoadCellProfile(name: 'New', capacityKg: 50, sensitivityMvV: 1),
+      );
+
+      expect(await rig.saveToDevice(), isTrue);
+      expect(transport.lastWrittenDoc, contains('hw.rev=3'));
+      expect(transport.lastWrittenDoc, contains('future.tooling=keep me'));
     });
   });
 


### PR DESCRIPTION
## Summary

Implements the remaining findings from the settings/calibration review:
the save-to-device path (the review's main open cluster), tare behavior,
and the smaller fixes. **+404/−51** across 10 files (most of the growth is
tests); analyzer clean; **251 tests pass (+8)**.

## Save path hardened (the review's main cluster)

- **Device-identity check in the model** — `RigState.saveToDevice` now
  refuses to write when the pending edits belong to a different device
  than the one on the link. Previously only the UI's `canSave` prevented
  stamping one device's factory board keys onto another's flash.
- **Read-back verification** — "the device holds exactly what we wrote"
  was an assumption (the write path is still `TODO(firmware)`-untested on
  real hardware). The transport gains `readFlashDoc()`; after writing,
  the document is read back and compared. A device that ignored,
  truncated, or normalized the write fails the save and keeps the edits.
  On success the **read-back** document — not the composed one — becomes
  flash truth, so device-side normalization is reflected in app state.
- **Mid-flight race guard** — an edit/revert/reconnect landing under the
  in-flight write previously got silently discarded (or clobbered the
  freshly-read flash doc). The save now refuses to commit when the
  pending session or flash doc moved; slot tap/drag/drop also close
  while a save is in flight.

## Flash format

- **Unknown keys are preserved** — `DeviceFlash.extraLines` keeps any
  `key=value` line the model doesn't own (future firmware keys, other
  tools, a future 8-channel device's `ch4.*`) and re-emits them verbatim.
  A save can no longer erase flash content the app doesn't understand.
- **No nominal stamping** — `ch$i.r=` is written only when it carries
  real information (characterized values, or factory readings present);
  a blank-flash device no longer gets nominal resistors written as if
  they were characterization.

## Tare

- **Re-tare no longer jumps**: the old offsets stay in effect while the
  averaging window fills, instead of zeroing up front and showing
  absolute (offset-inclusive) readings for a second.
- **Stall deadline**: a tare whose window stops filling (device gone
  silent) is abandoned after 5× the window length — previously `taring`
  never timed out, leaving recording refused indefinitely.

## Smaller fixes

- Status bar's clean state: "All settings saved to device." →
  "Settings shown are read from the device." (provenance, not a success
  claim — the clean state also covers reverts and stale-edit discards).
- `updateBoardCalibration` gained the content-equality short-circuit
  `updateLoadCells` already had: identical re-reads no longer invalidate
  the graph caches on every reconnect.
- Dead `RigHistoryEntry.origin` removed; history persists once per flash
  read instead of once per cell.
- `_typedNumber`'s comment now states the real single-comma ambiguity
  ("1,000" → 1.0) instead of claiming thousands input fails safe.

## Test plan

- `flutter analyze` clean, `flutter test` 251/251 pass (+8 new):
  wrong-device refusal, read-back mismatch, edit-mid-write survival,
  unknown-keys-through-save, extraLines round-trip, blank-flash
  no-stamping, re-tare offset hold, board-cal equality.
- Not covered: the tare deadline's wall-clock timing (would need a fake
  clock for one check — judged not worth the injection seam), and the
  real-firmware write/read-back round-trip (`TODO(firmware)` stands —
  the demo device exercises the verification path faithfully).