### PR TITLE
Bulk rename of ForceUnit to DisplayUnit

### DIFF
--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/adc_protocol.dart';
-import 'force_unit.dart';
+import 'display_unit.dart';
 
 /// Application-wide settings, persisted via SharedPreferences.
 ///
@@ -23,9 +23,9 @@ class AppSettings extends ChangeNotifier {
 
     final unitName = _prefs.getString(_keyUnit);
     if (unitName != null) {
-      _displayUnit = ForceUnit.values.firstWhere(
+      _displayUnit = DisplayUnit.values.firstWhere(
         (u) => u.name == unitName,
-        orElse: () => ForceUnit.mVv,
+        orElse: () => DisplayUnit.mVv,
       );
     }
 
@@ -55,8 +55,8 @@ class AppSettings extends ChangeNotifier {
   // mV/V is the default: it converts with board calibration alone, so a
   // fresh install shows meaningful numbers before any load cell is assigned
   // (force units need per-channel load-cell profiles).
-  ForceUnit _displayUnit = ForceUnit.mVv;
-  ForceUnit get displayUnit => _displayUnit;
+  DisplayUnit _displayUnit = DisplayUnit.mVv;
+  DisplayUnit get displayUnit => _displayUnit;
 
   /// Which channels are shown in the live view. Local to the live tab —
   /// each recorded session carries its own visibility set.
@@ -72,7 +72,7 @@ class AppSettings extends ChangeNotifier {
   bool _wakelockEnabled = false;
   bool get wakelockEnabled => _wakelockEnabled;
 
-  Future<void> setDisplayUnit(ForceUnit unit) async {
+  Future<void> setDisplayUnit(DisplayUnit unit) async {
     _displayUnit = unit;
     notifyListeners();
     await _prefs.setString(_keyUnit, unit.name);

--- a/lib/models/calibration.dart
+++ b/lib/models/calibration.dart
@@ -174,7 +174,7 @@ class ChannelBoardCalibration {
   /// Map an absolute raw ADC reading to mV/V of excitation via the piecewise
   /// map. Out-of-range readings extend the outermost segment. Readings are
   /// absolute (offset included): net values come from subtracting the map at
-  /// the tare point — see `ForceUnit.converterFor`.
+  /// the tare point — see `DisplayUnit.converterFor`.
   double mvVFromRaw(double raw) {
     final r = readings;
     if (r == null) return raw / nominalCountsPerMvV;

--- a/lib/models/display_unit.dart
+++ b/lib/models/display_unit.dart
@@ -13,7 +13,7 @@ export 'calibration.dart'
 /// board's piecewise map plus the assigned load cell). Force units are
 /// unavailable — a null converter — for channels without an assigned load
 /// cell; the UI shows '—' there. Electrical units are always available.
-enum ForceUnit {
+enum DisplayUnit {
   kN('kN', 'Kilonewtons', kgfFactor: 9.80665 / 1000),
   lbf('lbf', 'Pounds-force', kgfFactor: 2.20462),
   kgf('kgf', 'Kilogram-force', kgfFactor: 1.0),
@@ -22,7 +22,7 @@ enum ForceUnit {
   mV('mV', 'Cell output voltage'),
   raw('Raw', 'ADC Counts');
 
-  const ForceUnit(this.symbol, this.label, {this.kgfFactor});
+  const DisplayUnit(this.symbol, this.label, {this.kgfFactor});
 
   final String symbol;
   final String label;
@@ -46,7 +46,7 @@ enum ForceUnit {
       final cell = channel.loadCell;
       return cell == null ? null : f * cell.kgfPerMvV;
     }
-    return this == ForceUnit.mV ? channel.board.effectiveExcitationV : 1.0;
+    return this == DisplayUnit.mV ? channel.board.effectiveExcitationV : 1.0;
   }
 
   /// Build the absolute-raw -> display-unit converter for one channel, net of
@@ -62,7 +62,7 @@ enum ForceUnit {
     ChannelCalibration channel,
     double tare,
   ) {
-    if (this == ForceUnit.raw) return (raw) => raw - tare;
+    if (this == DisplayUnit.raw) return (raw) => raw - tare;
     final scale = _scalePerMvV(channel);
     if (scale == null) return null;
     final board = channel.board;
@@ -78,7 +78,7 @@ enum ForceUnit {
   double Function(double rawDiff)? diffConverterFor(
     ChannelCalibration channel,
   ) {
-    if (this == ForceUnit.raw) return (diff) => diff;
+    if (this == DisplayUnit.raw) return (diff) => diff;
     final scale = _scalePerMvV(channel);
     if (scale == null) return null;
     final perCount = scale / channel.board.spanCountsPerMvV;
@@ -90,8 +90,8 @@ enum ForceUnit {
   String _formatValue(double value, String suffix) {
     final sign = value < 0 ? '-' : '+';
     final decimals = switch (this) {
-      ForceUnit.raw => 0,
-      ForceUnit.mV || ForceUnit.mVv => 4,
+      DisplayUnit.raw => 0,
+      DisplayUnit.mV || DisplayUnit.mVv => 4,
       _ => 3,
     };
     final numStr = value.abs().toStringAsFixed(decimals);

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -8,7 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:file_selector/file_selector.dart';
 
 import '../models/app_settings.dart';
-import '../models/force_unit.dart';
+import '../models/display_unit.dart';
 import '../services/database.dart';
 import '../services/session_storage.dart';
 import '../utils/format.dart';
@@ -341,7 +341,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
           final raw = data.channels[ch][s];
           // kgf via the calibration recorded with the session; blank when
           // the channel had no load cell assigned.
-          final kgf = ForceUnit.kgf
+          final kgf = DisplayUnit.kgf
               .converterFor(data.calibrationFor(ch), data.tares[ch])
               ?.call(raw.toDouble());
           buf.write(kgf == null ? ',$raw,' : ',$raw,${kgf.toStringAsFixed(6)}');

--- a/lib/screens/settings_tab.dart
+++ b/lib/screens/settings_tab.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../models/app_settings.dart';
-import '../models/force_unit.dart';
+import '../models/display_unit.dart';
 import '../services/ble_link_manager.dart';
 import '../widgets/board_calibration_section.dart';
 import '../widgets/rig_slots_section.dart';
@@ -49,14 +49,14 @@ class SettingsTab extends StatelessWidget {
           _UnitGroup(
             label: 'Force',
             units: [
-              for (final u in ForceUnit.values)
+              for (final u in DisplayUnit.values)
                 if (u.isForce) u,
             ],
           ),
           _UnitGroup(
             label: 'Electrical',
             units: [
-              for (final u in ForceUnit.values)
+              for (final u in DisplayUnit.values)
                 if (!u.isForce) u,
             ],
           ),
@@ -180,7 +180,7 @@ class _UnitGroup extends StatelessWidget {
   const _UnitGroup({required this.label, required this.units});
 
   final String label;
-  final List<ForceUnit> units;
+  final List<DisplayUnit> units;
 
   @override
   Widget build(BuildContext context) {
@@ -190,7 +190,7 @@ class _UnitGroup extends StatelessWidget {
       children: [
         Text(label, style: Theme.of(context).textTheme.labelMedium),
         const SizedBox(height: 4),
-        SegmentedButton<ForceUnit>(
+        SegmentedButton<DisplayUnit>(
           segments: [
             for (final u in units)
               ButtonSegment(value: u, label: Text(u.symbol)),

--- a/lib/services/data_hub.dart
+++ b/lib/services/data_hub.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'adc_protocol.dart';
 import '../models/bucket_series.dart';
 import '../models/calibration.dart';
-import '../models/force_unit.dart';
+import '../models/display_unit.dart';
 import '../models/gap_list.dart';
 import '../models/graph_data_source.dart';
 
@@ -418,7 +418,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   /// a gap this returns the held (last real) value; check [liveEdgeIsGap] to
   /// mark it stale in the UI. Null when the unit is unavailable for the
   /// channel (a force unit without an assigned load cell).
-  double? currentValue(int adcChannel, ForceUnit unit) {
+  double? currentValue(int adcChannel, DisplayUnit unit) {
     assert(adcChannel >= 0 && adcChannel < numAdcChannels);
     final conv = unit.converterFor(
       calibrationFor(adcChannel),
@@ -430,7 +430,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   /// Get peak value for a given ADC channel in the specified unit. Returns 0
   /// before the first sample arrives ([rawMax] still holds its sentinel);
   /// null when the unit is unavailable for the channel.
-  double? peakValue(int adcChannel, ForceUnit unit) {
+  double? peakValue(int adcChannel, DisplayUnit unit) {
     assert(adcChannel >= 0 && adcChannel < numAdcChannels);
     if (totalSamples == 0) return 0;
     final conv = unit.converterFor(
@@ -443,7 +443,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
   /// Get minimum (most negative) value for a given ADC channel in the
   /// specified unit. Returns 0 before the first sample arrives; null when
   /// the unit is unavailable for the channel.
-  double? minValue(int adcChannel, ForceUnit unit) {
+  double? minValue(int adcChannel, DisplayUnit unit) {
     assert(adcChannel >= 0 && adcChannel < numAdcChannels);
     if (totalSamples == 0) return 0;
     final conv = unit.converterFor(
@@ -455,7 +455,7 @@ class DataHub extends ChangeNotifier implements GraphDataSource {
 
   /// Get the instantaneous derivative (first-difference) for a channel in
   /// unit/s; null when the unit is unavailable for the channel.
-  double? currentDerivative(int adcChannel, ForceUnit unit) {
+  double? currentDerivative(int adcChannel, DisplayUnit unit) {
     assert(adcChannel >= 0 && adcChannel < numAdcChannels);
     if (totalSamples < 2) return 0;
 

--- a/lib/widgets/channel_stats_table.dart
+++ b/lib/widgets/channel_stats_table.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../models/force_unit.dart';
+import '../models/display_unit.dart';
 import 'graph_components.dart' show getChannelColor;
 
 /// One row of per-channel values in a [ChannelStatsTable].
@@ -64,7 +64,7 @@ class ChannelStatsTable extends StatelessWidget {
   final ValueChanged<int> onToggleChannel;
 
   /// Unit the row [ChannelStatsRow.values] are expressed in.
-  final ForceUnit unit;
+  final DisplayUnit unit;
 
   /// Stat rows below the channel header.
   final List<ChannelStatsRow> rows;
@@ -223,7 +223,7 @@ class _TableCellValue extends StatelessWidget {
   /// The value in [unit] units, or null when the unit is unavailable for
   /// this channel (rendered '—').
   final double? value;
-  final ForceUnit unit;
+  final DisplayUnit unit;
   final bool isActive;
   final bool isStale;
   final TextStyle? textStyle;

--- a/lib/widgets/graph_components.dart
+++ b/lib/widgets/graph_components.dart
@@ -9,7 +9,7 @@ import 'package:flutter/scheduler.dart';
 
 import '../models/app_settings.dart';
 import '../models/bucket_series.dart';
-import '../models/force_unit.dart';
+import '../models/display_unit.dart';
 import '../models/gap_list.dart';
 import '../models/graph_data_source.dart';
 
@@ -2058,7 +2058,7 @@ void _drawChannelEnvelope(
 double Function(int j) _taredDisplaySampleAt(
   GraphDataSource data,
   int channel,
-  ForceUnit unit,
+  DisplayUnit unit,
 ) {
   final s = data.channel(channel);
   final line = s.data;
@@ -2081,7 +2081,7 @@ double Function(int j) _taredDisplaySampleAt(
 double Function(double raw) _taredDisplayFromRaw(
   GraphDataSource data,
   int channel,
-  ForceUnit unit,
+  DisplayUnit unit,
 ) {
   final tare = data.channel(channel).tare;
   return unit.converterFor(data.calibrationFor(channel), tare)!;
@@ -2093,7 +2093,7 @@ double Function(double raw) _taredDisplayFromRaw(
 EnvelopeSeries _taredEnvelopeSeries(
   GraphDataSource data,
   int channel,
-  ForceUnit unit,
+  DisplayUnit unit,
 ) => EnvelopeSeries.bucketed(
   sampleAt: _taredDisplaySampleAt(data, channel, unit),
   buckets: data.channel(channel).buckets,
@@ -2107,7 +2107,7 @@ EnvelopeSeries _taredEnvelopeSeries(
 List<Object?> _envelopeCacheKeyExtras(
   GraphDataSource data,
   List<double> tares,
-  ForceUnit unit,
+  DisplayUnit unit,
 ) => [data.dataGeneration, ...tares, unit, data.calibrationVersion];
 
 /// Fold the raw extremes of [channels] over `[start, end)` (already clamped
@@ -2677,7 +2677,7 @@ class _DerivativeGraphPainter extends _TimeSeriesGraphPainter {
   }
 
   /// Raw-diff -> display-units-per-second map for the bucket fast path of
-  /// [channel] (terminal-slope based, see [ForceUnit.diffConverterFor]).
+  /// [channel] (terminal-slope based, see [DisplayUnit.diffConverterFor]).
   double Function(double rawDiff) _diffDisplayFor(int channel) {
     final diffConv = _settings.displayUnit.diffConverterFor(
       _data.calibrationFor(channel),

--- a/test/app_settings_test.dart
+++ b/test/app_settings_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dynamite_app/models/app_settings.dart';
-import 'package:dynamite_app/models/force_unit.dart';
+import 'package:dynamite_app/models/display_unit.dart';
 
 /// Tests for [AppSettings] persistence (SharedPreferences backed by the
 /// in-memory mock). The constructor loads synchronously from the injected
@@ -17,16 +17,16 @@ void main() {
 
   test('defaults: mV/V unit, all channels active', () async {
     final s = await newSettings();
-    expect(s.displayUnit, ForceUnit.mVv);
+    expect(s.displayUnit, DisplayUnit.mVv);
     expect(s.activeChannels, everyElement(isTrue));
   });
 
   test('display unit persists across instances', () async {
     final s = await newSettings();
-    await s.setDisplayUnit(ForceUnit.kgf);
+    await s.setDisplayUnit(DisplayUnit.kgf);
 
     final s2 = await newSettings();
-    expect(s2.displayUnit, ForceUnit.kgf);
+    expect(s2.displayUnit, DisplayUnit.kgf);
   });
 
   test('legacy pre-slot keys are erased on load', () async {

--- a/test/data_hub_test.dart
+++ b/test/data_hub_test.dart
@@ -3,12 +3,12 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dynamite_app/models/calibration.dart';
-import 'package:dynamite_app/models/force_unit.dart';
+import 'package:dynamite_app/models/display_unit.dart';
 import 'package:dynamite_app/services/data_hub.dart';
 import 'package:dynamite_app/services/demo_calibration.dart';
 
 /// Unit tests for the hub's per-stream lifecycle (peaks, tare, reset). Uses
-/// [ForceUnit.raw] throughout so forces equal tare-adjusted raw counts.
+/// [DisplayUnit.raw] throughout so forces equal tare-adjusted raw counts.
 void main() {
   const int channels = DataHub.numAdcChannels;
 
@@ -25,8 +25,8 @@ void main() {
     test('an untouched hub reports zero peak/min, not sentinel garbage', () {
       final hub = DataHub();
       for (int ch = 0; ch < channels; ch++) {
-        expect(hub.peakValue(ch, ForceUnit.raw), 0);
-        expect(hub.minValue(ch, ForceUnit.raw), 0);
+        expect(hub.peakValue(ch, DisplayUnit.raw), 0);
+        expect(hub.minValue(ch, DisplayUnit.raw), 0);
       }
     });
 
@@ -55,8 +55,8 @@ void main() {
         frame[0] = v;
         hub.addSampleFrame(frame);
       }
-      expect(hub.peakValue(0, ForceUnit.raw), -50);
-      expect(hub.minValue(0, ForceUnit.raw), -300);
+      expect(hub.peakValue(0, DisplayUnit.raw), -50);
+      expect(hub.minValue(0, DisplayUnit.raw), -300);
     });
 
     test('a never-negative channel reports its true (positive) min', () {
@@ -66,8 +66,8 @@ void main() {
         frame[0] = v;
         hub.addSampleFrame(frame);
       }
-      expect(hub.peakValue(0, ForceUnit.raw), 300);
-      expect(hub.minValue(0, ForceUnit.raw), 50);
+      expect(hub.peakValue(0, DisplayUnit.raw), 300);
+      expect(hub.minValue(0, DisplayUnit.raw), 50);
     });
 
     test('peaks are tare-adjusted at read time', () {
@@ -75,8 +75,8 @@ void main() {
       feed(hub, frameOf(1000), 10);
       hub.requestTare();
       feed(hub, frameOf(1000), 1024); // completes the tare at 1000
-      expect(hub.peakValue(0, ForceUnit.raw), 0);
-      expect(hub.minValue(0, ForceUnit.raw), 0);
+      expect(hub.peakValue(0, DisplayUnit.raw), 0);
+      expect(hub.minValue(0, DisplayUnit.raw), 0);
     });
   });
 
@@ -99,8 +99,8 @@ void main() {
       expect(hub.gaps.isEmpty, isTrue);
       expect(hub.taring, isFalse);
       expect(hub.tare[0], 0);
-      expect(hub.peakValue(0, ForceUnit.raw), 0);
-      expect(hub.minValue(0, ForceUnit.raw), 0);
+      expect(hub.peakValue(0, DisplayUnit.raw), 0);
+      expect(hub.minValue(0, DisplayUnit.raw), 0);
       expect(hub.valueBuckets[0].series.samples, 0);
       expect(hub.diffBuckets[0].series.samples, 0);
 
@@ -108,7 +108,7 @@ void main() {
       feed(hub, frameOf(-500), 10);
       expect(hub.totalSamples, 10);
       expect(hub.rawData[0][0], -500);
-      expect(hub.peakValue(0, ForceUnit.raw), -500);
+      expect(hub.peakValue(0, DisplayUnit.raw), -500);
     });
 
     test('aborts an in-progress tare', () {
@@ -154,7 +154,7 @@ void main() {
       expect(hub.rawData[0][100 + 1023], 500);
       expect(hub.taring, isFalse);
       expect(hub.tare[0], 500);
-      expect(hub.currentValue(0, ForceUnit.raw), 0); // 500 - 500
+      expect(hub.currentValue(0, DisplayUnit.raw), 0); // 500 - 500
     });
 
     test('recordings observe the samples appended during a tare', () {
@@ -213,12 +213,12 @@ void main() {
       feed(hub, frameOf(1500), 100);
       expect(hub.taring, isTrue);
       expect(hub.tare[0], 1000);
-      expect(hub.currentValue(0, ForceUnit.raw), 500); // 1500 - 1000
+      expect(hub.currentValue(0, DisplayUnit.raw), 500); // 1500 - 1000
 
       feed(hub, frameOf(1500), 1024 - 100);
       expect(hub.taring, isFalse);
       expect(hub.tare[0], 1500);
-      expect(hub.currentValue(0, ForceUnit.raw), 0);
+      expect(hub.currentValue(0, DisplayUnit.raw), 0);
     });
   });
 
@@ -227,13 +227,13 @@ void main() {
       final hub = DataHub();
       feed(hub, frameOf(1000), 5);
 
-      expect(hub.currentValue(0, ForceUnit.kgf), isNull);
-      expect(hub.peakValue(0, ForceUnit.kgf), isNull);
-      expect(hub.minValue(0, ForceUnit.kgf), isNull);
-      expect(hub.currentDerivative(0, ForceUnit.kgf), isNull);
+      expect(hub.currentValue(0, DisplayUnit.kgf), isNull);
+      expect(hub.peakValue(0, DisplayUnit.kgf), isNull);
+      expect(hub.minValue(0, DisplayUnit.kgf), isNull);
+      expect(hub.currentDerivative(0, DisplayUnit.kgf), isNull);
       // Electrical units convert with board calibration alone.
-      expect(hub.currentValue(0, ForceUnit.mVv), isNotNull);
-      expect(hub.currentDerivative(0, ForceUnit.mVv), isNotNull);
+      expect(hub.currentValue(0, DisplayUnit.mVv), isNotNull);
+      expect(hub.currentDerivative(0, DisplayUnit.mVv), isNotNull);
     });
 
     test('assigning a load cell enables force units and bumps the version', () {
@@ -251,10 +251,10 @@ void main() {
       expect(hub.calibrationVersion, greaterThan(v0));
       // Nominal board: kgf = (raw - tare) / nominalCountsPerMvV * (200/2).
       expect(
-        hub.currentValue(0, ForceUnit.kgf),
+        hub.currentValue(0, DisplayUnit.kgf),
         closeTo(1000 / nominalCountsPerMvV * 100, 1e-12),
       );
-      expect(hub.currentValue(1, ForceUnit.kgf), isNull); // unassigned
+      expect(hub.currentValue(1, DisplayUnit.kgf), isNull); // unassigned
     });
 
     test('board calibration replaces the nominal chain and bumps version', () {
@@ -278,22 +278,22 @@ void main() {
 
       feed(hub, frameOf(1000), 5);
       expect(
-        hub.currentValue(0, ForceUnit.mVv),
+        hub.currentValue(0, DisplayUnit.mVv),
         closeTo(1000 / (0.5 * nominalCountsPerMvV), 1e-12),
       );
       expect(
-        hub.currentValue(1, ForceUnit.mVv),
+        hub.currentValue(1, DisplayUnit.mVv),
         closeTo(1000 / nominalCountsPerMvV, 1e-12),
       );
     });
 
     test('derivative scales the converted difference per second', () {
       final hub = DataHub();
-      expect(hub.currentDerivative(0, ForceUnit.raw), 0); // < 2 samples
+      expect(hub.currentDerivative(0, DisplayUnit.raw), 0); // < 2 samples
       feed(hub, frameOf(0), 1);
       hub.addSampleFrame(frameOf(1000));
       expect(
-        hub.currentDerivative(0, ForceUnit.raw),
+        hub.currentDerivative(0, DisplayUnit.raw),
         1000.0 * DataHub.samplesPerSec,
       );
     });

--- a/test/display_unit_test.dart
+++ b/test/display_unit_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dynamite_app/models/calibration.dart';
-import 'package:dynamite_app/models/force_unit.dart';
+import 'package:dynamite_app/models/display_unit.dart';
 
-/// Tests for [ForceUnit]'s per-channel converters: availability (force units
+/// Tests for [DisplayUnit]'s per-channel converters: availability (force units
 /// need an assigned load cell), tare-netting through the board map, and the
 /// terminal-slope diff converters used by the derivative graph.
 void main() {
@@ -23,15 +23,15 @@ void main() {
     test(
       'electrical units convert without a load cell; force units do not',
       () {
-        for (final u in [ForceUnit.mVv, ForceUnit.mV, ForceUnit.raw]) {
+        for (final u in [DisplayUnit.mVv, DisplayUnit.mV, DisplayUnit.raw]) {
           expect(u.converterFor(bare, alpha), isNotNull, reason: u.symbol);
           expect(u.diffConverterFor(bare), isNotNull, reason: u.symbol);
         }
         for (final u in [
-          ForceUnit.kN,
-          ForceUnit.lbf,
-          ForceUnit.kgf,
-          ForceUnit.n,
+          DisplayUnit.kN,
+          DisplayUnit.lbf,
+          DisplayUnit.kgf,
+          DisplayUnit.n,
         ]) {
           expect(u.converterFor(bare, alpha), isNull, reason: u.symbol);
           expect(u.diffConverterFor(bare), isNull, reason: u.symbol);
@@ -43,13 +43,13 @@ void main() {
 
   group('converters net the tare through the board map', () {
     test('mV/V at a cal point is its setpoint minus the zero point', () {
-      final conv = ForceUnit.mVv.converterFor(assigned, alpha)!;
+      final conv = DisplayUnit.mVv.converterFor(assigned, alpha)!;
       expect(conv(board.readings![0]), closeTo(sp[0], 1e-9));
       expect(conv(alpha), 0.0); // tare point maps to zero
     });
 
     test('raw is tare-subtracted counts', () {
-      final conv = ForceUnit.raw.converterFor(assigned, alpha)!;
+      final conv = DisplayUnit.raw.converterFor(assigned, alpha)!;
       expect(
         conv(board.readings![0]),
         closeTo(board.readings![0] - alpha, 1e-9),
@@ -57,14 +57,14 @@ void main() {
     });
 
     test('mV follows mV/V via the effective excitation', () {
-      final mvV = ForceUnit.mVv.converterFor(assigned, alpha)!;
-      final mv = ForceUnit.mV.converterFor(assigned, alpha)!;
+      final mvV = DisplayUnit.mVv.converterFor(assigned, alpha)!;
+      final mv = DisplayUnit.mV.converterFor(assigned, alpha)!;
       final raw = board.readings![1];
       expect(mv(raw), closeTo(mvV(raw) * board.effectiveExcitationV, 1e-9));
     });
 
     test('nominal mV matches the legacy fixed multiplier', () {
-      final conv = ForceUnit.mV.converterFor(
+      final conv = DisplayUnit.mV.converterFor(
         ChannelCalibration(board: nominalBoard),
         0,
       )!;
@@ -72,8 +72,8 @@ void main() {
     });
 
     test('kgf scales mV/V by capacity/sensitivity; kN by 9.80665e-3', () {
-      final kgf = ForceUnit.kgf.converterFor(assigned, alpha)!;
-      final kN = ForceUnit.kN.converterFor(assigned, alpha)!;
+      final kgf = DisplayUnit.kgf.converterFor(assigned, alpha)!;
+      final kN = DisplayUnit.kN.converterFor(assigned, alpha)!;
       final raw = board.readings![0];
       expect(kgf(raw), closeTo(sp[0] * 100, 1e-9)); // 200 kg / 2 mV/V
       expect(kN(raw), closeTo(kgf(raw) * 9.80665 / 1000, 1e-12));
@@ -82,22 +82,22 @@ void main() {
 
   group('diff converters', () {
     test('mV/V diff is counts over the terminal span', () {
-      final diff = ForceUnit.mVv.diffConverterFor(assigned)!;
+      final diff = DisplayUnit.mVv.diffConverterFor(assigned)!;
       expect(diff(1000), closeTo(1000 / board.spanCountsPerMvV, 1e-15));
     });
 
     test('kgf diff folds in the load cell', () {
-      final diff = ForceUnit.kgf.diffConverterFor(assigned)!;
+      final diff = DisplayUnit.kgf.diffConverterFor(assigned)!;
       expect(diff(1000), closeTo(1000 / board.spanCountsPerMvV * 100, 1e-12));
     });
   });
 
   group('formatting', () {
     test('mV/V shows four decimals with an explicit sign', () {
-      expect(ForceUnit.mVv.format(1.996), '+1.9960 mV/V');
-      expect(ForceUnit.mVv.formatValueOnly(-0.5), '-0.5000');
-      expect(ForceUnit.raw.format(12345), '+12345 Raw');
-      expect(ForceUnit.kgf.format(1.5), '+1.500 kgf');
+      expect(DisplayUnit.mVv.format(1.996), '+1.9960 mV/V');
+      expect(DisplayUnit.mVv.formatValueOnly(-0.5), '-0.5000');
+      expect(DisplayUnit.raw.format(12345), '+12345 Raw');
+      expect(DisplayUnit.kgf.format(1.5), '+1.500 kgf');
     });
   });
 }

--- a/test/session_storage_test.dart
+++ b/test/session_storage_test.dart
@@ -5,7 +5,7 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dynamite_app/models/calibration.dart';
-import 'package:dynamite_app/models/force_unit.dart';
+import 'package:dynamite_app/models/display_unit.dart';
 import 'package:dynamite_app/services/data_hub.dart';
 import 'package:dynamite_app/services/database.dart';
 import 'package:dynamite_app/services/session_storage.dart';
@@ -344,13 +344,13 @@ void main() {
         expect(cell.name, 'Ref');
         expect(cell.sensitivityMvV, closeTo(2.02, 1e-12));
         // End-to-end: kgf converts through the stored board AND stored cell.
-        final kgf = ForceUnit.kgf.converterFor(loaded.calibrationFor(0), 0)!;
+        final kgf = DisplayUnit.kgf.converterFor(loaded.calibrationFor(0), 0)!;
         expect(
           kgf(1000),
           closeTo(1000 / (0.5 * nominalCountsPerMvV) * (100 / 2.02), 1e-9),
         );
         // ch1 had no load cell assigned at recording time.
-        expect(ForceUnit.kgf.converterFor(loaded.calibrationFor(1), 0), isNull);
+        expect(DisplayUnit.kgf.converterFor(loaded.calibrationFor(1), 0), isNull);
       },
     );
   });


### PR DESCRIPTION
With the introduction of non-force units (mV, raw ADC values, etc), ForceUnit doesn't make as much sense.